### PR TITLE
fix(ui): fixed tooltip bug that was causing giraffe to crash for scatterplots

### DIFF
--- a/giraffe/src/utils/fixtures/tooltip.ts
+++ b/giraffe/src/utils/fixtures/tooltip.ts
@@ -23,7 +23,7 @@ const getRandomNumber = (
 }
 
 export const COLUMN_KEY = 'cpu'
-export const POINT_KEY = 'cpu'
+export const POINT_KEY = 'disk'
 export const HOST_KEY = 'host'
 
 export const createSampleTable = (options: SampleTableOptions) => {
@@ -42,6 +42,7 @@ export const createSampleTable = (options: SampleTableOptions) => {
   const VALUE_COL = []
   const CPU_COL = []
   const SYMBOL_COL = []
+  const DISK_COL = []
   const HOST_COL = []
 
   for (let i = 0; i < numberOfRecords; i += 1) {
@@ -56,18 +57,19 @@ export const createSampleTable = (options: SampleTableOptions) => {
     TIME_COL.push(now + (i % recordsPerLine) * 1000 * 60)
     if (plotType === 'scatterplot') {
       SYMBOL_COL.push(i % 2)
+      DISK_COL.push(`disk-${i % recordsPerLine}`)
       HOST_COL.push(`host-${i % 2}`)
     }
   }
   const table = newTable(numberOfRecords)
     .addColumn('_time', 'time', TIME_COL)
     .addColumn('_value', 'number', VALUE_COL)
-    .addColumn('cpu', 'string', CPU_COL)
 
   if (plotType === 'scatterplot') {
     return table
+      .addColumn(POINT_KEY, 'string', DISK_COL)
       .addColumn('__symbol', 'string', SYMBOL_COL)
       .addColumn(HOST_KEY, 'string', HOST_COL)
   }
-  return table
+  return table.addColumn(COLUMN_KEY, 'string', CPU_COL)
 }

--- a/giraffe/src/utils/fixtures/tooltip.ts
+++ b/giraffe/src/utils/fixtures/tooltip.ts
@@ -7,6 +7,7 @@ interface SampleTableOptions {
   maxValue?: number
   numberOfRecords?: number
   recordsPerLine?: number
+  plotType?: string
 }
 
 const getRandomNumber = (
@@ -22,6 +23,8 @@ const getRandomNumber = (
 }
 
 export const COLUMN_KEY = 'cpu'
+export const POINT_KEY = 'cpu'
+export const HOST_KEY = 'host'
 
 export const createSampleTable = (options: SampleTableOptions) => {
   const {
@@ -31,12 +34,15 @@ export const createSampleTable = (options: SampleTableOptions) => {
     maxValue = 100,
     numberOfRecords = 20,
     recordsPerLine = 5,
+    plotType = 'line',
   } = options
 
   const now = Date.now()
   const TIME_COL = []
   const VALUE_COL = []
   const CPU_COL = []
+  const SYMBOL_COL = []
+  const HOST_COL = []
 
   for (let i = 0; i < numberOfRecords; i += 1) {
     let num = getRandomNumber(maxValue, decimalPlaces)
@@ -48,9 +54,20 @@ export const createSampleTable = (options: SampleTableOptions) => {
     VALUE_COL.push(num)
     CPU_COL.push(`${COLUMN_KEY}${Math.floor(i / recordsPerLine)}`)
     TIME_COL.push(now + (i % recordsPerLine) * 1000 * 60)
+    if (plotType === 'scatterplot') {
+      SYMBOL_COL.push(i % 2)
+      HOST_COL.push(`host-${i % 2}`)
+    }
   }
-  return newTable(numberOfRecords)
+  const table = newTable(numberOfRecords)
     .addColumn('_time', 'time', TIME_COL)
     .addColumn('_value', 'number', VALUE_COL)
     .addColumn('cpu', 'string', CPU_COL)
+
+  if (plotType === 'scatterplot') {
+    return table
+      .addColumn('__symbol', 'string', SYMBOL_COL)
+      .addColumn(HOST_KEY, 'string', HOST_COL)
+  }
+  return table
 }

--- a/giraffe/src/utils/tooltip.test.ts
+++ b/giraffe/src/utils/tooltip.test.ts
@@ -51,7 +51,7 @@ describe('getPointsTooltipData', () => {
     }
 
     const [fillColumn, fillColumnMap] = createGroupIDColumn(sampleTable, [
-      COLUMN_KEY,
+      plotType === 'line' ? COLUMN_KEY : HOST_KEY,
     ])
     fillScale = getNominalColorScale(fillColumnMap, NINETEEN_EIGHTY_FOUR)
     sampleTable = sampleTable.addColumn(FILL, 'number', fillColumn)
@@ -271,7 +271,7 @@ describe('getPointsTooltipData', () => {
         yColKey,
         FILL,
         pointFormatter,
-        [COLUMN_KEY, HOST_KEY],
+        [POINT_KEY, HOST_KEY],
         fillScale
       )
       expect(sampleTable.getColumn(POINT_KEY)).toBeTruthy()

--- a/giraffe/src/utils/tooltip.ts
+++ b/giraffe/src/utils/tooltip.ts
@@ -28,11 +28,11 @@ const orderDataByValue = (
 }
 
 const getDataSortOrder = (
-  lineData: LineData = {},
+  lineData: LineData,
   hoveredRowIndices: number[],
   position: LinePosition
 ): number[] => {
-  if (position === 'overlaid' || Object.keys(lineData).length === 0) {
+  if (position === 'overlaid') {
     return hoveredRowIndices
   }
   const dataMap = {}
@@ -100,7 +100,9 @@ export const getPointsTooltipData = (
   position?: LinePosition,
   lineData?: LineData
 ): TooltipData => {
-  const sortOrder = getDataSortOrder(lineData, hoveredRowIndices, position)
+  const sortOrder = lineData
+    ? getDataSortOrder(lineData, hoveredRowIndices, position)
+    : hoveredRowIndices
   const xColData = table.getColumn(xColKey, 'number')
   const yColData = table.getColumn(yColKey, 'number')
   const groupColData = table.getColumn(groupColKey, 'number')

--- a/giraffe/src/utils/tooltip.ts
+++ b/giraffe/src/utils/tooltip.ts
@@ -28,11 +28,11 @@ const orderDataByValue = (
 }
 
 const getDataSortOrder = (
-  lineData: LineData,
+  lineData: LineData = {},
   hoveredRowIndices: number[],
   position: LinePosition
 ): number[] => {
-  if (position === 'overlaid') {
+  if (position === 'overlaid' || Object.keys(lineData).length === 0) {
     return hoveredRowIndices
   }
   const dataMap = {}


### PR DESCRIPTION
Closes https://app.zenhub.com/workspaces/applicationmonitoring-5e3b05772922e316b3a210a4/issues/influxdata/influxdb/16984

### Problem

Giraffe's sorting functionality was assuming that the lineData would exist, even though it was an option parameter

### Solution

Added defaults to the lineData prop and return the default hover index if the lineData is empty. This was simply the most straightforward solution, but it could be that we would need to implement a more dynamic solution that handles sorting for scatter plots specifically since some of those properties do not exist