### PR TITLE
fix: export DomainLabel and fix type

### DIFF
--- a/giraffe/src/index.ts
+++ b/giraffe/src/index.ts
@@ -34,4 +34,5 @@ export {
   LayerConfig,
   Config,
   Formatter,
+  DomainLabel,
 } from './types'

--- a/giraffe/src/utils/lineData.ts
+++ b/giraffe/src/utils/lineData.ts
@@ -1,4 +1,4 @@
-import {Table, Scale, LineData, DomainLabel} from '../types'
+import {Table, Scale, LineData, DomainLabel, NumericColumnData} from '../types'
 import {simplify} from '../utils/simplify'
 import {FILL} from '../constants/columnKeys'
 
@@ -55,7 +55,7 @@ export const simplifyLineData = (
 export const getDomainDataFromLines = (
   lineData: LineData,
   domainLabel: DomainLabel
-): Array<number> => {
+): NumericColumnData => {
   let result = []
   const numberOfLines = Object.keys(lineData).length
   for (let index = 0; index < numberOfLines; index += 1) {


### PR DESCRIPTION
Additional export needed for https://github.com/influxdata/influxdb/issues/16111

This also fixes the type for `getDomainDataFromLines`