### PR TITLE
feat(giraffe): add log scale type

### DIFF
--- a/giraffe/src/constants/index.ts
+++ b/giraffe/src/constants/index.ts
@@ -37,6 +37,8 @@ export const CONFIG_DEFAULTS: Partial<Config> = {
   valueFormatters: {},
   xAxisLabel: '',
   yAxisLabel: '',
+  xScale: 'linear',
+  yScale: 'linear',
   showAxes: true,
   axisColor: '#292933',
   axisOpacity: 1,

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -40,6 +40,13 @@ export interface Scale<D = any, R = any> {
   invert?: (y: R) => D
 }
 
+export type ScaleFactory = (
+  domainStart: number,
+  domainStop: number,
+  rangeStart: number,
+  rangeStop: number
+) => Scale<number, number>
+
 export interface Margins {
   top: number
   right: number
@@ -202,6 +209,9 @@ export interface Config {
 
   xAxisLabel?: string
   yAxisLabel?: string
+
+  xScale?: string
+  yScale?: string
 
   xTicks?: number[]
   yTicks?: number[]

--- a/giraffe/src/utils/PlotEnv.ts
+++ b/giraffe/src/utils/PlotEnv.ts
@@ -5,7 +5,7 @@ import {extentOfExtents} from './extrema'
 import {identityMerge} from './identityMerge'
 import {MemoizedFunctionCache} from './MemoizedFunctionCache'
 import {timeFormatter} from './formatters'
-import {getLinearScale} from './getLinearScale'
+import {getScale} from './getScale'
 import {lineTransform} from '../transforms/line'
 import {scatterTransform} from '../transforms/scatter'
 import {histogramTransform} from '../transforms/histogram'
@@ -118,10 +118,10 @@ export class PlotEnv {
   }
 
   public get xScale(): Scale<number, number> {
-    const getXScaleMemoized = this.fns.get('xScale', getLinearScale)
+    const scale = getScale(this.config.xScale)
     const {xDomain, rangePadding, innerWidth} = this
 
-    return getXScaleMemoized(
+    return scale(
       xDomain[0],
       xDomain[1],
       rangePadding,
@@ -130,10 +130,10 @@ export class PlotEnv {
   }
 
   public get yScale(): Scale<number, number> {
-    const getYScaleMemoized = this.fns.get('yScale', getLinearScale)
+    const scale = getScale(this.config.yScale)
     const {yDomain, rangePadding, innerHeight} = this
 
-    return getYScaleMemoized(
+    return scale(
       yDomain[0],
       yDomain[1],
       innerHeight - rangePadding * 2,

--- a/giraffe/src/utils/PlotEnv.ts
+++ b/giraffe/src/utils/PlotEnv.ts
@@ -118,10 +118,13 @@ export class PlotEnv {
   }
 
   public get xScale(): Scale<number, number> {
-    const scale = getScale(this.config.xScale)
+    const getXScaleMemoized = this.fns.get(
+      `xScale_${this.config.xScale}`,
+      getScale(this.config.xScale)
+    )
     const {xDomain, rangePadding, innerWidth} = this
 
-    return scale(
+    return getXScaleMemoized(
       xDomain[0],
       xDomain[1],
       rangePadding,
@@ -130,10 +133,13 @@ export class PlotEnv {
   }
 
   public get yScale(): Scale<number, number> {
-    const scale = getScale(this.config.yScale)
+    const getYScaleMemoized = this.fns.get(
+      `yScale_${this.config.yScale}`,
+      getScale(this.config.yScale)
+    )
     const {yDomain, rangePadding, innerHeight} = this
 
-    return scale(
+    return getYScaleMemoized(
       yDomain[0],
       yDomain[1],
       innerHeight - rangePadding * 2,

--- a/giraffe/src/utils/getLogScale.ts
+++ b/giraffe/src/utils/getLogScale.ts
@@ -1,0 +1,14 @@
+import {scaleLog} from 'd3-scale'
+
+import {Scale} from '../types'
+
+export const getLogScale = (
+  domainStart: number,
+  domainStop: number,
+  rangeStart: number,
+  rangeStop: number
+): Scale<number, number> => {
+  return scaleLog()
+    .domain([domainStart, domainStop])
+    .range([rangeStart, rangeStop])
+}

--- a/giraffe/src/utils/getScale.ts
+++ b/giraffe/src/utils/getScale.ts
@@ -1,0 +1,15 @@
+import {getLogScale} from './getLogScale'
+import {getLinearScale} from './getLinearScale'
+
+import {ScaleFactory} from '../types'
+
+export const getScale = (scale: string): ScaleFactory => {
+  switch (scale) {
+    case 'linear':
+      return getLinearScale
+    case 'log':
+      return getLogScale
+    default:
+      return getLinearScale
+  }
+}

--- a/stories/package.json
+++ b/stories/package.json
@@ -40,6 +40,7 @@
     "webpack": "^4.35.3"
   },
   "dependencies": {
+    "d3-array": "^2.4.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   }

--- a/stories/src/helpers.tsx
+++ b/stories/src/helpers.tsx
@@ -119,6 +119,26 @@ export const interpolationKnob = () =>
     'monotoneX'
   )
 
+export const xScaleKnob = () =>
+  select(
+    'X-Scale',
+    {
+      linear: 'linear',
+      log: 'log',
+    },
+    'linear'
+  )
+
+export const yScaleKnob = () =>
+  select(
+    'Y-Scale',
+    {
+      linear: 'linear',
+      log: 'log',
+    },
+    'linear'
+  )
+
 export const showAxesKnob = () => boolean('Axes', true)
 
 export const timeZoneKnob = (initial?: string) =>

--- a/stories/src/index.stories.tsx
+++ b/stories/src/index.stories.tsx
@@ -9,6 +9,8 @@ import {
   PlotContainer,
   xKnob,
   yKnob,
+  xScaleKnob,
+  yScaleKnob,
   fillKnob,
   symbolKnob,
   tableKnob,
@@ -30,6 +32,8 @@ storiesOf('XY Plot', module)
     const x = xKnob(table)
     const y = yKnob(table)
     const yAxisLabel = text('Y Axis Label', 'foo')
+    const xScale = xScaleKnob()
+    const yScale = yScaleKnob()
     const timeZone = timeZoneKnob()
     const timeFormat = select(
       'Time Format',
@@ -70,6 +74,8 @@ storiesOf('XY Plot', module)
         _time: timeFormatter({timeZone, format: timeFormat}),
         [y]: y => `${Math.round(y)} ${yAxisLabel}`,
       },
+      xScale,
+      yScale,
       legendFont,
       tickFont,
       showAxes,
@@ -103,6 +109,8 @@ storiesOf('XY Plot', module)
     const tickFont = tickFontKnob()
     const x = xKnob(table)
     const y = yKnob(table)
+    const xScale = xScaleKnob()
+    const yScale = yScaleKnob()
     const timeZone = timeZoneKnob()
     const timeFormat = select(
       'Time Format',
@@ -141,6 +149,8 @@ storiesOf('XY Plot', module)
       legendFont,
       tickFont,
       showAxes,
+      xScale,
+      yScale,
       layers: [
         {
           type: 'line',
@@ -170,6 +180,8 @@ storiesOf('XY Plot', module)
     const tickFont = tickFontKnob()
     const x = xKnob(table)
     const y = yKnob(table)
+    const xScale = xScaleKnob()
+    const yScale = yScaleKnob()
     const fill = fillKnob(table, 'cpu')
     const symbol = symbolKnob(table, 'host')
 
@@ -181,6 +193,8 @@ storiesOf('XY Plot', module)
       legendFont,
       tickFont,
       showAxes,
+      xScale,
+      yScale,
       layers: [
         {
           type: 'scatter',
@@ -206,11 +220,15 @@ storiesOf('XY Plot', module)
     const tickFont = tickFontKnob()
     const x = xKnob(table)
     const y = yKnob(table)
+    const xScale = xScaleKnob()
+    const yScale = yScaleKnob()
     const showAxes = showAxesKnob()
 
     const config: Config = {
       table,
       legendFont,
+      xScale,
+      yScale,
       tickFont,
       showAxes,
       valueFormatters: {[y]: y => `${Math.round(y)}%`},
@@ -229,6 +247,8 @@ storiesOf('XY Plot', module)
     const legendFont = legendFontKnob()
     const tickFont = tickFontKnob()
     const x = xKnob(table, '_value')
+    const xScale = xScaleKnob()
+    const yScale = yScaleKnob()
     const showAxes = showAxesKnob()
     const binCount = number('Bin Count', 10)
 
@@ -237,6 +257,8 @@ storiesOf('XY Plot', module)
       legendFont,
       tickFont,
       showAxes,
+      xScale,
+      yScale,
       valueFormatters: {[x]: x => `${Math.round(x)}%`},
       layers: [{type: 'histogram', x, fill: ['cpu'], colors, binCount}],
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4083,6 +4083,11 @@ cyclist@~0.2.2:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.2.0.tgz#a9e966b8f8d78f0888d98db1fb840fc8da8ac5c7"
   integrity sha512-eE0QmSh6xToqM3sxHiJYg/QFdNn52ZEgmFE8A8abU8GsHvsIOolqH8B70/8+VGAKm5MlwaExhqR3DLIjOJMLPA==
 
+d3-array@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
+  integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==
+
 d3-color@1, d3-color@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.2.3.tgz#6c67bb2af6df3cc8d79efcc4d3a3e83e28c8048f"


### PR DESCRIPTION
Closes: #12 

X and Y Scale can now be updated to be either linear or logarithmic.

Typically, switching to log scale is in response to skewness towards large values.
