### PR TITLE
Fix tooltip crash

### DIFF
--- a/src/utils/tooltip.ts
+++ b/src/utils/tooltip.ts
@@ -32,7 +32,9 @@ const getTooltipGroupColumns = (
       name: table.getColumnName(key),
       type: table.getColumnType(key),
       colors: rowColors,
-      values: rowIndices.map(i => formatter(colData[i])),
+      values: rowIndices.map(i =>
+        !isVoid(colData[i]) ? formatter(colData[i]) : null
+      ),
     }
   })
 


### PR DESCRIPTION
Fixes an issue where a plot would crash if the tooltip attempting to format void values.

Connect influxdata/influxdb#14436