### PR TITLE
Mouse position should be aware of y position just like x position

### DIFF
--- a/giraffe/src/utils/useHoverPointIndices.ts
+++ b/giraffe/src/utils/useHoverPointIndices.ts
@@ -18,7 +18,14 @@ export const useHoverPointIndices = (
   height: number
 ): number[] => {
   const isActive =
-    mouseX !== undefined && mouseX !== null && mouseX >= 0 && mouseX < width
+    mouseX !== undefined &&
+    mouseX !== null &&
+    mouseX >= 0 &&
+    mouseX < width &&
+    mouseY !== undefined &&
+    mouseY !== null &&
+    mouseY >= 0 &&
+    mouseY < width
 
   const index = useLazyMemo(
     () => buildIndex(xColData, yColData, xScale, yScale, width, height),


### PR DESCRIPTION
Layer legends were visible event when mouse y position was past the height of the canvas. 
With this, hover actions will not be active when mouseY > height. 