### PR TITLE
feat(formatTime): added in capacity to output am/pm in custom formats

### DIFF
--- a/giraffe/src/utils/formatters.ts
+++ b/giraffe/src/utils/formatters.ts
@@ -150,15 +150,15 @@ export const timeFormatter = ({
     },
     sss: (_, date) => String(date.getMilliseconds()).padStart(3, '0'),
     D: parts => String(Number(parts.day)),
-    a: ({hour}) => {
+    a: ({dayPeriod, hour}) => {
       if (format.includes('a') && is24hourLocale) {
-        if (Number(hour) >= 1 && Number(hour) <= 11) {
-          return 'am'
+        if (Number(hour) >= 12) {
+          return 'PM'
         } else {
-          return 'pm'
+          return 'AM'
         }
       }
-      return ''
+      return dayPeriod || ''
     },
     ZZ: (_, date) => getShortTimeZoneName(timeZone, date),
   })

--- a/giraffe/src/utils/formatters.ts
+++ b/giraffe/src/utils/formatters.ts
@@ -1,6 +1,6 @@
 /*
   This module contains utilites for formatting values in visualizations.
-  
+
   A `Formatter` takes a value in a table and formats it as a user-facing
   string. A formatter factory creates a `Formatter`. Here we define several
   formatter factories for common use cases such as formatting time values, or
@@ -151,7 +151,7 @@ export const timeFormatter = ({
     sss: (_, date) => String(date.getMilliseconds()).padStart(3, '0'),
     D: parts => String(Number(parts.day)),
     a: ({hour}) => {
-      if (format === 'HH:mm a' && is24hourLocale) {
+      if (format.includes('a') && is24hourLocale) {
         if (Number(hour) >= 1 && Number(hour) <= 11) {
           return 'am'
         } else {

--- a/giraffe/src/utils/formatters.ts
+++ b/giraffe/src/utils/formatters.ts
@@ -140,7 +140,7 @@ export const timeFormatter = ({
   // output the timezone incorrectly. The same goes for determining the `HH`, etc...
   const formatStringFormatter = createDateFormatter({
     HH: ({hour}) => {
-      if (format === 'HH:mm a' && is24hourLocale) {
+      if (format.includes('a') && is24hourLocale) {
         if (Number(hour) > 12) {
           return String(Number(hour) - 12)
         }


### PR DESCRIPTION
### Problem

Currently passing in a custom formatted time into the `formatTime` function will error out if a flag for `a` (am/pm) is passed in the time format 

### Solution

Added a custom check for whether the formatted time includes an `a` and resorts to forcing the format to set the times to 12h with `am/pm`