### PR TITLE
fix: show the additional columns

### DIFF
--- a/giraffe/src/utils/tooltip.test.ts
+++ b/giraffe/src/utils/tooltip.test.ts
@@ -80,7 +80,7 @@ describe('getPointsTooltipData', () => {
         'overlaid',
         lineSpec.lineData
       )
-      const singleValueColumn = result.find(column => column.key === yColKey)
+      const singleValueColumn = result.find(column => column.name === yColKey)
       expect(singleValueColumn.values.map(value => Number(value))).toEqual(
         hoveredValues
       )
@@ -113,7 +113,7 @@ describe('getPointsTooltipData', () => {
       ).toEqual(true)
 
       cumulativeValueColumn = result.find(
-        column => column.key === STACKED_LINE_CUMULATIVE
+        column => column.name === STACKED_LINE_CUMULATIVE
       )
       expect(cumulativeValueColumn).toBeTruthy()
       expect(
@@ -125,7 +125,7 @@ describe('getPointsTooltipData', () => {
         })
       ).toEqual(true)
 
-      expect(result.find(column => column.key === LINE_COUNT)).toBeTruthy()
+      expect(result.find(column => column.name === LINE_COUNT)).toBeTruthy()
     })
 
     it('should create proper columns when all values are positive numbers', () => {
@@ -154,7 +154,7 @@ describe('getPointsTooltipData', () => {
         'stacked',
         lineSpec.lineData
       )
-      const singleValueColumn = result.find(column => column.key === yColKey)
+      const singleValueColumn = result.find(column => column.name === yColKey)
       expect(singleValueColumn).toBeTruthy()
       expect(
         singleValueColumn.values.map(value => Number(value)).reverse()
@@ -187,7 +187,7 @@ describe('getPointsTooltipData', () => {
         'stacked',
         lineSpec.lineData
       )
-      const singleValueColumn = result.find(column => column.key === yColKey)
+      const singleValueColumn = result.find(column => column.name === yColKey)
 
       expect(singleValueColumn).toBeTruthy()
       expect(singleValueColumn.values.map(value => Number(value))).toEqual(
@@ -221,7 +221,7 @@ describe('getPointsTooltipData', () => {
         'stacked',
         lineSpec.lineData
       )
-      expect(result.find(column => column.key === yColKey)).toBeTruthy()
+      expect(result.find(column => column.name === yColKey)).toBeTruthy()
     })
   })
 })

--- a/giraffe/src/utils/tooltip.ts
+++ b/giraffe/src/utils/tooltip.ts
@@ -135,7 +135,7 @@ export const getPointsTooltipData = (
   const tooltipAdditionalColumns = []
   if (position === 'stacked') {
     tooltipAdditionalColumns.push({
-      key: STACKED_LINE_CUMULATIVE,
+      key: yColKey,
       name: STACKED_LINE_CUMULATIVE,
       type: table.getColumnType(yColKey),
       colors,
@@ -152,7 +152,7 @@ export const getPointsTooltipData = (
       ),
     })
     tooltipAdditionalColumns.push({
-      key: LINE_COUNT,
+      key: yColKey,
       name: LINE_COUNT,
       type: table.getColumnType(FILL),
       colors,


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/16489 (for real this time)

Actually show the columns in the tooltip by associating them to the correct column