### PR TITLE
fix: remove leading zero from 12-hour format

### DIFF
--- a/giraffe/src/utils/formatters.test.ts
+++ b/giraffe/src/utils/formatters.test.ts
@@ -15,7 +15,7 @@ describe('timeFormatter', () => {
     expect(utcFormatter(d)).toEqual('2019-01-01 00:00:00 UTC')
 
     // Defaults to 12 hour time when not UTC
-    expect(nonUTCFormatter(d)).toEqual('2018-12-31 04:00:00 PM PST')
+    expect(nonUTCFormatter(d)).toEqual('2018-12-31  4:00:00 PM PST')
   })
 
   test('uses AM/PM when given "a" in the format regardless of time zone or time format', () => {
@@ -44,7 +44,7 @@ describe('timeFormatter', () => {
     )
     expect(nonUTCFormatterWithFormat(d)).toEqual('2018-12-31 4:00:00 PM PST')
     expect(nonUTCFormatterWithFormatWithLowerH(d)).toEqual(
-      '2018-12-31 04:00:00 PM PST'
+      '2018-12-31  4:00:00 PM PST'
     )
   })
 

--- a/giraffe/src/utils/formatters.ts
+++ b/giraffe/src/utils/formatters.ts
@@ -139,7 +139,9 @@ export const timeFormatter = ({
   // for example, modifying the timezone before determing the `am/pm` will
   // output the timezone incorrectly. The same goes for determining the `HH`, etc...
   const formatStringFormatter = createDateFormatter({
-    hh: ({hour}) => (Number(hour) < 10 ? `0${Number(hour)}` : String(hour)),
+    // a deliberate space in front of single digit hours keeps the tick label length
+    // and the total number of ticks consistent regardless of time frame
+    hh: ({hour}) => (Number(hour) < 10 ? ` ${Number(hour)}` : String(hour)),
     HH: ({lhour}) => {
       if (format && format.includes('a')) {
         if (Number(lhour) === 0) {


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/16122

Updates 12-hour time format to remove leading zeros.