### PR TITLE
fix(undefined-timezone): fixed issue where 24h time formats were displaying undefined timezones

### DIFF
--- a/giraffe/src/utils/formatters.ts
+++ b/giraffe/src/utils/formatters.ts
@@ -167,13 +167,15 @@ export const timeFormatter = ({
         timeFormat = timeFormats.zoned12
       } else if (hour12 === false) {
         timeFormat = timeFormats.local24
-      } else {
-        // this is a temporary solution. Russ said that we should
-        // allow users to choose their timeformat based on their settings
-        // rather than having a default system setting dictate their times
+      } else if (
+        new Date(2014, 1, 1, 15, 0, 0, 0).toLocaleTimeString().includes('15')
+      ) {
+        // this implementation checks the user's OS/browser settings to
+        // check whether their locale is 12h or 24h
+        // Evaluating true means that the local is based on a 24h locale
         timeFormat = timeFormats.local24
-        // this default statement is causing problems
-        // timeFormat = timeFormats.local12
+      } else {
+        timeFormat = timeFormats.local12
       }
 
       return formatStringFormatter(new Date(x), timeFormat, {

--- a/giraffe/src/utils/formatters.ts
+++ b/giraffe/src/utils/formatters.ts
@@ -168,7 +168,12 @@ export const timeFormatter = ({
       } else if (hour12 === false) {
         timeFormat = timeFormats.local24
       } else {
-        timeFormat = timeFormats.local12
+        // this is a temporary solution. Russ said that we should
+        // allow users to choose their timeformat based on their settings
+        // rather than having a default system setting dictate their times
+        timeFormat = timeFormats.local24
+        // this default statement is causing problems
+        // timeFormat = timeFormats.local12
       }
 
       return formatStringFormatter(new Date(x), timeFormat, {

--- a/stories/package.json
+++ b/stories/package.json
@@ -38,7 +38,7 @@
     "webpack": "^4.35.3"
   },
   "dependencies": {
-    "@influxdata/giraffe": "0.16.4",
+    "@influxdata/giraffe": "0.16.5",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }


### PR DESCRIPTION
Closes #15808:

https://github.com/influxdata/influxdb/issues/15808

### Problem

The default statement for formatting the date/time in giraffe is based on US 12h timezones. When users from countries that have a 24h based system access giraffe, their timezone is undefined.

### Solution

Updated default format to be the 24h system. This is a patch solution until a new feature is implemented that allows users to specify their display time preferences