### PR TITLE
feat: export LinePosition as a type

### DIFF
--- a/giraffe/src/index.ts
+++ b/giraffe/src/index.ts
@@ -24,6 +24,7 @@ export {
   Margins,
   HistogramLayerConfig,
   HistogramPosition,
+  LinePosition,
   LineInterpolation,
   LineLayerConfig,
   LayerConfig,


### PR DESCRIPTION
In order to use LinePosition, we need to export it