### PR TITLE
Add format string support for formatting dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-config-prettier": "^5.0.0",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.12.4",
+    "intl-dateformat": "^0.1.1",
     "jest": "^24.5.0",
     "memoize-one": "^5.0.2",
     "prettier": "^1.16.4",

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -5,17 +5,52 @@ import {
 } from './formatters'
 
 describe('timeFormatter', () => {
-  test('defaults to 24 hour time when timezone is UTC', () => {
+  test('defaults to 12 hour time unless timezone is UTC', () => {
     const utcFormatter = timeFormatter({timeZone: 'UTC'})
     const nonUTCFormatter = timeFormatter({timeZone: 'America/Los_Angeles'})
 
     const d = new Date('2019-01-01T00:00Z')
 
     // 24 hour time when using UTC
-    expect(utcFormatter(d)).toEqual('1/1/2019, 00:00 UTC')
+    expect(utcFormatter(d)).toEqual('2019-01-01 00:00:00 UTC')
 
-    // Default (locale specific) when not UTC
-    expect(nonUTCFormatter(d)).toEqual('12/31/2018, 4:00 PM PST')
+    // Defaults to 12 hour time when not UTC
+    expect(nonUTCFormatter(d)).toEqual('2018-12-31 4:00:00 PM PST')
+  })
+
+  test('can format times with format strings', () => {
+    const tests = [
+      ['YYYY-MM-DD HH:mm:ss', '2019-01-01 00:00:00'],
+      ['YYYY-MM-DD HH:mm:ss ZZ', '2019-01-01 00:00:00 UTC'],
+      ['MM/DD/YYYY HH:mm:ss.sss', '01/01/2019 00:00:00.000'],
+      ['YYYY/MM/DD HH:mm:ss', '2019/01/01 00:00:00'],
+      ['HH:mm:ss', '00:00:00'],
+      ['HH:mm:ss.sss', '00:00:00.000'],
+      ['MMMM D, YYYY HH:mm:ss', 'January 1, 2019 00:00:00'],
+      ['dddd, MMMM D, YYYY HH:mm:ss', 'Tuesday, January 1, 2019 00:00:00'],
+    ]
+
+    for (const [format, expected] of tests) {
+      const d = new Date('2019-01-01T00:00:00Z')
+      const formatter = timeFormatter({format, timeZone: 'UTC'})
+
+      expect(formatter(d)).toEqual(expected)
+    }
+  })
+
+  test('it can format times with a variable level of detail', () => {
+    const formatter = timeFormatter({timeZone: 'UTC'})
+
+    // Defaults to quite detailed if no domainWidth passed
+    expect(formatter(0)).toEqual('1970-01-01 00:00:00 UTC')
+
+    const WEEK = 1000 * 60 * 60 * 24 * 7
+    const YEAR = 1000 * 60 * 60 * 24 * 365
+
+    // Otherwise formats numbers according to domainWidth
+    expect(formatter(0, {domainWidth: 1})).toEqual('00:00:00.000 UTC')
+    expect(formatter(0, {domainWidth: WEEK})).toEqual('Jan 01, 00:00 UTC')
+    expect(formatter(0, {domainWidth: YEAR})).toEqual('1970-01-01')
   })
 })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "strictNullChecks": false,
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5908,6 +5908,11 @@ interpret@^1.0.0, interpret@^1.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
+intl-dateformat@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/intl-dateformat/-/intl-dateformat-0.1.1.tgz#6f7b45279d84a4752e0838b7972f98933d88048c"
+  integrity sha512-N/jU7FiGLGEEkkwLeusKrLy6z3k/VXgsCOOyShmJhOrVF7fWaoZgKg4BMt38b6l9kVPNA1dfAkkJ6GuPsVEn8A==
+
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"


### PR DESCRIPTION
Adds support for constructing time formatters using a format string:

```
import {timeFormatter} from '@influxdata/giraffe'

const f = timeFormatter({format: 'YYYY-MM-DD HH:mm Z', timeZone: 'UTC'})

f(new Date(0)) // => "1970-01-01 00:00 UTC"
```

Pulls in [intl-dateformat](https://github.com/zapier/intl-dateformat), a small library, to help accomplish this. 

Closes #95 