### PR TITLE
fix: expose line transformation for external use

### DIFF
--- a/giraffe/src/index.ts
+++ b/giraffe/src/index.ts
@@ -10,6 +10,7 @@ export {
   siPrefixFormatter,
   binaryPrefixFormatter,
 } from './utils/formatters'
+export {getDomainDataFromLines} from './utils/lineData'
 
 // Transforms
 export {lineTransform} from './transforms/line'

--- a/giraffe/src/index.ts
+++ b/giraffe/src/index.ts
@@ -11,6 +11,9 @@ export {
   binaryPrefixFormatter,
 } from './utils/formatters'
 
+// Transforms
+export {lineTransform} from './transforms/line'
+
 // Constants
 export * from './constants/colorSchemes'
 


### PR DESCRIPTION
Will help with closing https://github.com/influxdata/influxdb/issues/16111

By exposing the `lineTransform` and `getDomainDataFromLines` methods, we allow consumers to create a flattened line spec in exactly the same way that giraffe does it. This will lead to consistency when we determine the `extent` and `domain` from a set of data without re-implementing the same solution externally.