### PR TITLE
test: add more tests for tooltip colors

### DIFF
--- a/giraffe/src/utils/tooltip.test.ts
+++ b/giraffe/src/utils/tooltip.test.ts
@@ -20,7 +20,7 @@ describe('getPointsTooltipData', () => {
   let result
   let cumulativeValueColumn
 
-  const numberOfRecords = 1000
+  const numberOfRecords = 40
   const recordsPerLine = 10
   let startingIndex
 
@@ -92,8 +92,16 @@ describe('getPointsTooltipData', () => {
 
     afterEach(() => {
       const totalColumns = result.length
+      const totalRows = numberOfRecords / recordsPerLine
       const colorsCounter = {}
 
+      // color is the same across a row
+      for (let i = 0; i < totalRows; i += 1) {
+        for (let j = 0; j < totalColumns; j += 1) {
+          const rowColor = result[0].colors[i]
+          expect(rowColor === result[j].colors[i])
+        }
+      }
       result.forEach(column => {
         const {colors} = column
         colors.forEach(color => {
@@ -103,9 +111,11 @@ describe('getPointsTooltipData', () => {
           colorsCounter[color] += 1
         })
       })
-      expect(Object.keys(colorsCounter).length).toEqual(
-        numberOfRecords / recordsPerLine
-      )
+
+      // number of different colors should equal number of rows
+      expect(Object.keys(colorsCounter).length).toEqual(totalRows)
+
+      // each column should have color
       expect(
         Object.values(colorsCounter).every(
           colorCount => colorCount === totalColumns

--- a/giraffe/src/utils/tooltip.test.ts
+++ b/giraffe/src/utils/tooltip.test.ts
@@ -20,7 +20,7 @@ describe('getPointsTooltipData', () => {
   let result
   let cumulativeValueColumn
 
-  const numberOfRecords = 40
+  const numberOfRecords = 1000
   const recordsPerLine = 10
   let startingIndex
 


### PR DESCRIPTION
More tests as part of https://github.com/influxdata/giraffe/issues/145

Adds more tests for tooltip colors. Consistent coloring is an effective way to ensure the data has been properly sorted and guards this functionality for future changes.