### PR TITLE
fix: use as many time ticks as d3 can fit on the x-axis

### DIFF
--- a/giraffe/src/utils/PlotEnv.ts
+++ b/giraffe/src/utils/PlotEnv.ts
@@ -98,6 +98,7 @@ export class PlotEnv {
       this.xDomain,
       this.config.width,
       this.charMetrics.width,
+      this.config.tickFont,
       this.xTickFormatter
     )
   }
@@ -113,6 +114,7 @@ export class PlotEnv {
       this.yDomain,
       this.config.height,
       this.charMetrics.height,
+      this.config.tickFont,
       this.yTickFormatter
     )
   }

--- a/giraffe/src/utils/__mocks__/getTextMetrics.ts
+++ b/giraffe/src/utils/__mocks__/getTextMetrics.ts
@@ -1,3 +1,12 @@
+/*
+  utils/getTextMetrics uses the DOM to measure the actual width and height of a string
+  Since Jest does not have access to the DOM, we will fix the width and height to be some arbitrary numbers,
+  so that our tests will run properly for consumers of getTextMetrics
+
+  This is a mock using a fake font that will always have
+  width equal to 1.2 times the length of the string
+  heigth equal to 12
+*/
 export const getTextMetrics = (...args) => ({
   width: Math.floor(args[1].length * 1.2),
   height: 12,

--- a/giraffe/src/utils/__mocks__/getTextMetrics.ts
+++ b/giraffe/src/utils/__mocks__/getTextMetrics.ts
@@ -1,0 +1,4 @@
+export const getTextMetrics = (...args) => ({
+  width: Math.floor(args[1].length * 1.2),
+  height: 12,
+})

--- a/giraffe/src/utils/getTicks.test.ts
+++ b/giraffe/src/utils/getTicks.test.ts
@@ -1,0 +1,103 @@
+import {FormatterType} from '../types'
+import {getTicks} from './getTicks'
+
+jest.mock('./getTextMetrics')
+
+describe('getTicks', () => {
+  const charHeight = 12
+  const font = '10px sans-serif'
+
+  describe('vertical axis', () => {
+    const laptopScreenHeight = 788
+    const formatter = (num: number): string => `${num} foo`
+    const domain = [0, 100]
+    const result = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+
+    it('should give the correct number of ticks', () => {
+      expect(
+        getTicks(domain, laptopScreenHeight, charHeight, font, formatter)
+      ).toEqual(result)
+    })
+    it('should handle extreme or unusual inputs', () => {
+      expect(getTicks(domain, 0, charHeight, font, formatter)).toEqual([])
+      expect(getTicks(domain, laptopScreenHeight, 0, font, formatter)).toEqual(
+        []
+      )
+      expect(
+        getTicks([0, 0], laptopScreenHeight, charHeight, font, formatter)
+      ).toEqual([0])
+      expect(
+        getTicks(domain, laptopScreenHeight, charHeight, font, formatter)
+      ).toEqual(result)
+    })
+  })
+
+  describe('horizontal axis', () => {
+    const axisLength = 1380
+    const formatter = (num: number): string => new Date(num).toDateString()
+    formatter._GIRAFFE_FORMATTER_TYPE = FormatterType.Time
+    const domain = [1578355945276, 1578357085276]
+    const result = [
+      1578355950000,
+      1578355980000,
+      1578356010000,
+      1578356040000,
+      1578356070000,
+      1578356100000,
+      1578356130000,
+      1578356160000,
+      1578356190000,
+      1578356220000,
+      1578356250000,
+      1578356280000,
+      1578356310000,
+      1578356340000,
+      1578356370000,
+      1578356400000,
+      1578356430000,
+      1578356460000,
+      1578356490000,
+      1578356520000,
+      1578356550000,
+      1578356580000,
+      1578356610000,
+      1578356640000,
+      1578356670000,
+      1578356700000,
+      1578356730000,
+      1578356760000,
+      1578356790000,
+      1578356820000,
+      1578356850000,
+      1578356880000,
+      1578356910000,
+      1578356940000,
+      1578356970000,
+      1578357000000,
+      1578357030000,
+      1578357060000,
+    ]
+    it('should give the correct number of ticks', () => {
+      expect(getTicks(domain, axisLength, charHeight, font, formatter)).toEqual(
+        result
+      )
+    })
+    it('should handle extreme or unusual inputs', () => {
+      expect(getTicks(domain, 0, charHeight, font, formatter)).toEqual([])
+      expect(getTicks([0, 0], axisLength, charHeight, font, formatter)).toEqual(
+        [0]
+      )
+      expect(getTicks(domain, axisLength, 0, font, formatter)).toEqual(result)
+      expect(
+        getTicks(domain, axisLength, 100000000000000000, font, formatter)
+      ).toEqual(result)
+      expect(getTicks(domain, axisLength, charHeight, font, formatter)).toEqual(
+        result
+      )
+      expect(
+        getTicks(domain, axisLength / 2, charHeight, font, formatter).length
+      ).toBeLessThan(result.length)
+      expect(getTicks(domain, 0, charHeight, font, formatter).length).toEqual(0)
+    })
+  })
+})

--- a/giraffe/src/utils/getTicks.ts
+++ b/giraffe/src/utils/getTicks.ts
@@ -36,7 +36,7 @@ const hasOptimalSpacing = (
   const fractionalSpaceAsPadding = 0.25
   const totalLength = ticks.length * timeTickLength
   if (ticks.length < 4) {
-    const padding = timeTickLength * ticks.length * fractionalSpaceAsPadding
+    const padding = totalLength * fractionalSpaceAsPadding
     if (totalLength < rangeLength - padding) {
       return true
     }

--- a/giraffe/src/utils/getTicks.ts
+++ b/giraffe/src/utils/getTicks.ts
@@ -18,27 +18,53 @@ const getNumTicks = (
   return sampleTickWidth === 0 ? 0 : Math.round(length / sampleTickWidth)
 }
 
+/*
+  Optimal spacing defined as:
+    I. when there are less than four ticks:
+      for each tick, spacing is one-quarter of the length of a tick
+      thusly: 0.25, 0.50, 0.75 of a tick's length as spacing for one, two, and three ticks respectively
+    II. when there are four or more ticks:
+      sum of all tick lengths is shorter than total available space by at least one tick's length
+    III. Based on rules I and II, we call d3 with the suggested number of ticks, and
+      allow d3 to determine the actual number of ticks and spacing
+*/
+const hasOptimalSpacing = (
+  rangeLength: number,
+  timeTickLength: number,
+  ticks: Date[]
+): boolean => {
+  const fractionalSpaceAsPadding = 0.25
+  const totalLength = ticks.length * timeTickLength
+  if (ticks.length < 4) {
+    const padding = timeTickLength * ticks.length * fractionalSpaceAsPadding
+    if (totalLength < rangeLength - padding) {
+      return true
+    }
+    return false
+  } else if (totalLength < rangeLength - timeTickLength) {
+    return true
+  }
+  return false
+}
+
 const getOptimalTimeTicks = (
   [d0, d1]: number[],
   rangeLength: number,
   timeTickLength: number
 ): Date[] => {
-  const maxUseableLength = rangeLength - timeTickLength
   const scaledTime = scaleUtc()
     .domain([d0, d1])
     .range([0, rangeLength])
-
   const maxNumTicks = Math.floor(rangeLength / timeTickLength)
-
   let optimalTicks = scaledTime.ticks(maxNumTicks)
-  let counter = 1
 
-  while (
+  for (
+    let counter = 1;
     counter < maxNumTicks &&
-    optimalTicks.length * timeTickLength > maxUseableLength
+    !hasOptimalSpacing(rangeLength, timeTickLength, optimalTicks);
+    counter += 1
   ) {
     optimalTicks = scaledTime.ticks(maxNumTicks - counter)
-    counter += 1
   }
   return optimalTicks
 }

--- a/stories/src/index.stories.tsx
+++ b/stories/src/index.stories.tsx
@@ -41,6 +41,7 @@ storiesOf('XY Plot', module)
         'DD/MM/YYYY HH:mm:ss.sss': 'DD/MM/YYYY HH:mm:ss.sss',
         'MM/DD/YYYY HH:mm:ss.sss': 'MM/DD/YYYY HH:mm:ss.sss',
         'YYYY/MM/DD HH:mm:ss': 'YYYY/MM/DD HH:mm:ss',
+        'YYYY-MM-DD HH:mm:ss ZZ': 'YYYY-MM-DD HH:mm:ss ZZ',
         'hh:mm a': 'hh:mm a',
         'HH:mm': 'HH:mm',
         'HH:mm:ss': 'HH:mm:ss',
@@ -49,7 +50,7 @@ storiesOf('XY Plot', module)
         'MMMM D, YYYY HH:mm:ss': 'MMMM D, YYYY HH:mm:ss',
         'dddd, MMMM D, YYYY HH:mm:ss': 'dddd, MMMM D, YYYY HH:mm:ss',
       },
-      'hh:mm a'
+      'YYYY-MM-DD HH:mm:ss ZZ'
     )
     const fill = fillKnob(table, 'cpu')
     const position = select(
@@ -118,6 +119,7 @@ storiesOf('XY Plot', module)
         'DD/MM/YYYY HH:mm:ss.sss': 'DD/MM/YYYY HH:mm:ss.sss',
         'MM/DD/YYYY HH:mm:ss.sss': 'MM/DD/YYYY HH:mm:ss.sss',
         'YYYY/MM/DD HH:mm:ss': 'YYYY/MM/DD HH:mm:ss',
+        'YYYY-MM-DD HH:mm:ss ZZ': 'YYYY-MM-DD HH:mm:ss ZZ',
         'hh:mm a': 'hh:mm a',
         'HH:mm': 'HH:mm',
         'HH:mm:ss': 'HH:mm:ss',
@@ -126,7 +128,7 @@ storiesOf('XY Plot', module)
         'MMMM D, YYYY HH:mm:ss': 'MMMM D, YYYY HH:mm:ss',
         'dddd, MMMM D, YYYY HH:mm:ss': 'dddd, MMMM D, YYYY HH:mm:ss',
       },
-      'YYYY/MM/DD HH:mm:ss'
+      'YYYY-MM-DD HH:mm:ss ZZ'
     )
     const fill = fillKnob(table, 'cpu')
     const interpolation = interpolationKnob()


### PR DESCRIPTION
Closes https://github.com/influxdata/giraffe/issues/135 and https://github.com/influxdata/influxdb/issues/16395

Instead of using 'W' for the average character width, we measure the exact width of the label. Then we ask d3 to give us as many time ticks as will fit on the x-axis with the following restrictions to act as padding around the labels:
- round down when finding the maximum number as the first suggestion to d3
- four or more labels: the sum of all the lengths of the labels is shorter than the available space by at least one label's length
- less than four labels: 0.25, 0.50, 0.75 label length as spacing for one, two, and three labels respectively
