### PR TITLE
Add custom layer support

### DIFF
--- a/src/components/Axes.tsx
+++ b/src/components/Axes.tsx
@@ -233,3 +233,5 @@ export const Axes: FunctionComponent<Props> = ({env, style}) => {
     />
   )
 }
+
+Axes.displayName = 'Axes'

--- a/src/components/Brush.tsx
+++ b/src/components/Brush.tsx
@@ -73,3 +73,5 @@ export const Brush: FunctionComponent<Props> = ({
 
   return <div className="giraffe-brush-selection" style={selectionStyle} />
 }
+
+Brush.displayName = 'Brush'

--- a/src/components/Brush.tsx
+++ b/src/components/Brush.tsx
@@ -22,8 +22,10 @@ export const Brush: FunctionComponent<Props> = ({
   onXBrushEnd,
   onYBrushEnd,
 }) => {
+  const isBrushing = event && event.direction
+
   useLayoutEffect(() => {
-    if (!event || !event.dragMode || event.type !== 'dragend') {
+    if (!isBrushing || event.type !== 'dragend') {
       return
     }
 
@@ -31,11 +33,11 @@ export const Brush: FunctionComponent<Props> = ({
     let p1
     let callback
 
-    if (event.dragMode === 'brushX') {
+    if (event.direction === 'x') {
       p0 = Math.min(event.initialX, event.x)
       p1 = Math.max(event.initialX, event.x)
       callback = onXBrushEnd
-    } else if (event.dragMode === 'brushY') {
+    } else if (event.direction === 'y') {
       p0 = Math.min(event.initialY, event.y)
       p1 = Math.max(event.initialY, event.y)
       callback = onYBrushEnd
@@ -50,7 +52,7 @@ export const Brush: FunctionComponent<Props> = ({
     callback([p0, p1])
   })
 
-  if (!event || !event.dragMode || event.type === 'dragend') {
+  if (!isBrushing || event.type === 'dragend') {
     return null
   }
 

--- a/src/components/LineHoverLayer.tsx
+++ b/src/components/LineHoverLayer.tsx
@@ -121,3 +121,5 @@ export const LineHoverLayer: FunctionComponent<Props> = ({
     </>
   )
 }
+
+LineHoverLayer.displayName = 'LineHoverLayer'

--- a/src/components/LineLayer.tsx
+++ b/src/components/LineLayer.tsx
@@ -91,3 +91,5 @@ export const LineLayer: FunctionComponent<Props> = props => {
     </>
   )
 }
+
+LineLayer.displayName = 'LineLayer'

--- a/src/components/Plot.tsx
+++ b/src/components/Plot.tsx
@@ -28,3 +28,5 @@ export const Plot: FunctionComponent<Props> = ({config, children}) => {
     </AutoSizer>
   )
 }
+
+Plot.displayName = 'Plot'

--- a/src/components/RectLayer.tsx
+++ b/src/components/RectLayer.tsx
@@ -96,3 +96,5 @@ export const RectLayer: FunctionComponent<Props> = ({
     </>
   )
 }
+
+RectLayer.displayName = 'RectLayer'

--- a/src/components/ScatterHoverLayer.tsx
+++ b/src/components/ScatterHoverLayer.tsx
@@ -94,3 +94,5 @@ export const ScatterHoverLayer: FunctionComponent<Props> = ({
     </>
   )
 }
+
+ScatterHoverLayer.displayName = 'ScatterHoverLayer'

--- a/src/components/ScatterLayer.tsx
+++ b/src/components/ScatterLayer.tsx
@@ -50,3 +50,5 @@ export const ScatterLayer: FunctionComponent<Props> = props => {
     </>
   )
 }
+
+ScatterLayer.displayName = 'ScatterLayer'

--- a/src/components/SizedPlot.tsx
+++ b/src/components/SizedPlot.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {useRef, useCallback, FunctionComponent, CSSProperties} from 'react'
+import {useCallback, FunctionComponent, CSSProperties} from 'react'
 
 import {Axes} from './Axes'
 import {
@@ -29,9 +29,8 @@ export const SizedPlot: FunctionComponent<Props> = ({
   const env = usePlotEnv(userConfig)
 
   const forceUpdate = useForceUpdate()
-  const innerPlotRef = useRef<HTMLDivElement>(null)
-  const [hoverEvent, hoverProps] = useMousePos()
-  const dragEvent = useDragEvent(innerPlotRef.current)
+  const [hoverEvent, hoverTargetProps] = useMousePos()
+  const [dragEvent, dragTargetProps] = useDragEvent()
   const hoverX = dragEvent ? null : hoverEvent.x
   const hoverY = dragEvent ? null : hoverEvent.y
 
@@ -88,9 +87,9 @@ export const SizedPlot: FunctionComponent<Props> = ({
           left: `${margins.left}px`,
           cursor: 'crosshair',
         }}
-        ref={innerPlotRef}
         onDoubleClick={handleResetDomains}
-        {...hoverProps}
+        {...hoverTargetProps}
+        {...dragTargetProps}
       >
         <div className="giraffe-layers" style={fullsizeStyle}>
           {config.layers.map((layerConfig, layerIndex) => {

--- a/src/components/SizedPlot.tsx
+++ b/src/components/SizedPlot.tsx
@@ -93,6 +93,22 @@ export const SizedPlot: FunctionComponent<Props> = ({
       >
         <div className="giraffe-layers" style={fullsizeStyle}>
           {config.layers.map((layerConfig, layerIndex) => {
+            if (layerConfig.type === 'custom') {
+              const renderProps = {
+                width,
+                height,
+                innerWidth: env.innerWidth,
+                innerHeight: env.innerHeight,
+                xScale: env.xScale,
+                yScale: env.yScale,
+                xDomain: env.xDomain,
+                yDomain: env.yDomain,
+                columnFormatter: env.getFormatterForColumn,
+              }
+
+              return layerConfig.render(renderProps)
+            }
+
             const spec = env.getSpec(layerIndex)
 
             const sharedProps = {

--- a/src/components/SizedPlot.tsx
+++ b/src/components/SizedPlot.tsx
@@ -157,3 +157,5 @@ export const SizedPlot: FunctionComponent<Props> = ({
     </div>
   )
 }
+
+SizedPlot.displayName = 'SizedPlot'

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -85,3 +85,5 @@ export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
     tooltipElement
   )
 }
+
+Tooltip.displayName = 'Tooltip'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -182,6 +182,9 @@ export interface Config {
   xAxisLabel?: string
   yAxisLabel?: string
 
+  xTicks?: number[]
+  yTicks?: number[]
+
   // The x domain of the plot can be explicitly set. If this option is passed,
   // then the component is operating in a "controlled" mode, where it always
   // uses the passed x domain. Any brush interaction with the plot that should

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -142,11 +142,29 @@ export interface ScatterLayerConfig {
   symbol?: string[]
 }
 
+export interface CustomLayerRenderProps {
+  xScale: Scale<number, number>
+  yScale: Scale<number, number>
+  xDomain: number[]
+  yDomain: number[]
+  width: number
+  height: number
+  innerWidth: number
+  innerHeight: number
+  columnFormatter: (colKey: string) => (x: any) => string
+}
+
+export interface CustomLayerConfig {
+  type: 'custom'
+  render: (p: CustomLayerRenderProps) => JSX.Element
+}
+
 export type LayerConfig =
   | LineLayerConfig
   | HistogramLayerConfig
   | HeatmapLayerConfig
   | ScatterLayerConfig
+  | CustomLayerConfig
 
 export enum FormatterType {
   Time = 'TIME',

--- a/src/utils/PlotEnv.ts
+++ b/src/utils/PlotEnv.ts
@@ -88,6 +88,10 @@ export class PlotEnv {
   }
 
   public get xTicks(): number[] {
+    if (this.config.xTicks) {
+      return this.config.xTicks
+    }
+
     const getTicksMemoized = this.fns.get('xTicks', getTicks)
 
     return getTicksMemoized(
@@ -99,6 +103,10 @@ export class PlotEnv {
   }
 
   public get yTicks(): number[] {
+    if (this.config.yTicks) {
+      return this.config.yTicks
+    }
+
     const getTicksMemoized = this.fns.get('yTicks', getTicks)
 
     return getTicksMemoized(

--- a/src/utils/PlotEnv.ts
+++ b/src/utils/PlotEnv.ts
@@ -255,6 +255,9 @@ export class PlotEnv {
         )
       }
 
+      case 'custom':
+        return null
+
       default:
         const unknownConfig: never = layerConfig
         const unknownType = (unknownConfig as any).type
@@ -322,7 +325,10 @@ export class PlotEnv {
   private getXDomain() {
     return (
       extentOfExtents(
-        ...this.config.layers.map((_, i) => this.getSpec(i).xDomain)
+        ...this.config.layers
+          .map((_, i) => this.getSpec(i))
+          .filter(spec => spec && spec.xDomain)
+          .map(spec => spec.xDomain)
       ) || DEFAULT_X_DOMAIN
     )
   }
@@ -330,7 +336,10 @@ export class PlotEnv {
   private getYDomain() {
     return (
       extentOfExtents(
-        ...this.config.layers.map((_, i) => this.getSpec(i).yDomain)
+        ...this.config.layers
+          .map((_, i) => this.getSpec(i))
+          .filter(spec => spec && spec.yDomain)
+          .map(spec => spec.yDomain)
       ) || DEFAULT_Y_DOMAIN
     )
   }

--- a/src/utils/brush.ts
+++ b/src/utils/brush.ts
@@ -6,7 +6,7 @@ export const getRectDimensions = (
   plotWidth: number,
   plotHeight: number
 ) => {
-  if (event.dragMode === 'brushX') {
+  if (event.direction === 'x') {
     const x = Math.max(0, Math.min(event.initialX, event.x))
 
     const width = Math.min(Math.max(event.initialX, event.x) - x, plotWidth - x)
@@ -19,7 +19,7 @@ export const getRectDimensions = (
     }
   }
 
-  if (event.dragMode === 'brushY') {
+  if (event.direction === 'y') {
     const y = Math.max(0, Math.min(event.initialY, event.y))
 
     const height = Math.min(

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -74,6 +74,13 @@ describe('siPrefixFormatter', () => {
 
     expect(f(1000)).toEqual('howdy1k')
   })
+
+  test('can specify zeros are always included', () => {
+    const f = siPrefixFormatter({trimZeros: false, significantDigits: 4})
+
+    expect(f(37)).toEqual('37.00')
+    expect(f(37.1234)).toEqual('37.12')
+  })
 })
 
 describe('binaryPrefixFormatter', () => {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -197,14 +197,18 @@ interface BinaryPrefixFormatterFactoryOptions {
   prefix?: string
   suffix?: string
   significantDigits?: number
+  trimZeros?: boolean
 }
 
 export const binaryPrefixFormatter = ({
   prefix = '',
   suffix = '',
   significantDigits = 6,
+  trimZeros = true,
 }: BinaryPrefixFormatterFactoryOptions = {}): BinaryPrefixFormatter => {
-  const formatSigFigs = d3Format(`.${significantDigits}~f`)
+  const formatSigFigs = d3Format(
+    `.${significantDigits}${trimZeros ? '~' : ''}f`
+  )
 
   const formatter = (x: number) => {
     const isXBig = Math.abs(x) >= 1024
@@ -234,14 +238,18 @@ interface SIPrefixFormatterFactoryOptions {
   prefix?: string
   suffix?: string
   significantDigits?: number
+  trimZeros?: boolean
 }
 
 export const siPrefixFormatter = ({
   prefix = '',
   suffix = '',
   significantDigits = 6,
+  trimZeros = true,
 }: SIPrefixFormatterFactoryOptions = {}): SIPrefixFormatter => {
-  const formatSIPrefix = d3Format(`.${significantDigits}~s`)
+  const formatSIPrefix = d3Format(
+    `.${significantDigits}${trimZeros ? '~' : ''}s`
+  )
 
   const formatter = (x: number): string =>
     `${prefix}${formatSIPrefix(x)}${suffix}`

--- a/stories/customLayer.stories.tsx
+++ b/stories/customLayer.stories.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+import {storiesOf} from '@storybook/react'
+
+import {Config, Plot} from '../src'
+
+import {PlotContainer} from './helpers'
+import {CPU} from './data'
+
+storiesOf('Custom Layer', module).add('Highlighted Region', () => {
+  const config: Config = {
+    table: CPU,
+    layers: [
+      {
+        type: 'scatter',
+        x: '_time',
+        y: '_value',
+      },
+      {
+        type: 'custom',
+        render: ({yScale}) => {
+          return (
+            <div
+              style={{
+                width: '100%',
+                position: 'absolute',
+                top: `${yScale(20)}px`,
+                height: `${yScale(10) - yScale(20)}px`,
+                background: 'tomato',
+                opacity: 0.3,
+              }}
+            />
+          )
+        },
+      },
+    ],
+  }
+
+  return (
+    <PlotContainer>
+      <Plot config={config} />
+    </PlotContainer>
+  )
+})

--- a/stories/snapshotTests.stories.tsx
+++ b/stories/snapshotTests.stories.tsx
@@ -195,3 +195,21 @@ storiesOf('Snapshot Tests', module)
 
     return <Plot config={config} />
   })
+  .add('custom y ticks', () => {
+    const config: Config = {
+      width: 600,
+      height: 400,
+      table: CPU,
+      yTicks: [13, 19, 23],
+      layers: [
+        {
+          type: 'line',
+          x: '_time',
+          y: '_value',
+          fill: ['cpu'],
+        },
+      ],
+    }
+
+    return <Plot config={config} />
+  })


### PR DESCRIPTION
This PR adds a few small features to giraffe to facilitate https://github.com/influxdata/influxdb/pull/14347.

I took the opportunity to clean up the brush event handling code, which was confusing.

I also added the `displayName` prop to all components. This makes them show up with nice names in the React devtools, even when the actual function component names have been mangled by terser (e.g. show `SizedPlot` instead of `n`).

It might be easiest to review commit by commit. 

