### PR TITLE
fix: Use correct scale when hovering over stacked line graphs

### DIFF
--- a/giraffe/src/components/LineLayer.tsx
+++ b/giraffe/src/components/LineLayer.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import {useMemo, useRef, FunctionComponent} from 'react'
 
-import {LayerProps, LineLayerSpec, LineLayerConfig} from '../types'
+import {LayerProps, LineLayerSpec, LineLayerConfig, DomainLabel} from '../types'
 import {LineHoverLayer} from './LineHoverLayer'
-import {simplifyLineData} from '../utils/lineData'
+import {simplifyLineData, getDomainDataFromLines} from '../utils/lineData'
 import {useCanvas} from '../utils/useCanvas'
 import {drawLines} from '../utils/drawLines'
 import {useHoverPointIndices} from '../utils/useHoverPointIndices'
@@ -16,6 +16,7 @@ export interface Props extends LayerProps {
 
 export const LineLayer: FunctionComponent<Props> = props => {
   const {config, spec, width, height, xScale, yScale, hoverX, hoverY} = props
+  const {position} = config
 
   const simplifiedLineData = useMemo(
     () => simplifyLineData(spec.lineData, xScale, yScale),
@@ -54,12 +55,16 @@ export const LineLayer: FunctionComponent<Props> = props => {
     hoverDimension = config.hoverDimension
   }
 
+  const hoverYColumnData =
+    position === 'stacked'
+      ? getDomainDataFromLines(spec.lineData, DomainLabel.Y)
+      : spec.table.getColumn(config.y, 'number')
   const hoverRowIndices = useHoverPointIndices(
     hoverDimension,
     hoverX,
     hoverY,
     spec.table.getColumn(config.x, 'number'),
-    spec.table.getColumn(config.y, 'number'),
+    hoverYColumnData,
     spec.table.getColumn(FILL, 'number'),
     xScale,
     yScale,

--- a/giraffe/src/constants/columnKeys.ts
+++ b/giraffe/src/constants/columnKeys.ts
@@ -8,3 +8,5 @@ export const COUNT = 'count'
 // Computed column names mapped to group aesthetics
 export const FILL = '__fill'
 export const SYMBOL = '__symbol'
+export const STACKED_LINE_CUMULATIVE = 'cumulative'
+export const LINE_COUNT = 'lines'

--- a/giraffe/src/utils/fixtures/tooltip.ts
+++ b/giraffe/src/utils/fixtures/tooltip.ts
@@ -1,0 +1,49 @@
+import {newTable} from '../newTable'
+
+interface SampleTableOptions {
+  include_negative?: boolean
+  all_negative?: boolean
+  decimalPlaces?: number
+  maxValue?: number
+  numberOfRecords?: number
+  recordsPerLine?: number
+  hoveredRowIndices?: number[]
+}
+
+const turnNegativeRandomly = (num: number) =>
+  num * (Math.floor(Math.random() * 2 + 1) === 1 ? 1 : -1)
+
+const getRandomNumber = (max: number, decimalPlaces: number) =>
+  Number((Math.random() * Math.floor(max)).toFixed(decimalPlaces))
+
+export const columnKey = 'cpu'
+
+export const createSampleTable = (options: SampleTableOptions) => {
+  const {
+    include_negative = false,
+    all_negative = false,
+    decimalPlaces = 2,
+    maxValue = 100,
+    numberOfRecords = 20,
+    recordsPerLine = 5,
+  } = options
+
+  const now = Date.now()
+  const TIME_COL = []
+  const VALUE_COL = []
+  const CPU_COL = []
+
+  for (let i = 0; i < numberOfRecords; i += 1) {
+    let num = getRandomNumber(maxValue, decimalPlaces)
+    if (include_negative) {
+      num = all_negative ? Math.abs(num) * -1 : turnNegativeRandomly(num)
+    }
+    VALUE_COL.push(num)
+    CPU_COL.push(`${columnKey}${Math.floor(i / recordsPerLine)}`)
+    TIME_COL.push(now + (i % recordsPerLine) * 1000 * 60)
+  }
+  return newTable(numberOfRecords)
+    .addColumn('_time', 'time', TIME_COL)
+    .addColumn('_value', 'number', VALUE_COL)
+    .addColumn('cpu', 'string', CPU_COL)
+}

--- a/giraffe/src/utils/fixtures/tooltip.ts
+++ b/giraffe/src/utils/fixtures/tooltip.ts
@@ -7,7 +7,6 @@ interface SampleTableOptions {
   maxValue?: number
   numberOfRecords?: number
   recordsPerLine?: number
-  hoveredRowIndices?: number[]
 }
 
 const turnNegativeRandomly = (num: number) =>

--- a/giraffe/src/utils/fixtures/tooltip.ts
+++ b/giraffe/src/utils/fixtures/tooltip.ts
@@ -9,13 +9,19 @@ interface SampleTableOptions {
   recordsPerLine?: number
 }
 
-const turnNegativeRandomly = (num: number) =>
-  num * (Math.floor(Math.random() * 2 + 1) === 1 ? 1 : -1)
+const getRandomNumber = (
+  max: number,
+  decimalPlaces: number,
+  include_negative?: boolean
+) => {
+  const result = include_negative
+    ? Number((Math.random() * (2 * max + 1) - max).toFixed(decimalPlaces))
+    : Number((Math.random() * max).toFixed(decimalPlaces))
 
-const getRandomNumber = (max: number, decimalPlaces: number) =>
-  Number((Math.random() * Math.floor(max)).toFixed(decimalPlaces))
+  return result === -0 ? 0 : result // eslint-disable-line no-compare-neg-zero
+}
 
-export const columnKey = 'cpu'
+export const COLUMN_KEY = 'cpu'
 
 export const createSampleTable = (options: SampleTableOptions) => {
   const {
@@ -35,10 +41,12 @@ export const createSampleTable = (options: SampleTableOptions) => {
   for (let i = 0; i < numberOfRecords; i += 1) {
     let num = getRandomNumber(maxValue, decimalPlaces)
     if (include_negative) {
-      num = all_negative ? Math.abs(num) * -1 : turnNegativeRandomly(num)
+      num = all_negative
+        ? Math.abs(num) * -1
+        : getRandomNumber(maxValue, decimalPlaces, true)
     }
     VALUE_COL.push(num)
-    CPU_COL.push(`${columnKey}${Math.floor(i / recordsPerLine)}`)
+    CPU_COL.push(`${COLUMN_KEY}${Math.floor(i / recordsPerLine)}`)
     TIME_COL.push(now + (i % recordsPerLine) * 1000 * 60)
   }
   return newTable(numberOfRecords)

--- a/giraffe/src/utils/tooltip.test.ts
+++ b/giraffe/src/utils/tooltip.test.ts
@@ -21,8 +21,8 @@ describe('getPointsTooltipData', () => {
   let cumulativeValueColumn
 
   const setUp = options => {
-    const {hoveredRowIndices, position} = options
-    sampleTable = createSampleTable(options)
+    const {hoveredRowIndices, position, ...tableOptions} = options
+    sampleTable = createSampleTable(tableOptions)
     lineSpec = lineTransform(
       sampleTable,
       xColKey,

--- a/giraffe/src/utils/tooltip.test.ts
+++ b/giraffe/src/utils/tooltip.test.ts
@@ -1,0 +1,178 @@
+import {getPointsTooltipData} from './tooltip'
+import {NINETEEN_EIGHTY_FOUR} from '../constants/colorSchemes'
+import {
+  FILL,
+  STACKED_LINE_CUMULATIVE,
+  LINE_COUNT,
+} from '../constants/columnKeys'
+import {getNominalColorScale, createGroupIDColumn} from '../transforms'
+import {lineTransform} from '../transforms/line'
+import {createSampleTable, columnKey} from './fixtures/tooltip'
+
+describe('getPointsTooltipData', () => {
+  let sampleTable
+  const xColKey = '_time'
+  const yColKey = '_value'
+  const columnFormatter = () => x => String(x)
+  let lineSpec
+  let fillScale
+  let hoveredValues
+  let result
+  let cumulativeValueColumn
+
+  const setUp = options => {
+    const {hoveredRowIndices, position} = options
+    sampleTable = createSampleTable(options)
+    lineSpec = lineTransform(
+      sampleTable,
+      xColKey,
+      yColKey,
+      [columnKey],
+      NINETEEN_EIGHTY_FOUR,
+      position
+    )
+
+    const [fillColumn, fillColumnMap] = createGroupIDColumn(sampleTable, [
+      columnKey,
+    ])
+    fillScale = getNominalColorScale(fillColumnMap, NINETEEN_EIGHTY_FOUR)
+    sampleTable = sampleTable.addColumn(FILL, 'number', fillColumn)
+
+    const fillColumnFromSampleTable = sampleTable.getColumn(FILL, 'number')
+    fillColumn.forEach((item, index) =>
+      expect(item).toEqual(fillColumnFromSampleTable[index])
+    )
+
+    const allValues = sampleTable.getColumn('_value')
+    hoveredValues = hoveredRowIndices.map(i => allValues[i])
+  }
+
+  describe('tooltip for overlaid line graph', () => {
+    const position = 'overlaid'
+
+    it('should have a value column that is not necessarily sorted', () => {
+      const hoveredRowIndices = [3, 8, 13, 18]
+      setUp({
+        include_negative: true,
+        all_negative: false,
+        hoveredRowIndices,
+        position,
+      })
+      result = getPointsTooltipData(
+        hoveredRowIndices,
+        sampleTable,
+        xColKey,
+        yColKey,
+        FILL,
+        columnFormatter,
+        [columnKey],
+        fillScale,
+        'overlaid',
+        lineSpec.lineData
+      )
+      const singleValueColumn = result.find(column => column.key === yColKey)
+      expect(singleValueColumn.values.map(value => Number(value))).toEqual(
+        hoveredValues
+      )
+    })
+  })
+
+  describe('tooltip for stacked line graph', () => {
+    const position = 'stacked'
+
+    afterEach(() => {
+      cumulativeValueColumn = result.find(
+        column => column.key === STACKED_LINE_CUMULATIVE
+      )
+      expect(cumulativeValueColumn).toBeTruthy()
+      expect(
+        cumulativeValueColumn.values.every((value, index, arr) => {
+          if (index === 0) {
+            return true
+          }
+          return Number(arr[index - 1]) >= Number(value)
+        })
+      ).toEqual(true)
+
+      expect(result.find(column => column.key === LINE_COUNT)).toBeTruthy()
+    })
+
+    it('should create proper columns when all values are positive numbers', () => {
+      const hoveredRowIndices = [0, 5, 10, 15]
+      setUp({
+        include_negative: false,
+        all_negative: false,
+        hoveredRowIndices,
+        position,
+      })
+      result = getPointsTooltipData(
+        hoveredRowIndices,
+        sampleTable,
+        xColKey,
+        yColKey,
+        FILL,
+        columnFormatter,
+        [columnKey],
+        fillScale,
+        'stacked',
+        lineSpec.lineData
+      )
+      const singleValueColumn = result.find(column => column.key === yColKey)
+      expect(singleValueColumn).toBeTruthy()
+      expect(
+        singleValueColumn.values.map(value => Number(value)).reverse()
+      ).toEqual(hoveredValues)
+    })
+
+    it('should create proper columns when all values are negative numbers', () => {
+      const hoveredRowIndices = [1, 6, 11, 16]
+      setUp({
+        include_negative: true,
+        all_negative: true,
+        hoveredRowIndices,
+        position,
+      })
+      result = getPointsTooltipData(
+        hoveredRowIndices,
+        sampleTable,
+        xColKey,
+        yColKey,
+        FILL,
+        columnFormatter,
+        [columnKey],
+        fillScale,
+        'stacked',
+        lineSpec.lineData
+      )
+      const singleValueColumn = result.find(column => column.key === yColKey)
+
+      expect(singleValueColumn).toBeTruthy()
+      expect(singleValueColumn.values.map(value => Number(value))).toEqual(
+        hoveredValues
+      )
+    })
+
+    it('should create proper columns when values can be positive or negative', () => {
+      const hoveredRowIndices = [2, 7, 12, 17]
+      setUp({
+        include_negative: true,
+        all_negative: false,
+        hoveredRowIndices,
+        position,
+      })
+      result = getPointsTooltipData(
+        hoveredRowIndices,
+        sampleTable,
+        xColKey,
+        yColKey,
+        FILL,
+        columnFormatter,
+        [columnKey],
+        fillScale,
+        'stacked',
+        lineSpec.lineData
+      )
+      expect(result.find(column => column.key === yColKey)).toBeTruthy()
+    })
+  })
+})

--- a/giraffe/src/utils/tooltip.test.ts
+++ b/giraffe/src/utils/tooltip.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../constants/columnKeys'
 import {getNominalColorScale, createGroupIDColumn} from '../transforms'
 import {lineTransform} from '../transforms/line'
-import {createSampleTable, columnKey} from './fixtures/tooltip'
+import {createSampleTable, COLUMN_KEY} from './fixtures/tooltip'
 
 describe('getPointsTooltipData', () => {
   let sampleTable
@@ -20,6 +20,10 @@ describe('getPointsTooltipData', () => {
   let result
   let cumulativeValueColumn
 
+  const numberOfRecords = 1000
+  const recordsPerLine = 10
+  let startingIndex
+
   const setUp = options => {
     const {hoveredRowIndices, position, ...tableOptions} = options
     sampleTable = createSampleTable(tableOptions)
@@ -27,13 +31,13 @@ describe('getPointsTooltipData', () => {
       sampleTable,
       xColKey,
       yColKey,
-      [columnKey],
+      [COLUMN_KEY],
       NINETEEN_EIGHTY_FOUR,
       position
     )
 
     const [fillColumn, fillColumnMap] = createGroupIDColumn(sampleTable, [
-      columnKey,
+      COLUMN_KEY,
     ])
     fillScale = getNominalColorScale(fillColumnMap, NINETEEN_EIGHTY_FOUR)
     sampleTable = sampleTable.addColumn(FILL, 'number', fillColumn)
@@ -51,10 +55,16 @@ describe('getPointsTooltipData', () => {
     const position = 'overlaid'
 
     it('should have a value column that is not necessarily sorted', () => {
-      const hoveredRowIndices = [3, 8, 13, 18]
+      startingIndex = 3
+      const hoveredRowIndices = []
+      for (let i = startingIndex; i < numberOfRecords; i += recordsPerLine) {
+        hoveredRowIndices.push(i)
+      }
       setUp({
         include_negative: true,
         all_negative: false,
+        numberOfRecords,
+        recordsPerLine,
         hoveredRowIndices,
         position,
       })
@@ -65,7 +75,7 @@ describe('getPointsTooltipData', () => {
         yColKey,
         FILL,
         columnFormatter,
-        [columnKey],
+        [COLUMN_KEY],
         fillScale,
         'overlaid',
         lineSpec.lineData
@@ -81,6 +91,27 @@ describe('getPointsTooltipData', () => {
     const position = 'stacked'
 
     afterEach(() => {
+      const totalColumns = result.length
+      const colorsCounter = {}
+
+      result.forEach(column => {
+        const {colors} = column
+        colors.forEach(color => {
+          if (!colorsCounter[color]) {
+            colorsCounter[color] = 0
+          }
+          colorsCounter[color] += 1
+        })
+      })
+      expect(Object.keys(colorsCounter).length).toEqual(
+        numberOfRecords / recordsPerLine
+      )
+      expect(
+        Object.values(colorsCounter).every(
+          colorCount => colorCount === totalColumns
+        )
+      ).toEqual(true)
+
       cumulativeValueColumn = result.find(
         column => column.key === STACKED_LINE_CUMULATIVE
       )
@@ -98,10 +129,16 @@ describe('getPointsTooltipData', () => {
     })
 
     it('should create proper columns when all values are positive numbers', () => {
-      const hoveredRowIndices = [0, 5, 10, 15]
+      startingIndex = 0
+      const hoveredRowIndices = []
+      for (let i = startingIndex; i < numberOfRecords; i += recordsPerLine) {
+        hoveredRowIndices.push(i)
+      }
       setUp({
         include_negative: false,
         all_negative: false,
+        numberOfRecords,
+        recordsPerLine,
         hoveredRowIndices,
         position,
       })
@@ -112,7 +149,7 @@ describe('getPointsTooltipData', () => {
         yColKey,
         FILL,
         columnFormatter,
-        [columnKey],
+        [COLUMN_KEY],
         fillScale,
         'stacked',
         lineSpec.lineData
@@ -125,10 +162,16 @@ describe('getPointsTooltipData', () => {
     })
 
     it('should create proper columns when all values are negative numbers', () => {
-      const hoveredRowIndices = [1, 6, 11, 16]
+      startingIndex = 1
+      const hoveredRowIndices = []
+      for (let i = startingIndex; i < numberOfRecords; i += recordsPerLine) {
+        hoveredRowIndices.push(i)
+      }
       setUp({
         include_negative: true,
         all_negative: true,
+        numberOfRecords,
+        recordsPerLine,
         hoveredRowIndices,
         position,
       })
@@ -139,7 +182,7 @@ describe('getPointsTooltipData', () => {
         yColKey,
         FILL,
         columnFormatter,
-        [columnKey],
+        [COLUMN_KEY],
         fillScale,
         'stacked',
         lineSpec.lineData
@@ -153,10 +196,16 @@ describe('getPointsTooltipData', () => {
     })
 
     it('should create proper columns when values can be positive or negative', () => {
-      const hoveredRowIndices = [2, 7, 12, 17]
+      startingIndex = 2
+      const hoveredRowIndices = []
+      for (let i = startingIndex; i < numberOfRecords; i += recordsPerLine) {
+        hoveredRowIndices.push(i)
+      }
       setUp({
         include_negative: true,
         all_negative: false,
+        numberOfRecords,
+        recordsPerLine,
         hoveredRowIndices,
         position,
       })
@@ -167,7 +216,7 @@ describe('getPointsTooltipData', () => {
         yColKey,
         FILL,
         columnFormatter,
-        [columnKey],
+        [COLUMN_KEY],
         fillScale,
         'stacked',
         lineSpec.lineData

--- a/giraffe/src/utils/tooltip.ts
+++ b/giraffe/src/utils/tooltip.ts
@@ -22,9 +22,9 @@ const orderDataByValue = (
   nextOrder: number[],
   data: Array<any>
 ) => {
-  const map = {}
-  originalOrder.forEach((key, i) => (map[key] = data[i]))
-  return nextOrder.map(index => map[index])
+  const dataMap = {}
+  originalOrder.forEach((place, index) => (dataMap[place] = data[index]))
+  return nextOrder.map(place => dataMap[place])
 }
 
 const getDataSortOrder = (
@@ -35,21 +35,21 @@ const getDataSortOrder = (
   if (position === 'overlaid') {
     return hoveredRowIndices
   }
-  const map = {}
-  const values = Object.keys(lineData).reduce(
-    (accum, value) => accum.concat(lineData[value][DomainLabel.Y]),
+  const dataMap = {}
+  const measurementValues = Object.keys(lineData).reduce(
+    (accumulator, id) => accumulator.concat(lineData[id][DomainLabel.Y]),
     []
   )
   const sortable = []
-  hoveredRowIndices.forEach(hoverRowIndex => {
-    if (!map[values[hoverRowIndex]]) {
-      map[values[hoverRowIndex]] = []
+  hoveredRowIndices.forEach(hoveredRowIndex => {
+    if (!dataMap[measurementValues[hoveredRowIndex]]) {
+      dataMap[measurementValues[hoveredRowIndex]] = []
     }
-    map[values[hoverRowIndex]].push(hoverRowIndex)
-    sortable.push(values[hoverRowIndex])
+    dataMap[measurementValues[hoveredRowIndex]].push(hoveredRowIndex)
+    sortable.push(measurementValues[hoveredRowIndex])
   })
   sortable.sort((first, second) => second - first)
-  return sortable.map(value => map[value].shift())
+  return sortable.map(measurement => dataMap[measurement].shift())
 }
 
 export const getRangeLabel = (min: number, max: number, formatter): string => {

--- a/stories/src/data/stackedLineLayer.ts
+++ b/stories/src/data/stackedLineLayer.ts
@@ -3,17 +3,17 @@ import {newTable} from '../../../giraffe/src'
 const now = Date.now()
 const numberOfRecords = 80
 const recordsPerLine = 20
-const maxIntValue = 100
+const maxValue = 100
 
 const TIME_COL = []
 const VALUE_COL = []
 const CPU_COL = []
 
-function getRandomInt(max) {
+function getRandomNumber(max) {
   return Math.random() * Math.floor(max)
 }
 for (let i = 0; i < numberOfRecords; i += 1) {
-  VALUE_COL.push(getRandomInt(maxIntValue))
+  VALUE_COL.push(getRandomNumber(maxValue))
   CPU_COL.push(`cpu${Math.floor(i / recordsPerLine)}`)
   TIME_COL.push(now + (i % recordsPerLine) * 1000 * 60)
 }

--- a/stories/src/data/stackedLineLayer.ts
+++ b/stories/src/data/stackedLineLayer.ts
@@ -10,7 +10,7 @@ const VALUE_COL = []
 const CPU_COL = []
 
 function getRandomInt(max) {
-  return Math.floor(Math.random() * Math.floor(max))
+  return Math.random() * Math.floor(max)
 }
 for (let i = 0; i < numberOfRecords; i += 1) {
   VALUE_COL.push(getRandomInt(maxIntValue))

--- a/stories/src/index.stories.tsx
+++ b/stories/src/index.stories.tsx
@@ -73,7 +73,7 @@ storiesOf('XY Plot', module)
       table,
       valueFormatters: {
         _time: timeFormatter({timeZone, format: timeFormat}),
-        [y]: y => `${Math.round(y)} ${yAxisLabel}`,
+        [y]: y => `${y.toFixed(2)} ${yAxisLabel}`,
       },
       xScale,
       yScale,


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/16489 and https://github.com/influxdata/giraffe/issues/145

**Stacked Line Graphs**
- Fixes the data for the hovered points when lines intersect (have similar values)
- Sorts the order of the rows in the tooltip to match the order of the hovered points
- Adds a column in the tooltip to make it clear how many lines are represented in each row
- Adds unit tests for the tooltip utility