### PR TITLE
fix: calculate correct cumulative values for lines of different lengths

### DIFF
--- a/giraffe/src/constants/columnKeys.ts
+++ b/giraffe/src/constants/columnKeys.ts
@@ -6,6 +6,7 @@ export const Y_MAX = 'yMax'
 export const COUNT = 'count'
 
 // Computed column names mapped to group aesthetics
+export const VALUE = '_value'
 export const FILL = '__fill'
 export const SYMBOL = '__symbol'
 export const STACKED_LINE_CUMULATIVE = 'cumulative'

--- a/giraffe/src/transforms/line.test.ts
+++ b/giraffe/src/transforms/line.test.ts
@@ -1,87 +1,49 @@
-import {DomainLabel} from '../types'
-import {getPreviousDomainNextValue} from './line'
+import {mapCumulativeValuesToTimeRange} from './line'
 
 describe('line transform utils', () => {
-  describe('get cumulative value from domain data', () => {
-    const lineData = {
-      0: {
-        xs: [1554308748000, 1554308948000, 1554309628000],
-        ys: [35, 10, 20],
-        fill: 'yes',
-      },
-    }
-    it('should return 0 when line data has only 1 line', () => {
-      expect(getPreviousDomainNextValue(lineData, 0, DomainLabel.X)).toEqual(0)
-      expect(getPreviousDomainNextValue(lineData, 0, DomainLabel.Y)).toEqual(0)
-    })
-    it('should return 0 when previous domain value does not exist', () => {
-      lineData[0] = {xs: [], ys: [], fill: 'yes'}
-      lineData[1] = {xs: [10, 20, 30], ys: [5, 6, 7], fill: 'yup'}
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.X)).toEqual(0)
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.Y)).toEqual(0)
-    })
-    it('should return 0 when group ID does not exist in the line data', () => {
-      lineData[0] = {xs: [10, 20, 30], ys: [2, 4, 6], fill: 'yes'}
-      lineData[1] = {xs: [10, 20], ys: [1, 3], fill: 'yup'}
-      expect(getPreviousDomainNextValue(lineData, 2, DomainLabel.X)).toEqual(0)
-      expect(getPreviousDomainNextValue(lineData, 13, DomainLabel.X)).toEqual(0)
-      expect(getPreviousDomainNextValue(lineData, 40, DomainLabel.X)).toEqual(0)
-      expect(getPreviousDomainNextValue(lineData, 2, DomainLabel.Y)).toEqual(0)
-      expect(getPreviousDomainNextValue(lineData, 38, DomainLabel.Y)).toEqual(0)
-      expect(getPreviousDomainNextValue(lineData, 104, DomainLabel.Y)).toEqual(
-        0
+  describe('creates a map of every time point with the cumulative values for every line', () => {
+    const threeTimePoints = [1582222037067, 1582222097067, 1582222157067]
+
+    it('should have a hash of all the time points when all lines are uniform in length', () => {
+      const fillCol = [0, 0, 0, 1, 1, 1, 2, 2, 2]
+      const timesCol = [
+        ...threeTimePoints,
+        ...threeTimePoints,
+        ...threeTimePoints,
+      ]
+      const valuesCol = [2, 2, 3, 1, 6, 4, 7, 8, 5]
+      const cumulativeValues = mapCumulativeValuesToTimeRange(
+        timesCol,
+        valuesCol,
+        fillCol
+      )
+      threeTimePoints.forEach(time =>
+        expect(cumulativeValues[time]).toBeTruthy()
+      )
+      expect(Object.keys(cumulativeValues).length).toEqual(
+        threeTimePoints.length
       )
     })
-    it('should return 0 when group ID minus 1 does not exist in the line data', () => {
-      lineData[99] = {xs: [10, 20], ys: [1, 3], fill: 'whoa'}
-      expect(getPreviousDomainNextValue(lineData, 10, DomainLabel.X)).toEqual(0)
-      expect(getPreviousDomainNextValue(lineData, 10, DomainLabel.Y)).toEqual(0)
-    })
-    it('should return 0 when previous and current domains are same length', () => {
-      lineData[0] = {xs: [10, 20, 30], ys: [2, 4, 6], fill: 'yes'}
-      lineData[1] = {xs: [10, 20, 30], ys: [1, 3, 5], fill: 'yup'}
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.X)).toEqual(0)
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.Y)).toEqual(0)
-    })
-    it('should return 0 when current domain is longer', () => {
-      lineData[0] = {xs: [10, 20, 30], ys: [2, 4, 6], fill: 'yes'}
-      lineData[1] = {xs: [10, 20, 30, 40], ys: [1, 3, 5, 7], fill: 'yup'}
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.X)).toEqual(0)
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.Y)).toEqual(0)
 
-      lineData[1][DomainLabel.X].push(50)
-      lineData[1][DomainLabel.Y].push(9)
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.X)).toEqual(0)
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.Y)).toEqual(0)
-
-      lineData[1][DomainLabel.X].push(60)
-      lineData[1][DomainLabel.X].push(70)
-      lineData[1][DomainLabel.X].push(80)
-      lineData[1][DomainLabel.Y].push(11)
-      lineData[1][DomainLabel.Y].push(13)
-      lineData[1][DomainLabel.Y].push(15)
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.X)).toEqual(0)
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.Y)).toEqual(0)
-    })
-    it('should return the corresponding next value of previous domain when current domain is shorter', () => {
-      lineData[0] = {xs: [10, 20, 30, 40], ys: [2, 4, 6, 8], fill: 'yes'}
-      lineData[1] = {xs: [10, 20, 30], ys: [1, 3, 5], fill: 'yup'}
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.X)).toEqual(40)
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.Y)).toEqual(8)
-
-      lineData[0][DomainLabel.X].push(50)
-      lineData[0][DomainLabel.Y].push(10)
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.X)).toEqual(40)
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.Y)).toEqual(8)
-
-      lineData[0][DomainLabel.X].push(60)
-      lineData[0][DomainLabel.X].push(70)
-      lineData[0][DomainLabel.X].push(80)
-      lineData[0][DomainLabel.Y].push(12)
-      lineData[0][DomainLabel.Y].push(14)
-      lineData[0][DomainLabel.Y].push(16)
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.X)).toEqual(40)
-      expect(getPreviousDomainNextValue(lineData, 1, DomainLabel.Y)).toEqual(8)
+    it('should have a hash of all the time points when lines have different lengths', () => {
+      const fillCol = [0, 0, 1, 1, 1, 1, 2, 2, 2]
+      const fourthTimePoint = 1582222217067
+      const timesCol = [
+        ...threeTimePoints.slice(1),
+        ...threeTimePoints,
+        fourthTimePoint,
+        ...threeTimePoints,
+      ]
+      const valuesCol = [5, 8, 19, 48, 35, 29, 10, 1, 23]
+      const cumulativeValues = mapCumulativeValuesToTimeRange(
+        timesCol,
+        valuesCol,
+        fillCol
+      )
+      threeTimePoints
+        .concat(fourthTimePoint)
+        .forEach(time => expect(cumulativeValues[time]).toBeTruthy())
+      expect(Object.keys(cumulativeValues).length).toEqual(4)
     })
   })
 })

--- a/giraffe/src/transforms/line.ts
+++ b/giraffe/src/transforms/line.ts
@@ -21,9 +21,12 @@ export const mapCumulativeValuesToTimeRange = (
       cumulativeValues[time] = {}
     }
     const maxGroup = fillCol[index]
-    for (let i = 0; i < maxGroup; i += 1) {
-      if (!cumulativeValues[time][i]) {
-        cumulativeValues[time][i] = 0
+
+    if (!cumulativeValues[time][maxGroup - 1]) {
+      for (let i = 0; i < maxGroup; i += 1) {
+        if (!cumulativeValues[time][i]) {
+          cumulativeValues[time][i] = 0
+        }
       }
     }
     cumulativeValues[time][maxGroup] =

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -275,6 +275,12 @@ export type LineData = {
   }
 }
 
+export type CumulativeValuesByTime = {
+  [time: number]: {
+    [groupID: number]: number
+  }
+}
+
 export interface LineLayerSpec {
   type: 'line'
   inputTable: Table

--- a/giraffe/src/utils/tooltip.ts
+++ b/giraffe/src/utils/tooltip.ts
@@ -159,10 +159,17 @@ export const getPointsTooltipData = (
       values: orderDataByValue(
         hoveredRowIndices,
         sortOrder,
-        hoveredRowIndices
-          .map(hoveredRowIndex => groupColData[hoveredRowIndex])
-          .sort()
-          .map((_groupId, key) => key + 1)
+        (() => {
+          const lineCountByGroupId = {}
+          hoveredRowIndices
+            .map(hoveredRowIndex => groupColData[hoveredRowIndex])
+            .sort()
+            .map((groupId, key) => (lineCountByGroupId[groupId] = key + 1))
+
+          return hoveredRowIndices.map(
+            hoveredRowIndex => lineCountByGroupId[groupColData[hoveredRowIndex]]
+          )
+        })()
       ),
     })
   }

--- a/giraffe/src/utils/tooltip.ts
+++ b/giraffe/src/utils/tooltip.ts
@@ -159,7 +159,10 @@ export const getPointsTooltipData = (
       values: orderDataByValue(
         hoveredRowIndices,
         sortOrder,
-        hoveredRowIndices.map(i => Number(table.getColumn(FILL)[i]) + 1)
+        hoveredRowIndices
+          .map(hoveredRowIndex => groupColData[hoveredRowIndex])
+          .sort()
+          .map((_groupId, key) => key + 1)
       ),
     })
   }

--- a/giraffe/src/utils/tooltip.ts
+++ b/giraffe/src/utils/tooltip.ts
@@ -164,7 +164,7 @@ export const getPointsTooltipData = (
           hoveredRowIndices
             .map(hoveredRowIndex => groupColData[hoveredRowIndex])
             .sort()
-            .map((groupId, key) => (lineCountByGroupId[groupId] = key + 1))
+            .forEach((groupId, key) => (lineCountByGroupId[groupId] = key + 1))
 
           return hoveredRowIndices.map(
             hoveredRowIndex => lineCountByGroupId[groupColData[hoveredRowIndex]]

--- a/giraffe/src/utils/tooltip.ts
+++ b/giraffe/src/utils/tooltip.ts
@@ -151,6 +151,12 @@ export const getPointsTooltipData = (
         })
       ),
     })
+
+    const lineCountByGroupId = {}
+    hoveredRowIndices
+      .map(hoveredRowIndex => groupColData[hoveredRowIndex])
+      .sort()
+      .forEach((groupId, key) => (lineCountByGroupId[groupId] = key + 1))
     tooltipAdditionalColumns.push({
       key: yColKey,
       name: LINE_COUNT,
@@ -159,17 +165,9 @@ export const getPointsTooltipData = (
       values: orderDataByValue(
         hoveredRowIndices,
         sortOrder,
-        (() => {
-          const lineCountByGroupId = {}
-          hoveredRowIndices
-            .map(hoveredRowIndex => groupColData[hoveredRowIndex])
-            .sort()
-            .forEach((groupId, key) => (lineCountByGroupId[groupId] = key + 1))
-
-          return hoveredRowIndices.map(
-            hoveredRowIndex => lineCountByGroupId[groupColData[hoveredRowIndex]]
-          )
-        })()
+        hoveredRowIndices.map(
+          hoveredRowIndex => lineCountByGroupId[groupColData[hoveredRowIndex]]
+        )
       ),
     })
   }


### PR DESCRIPTION
Closes https://github.com/influxdata/giraffe/issues/158

By creating a map of all the time points, we can correctly track and add up cumulative values as the time points are traversed during line transformation