### PR TITLE
fix: separate creation of horizontal and vertical ticks

### DIFF
--- a/giraffe/src/constants/columnKeys.ts
+++ b/giraffe/src/constants/columnKeys.ts
@@ -6,6 +6,7 @@ export const Y_MAX = 'yMax'
 export const COUNT = 'count'
 
 // Computed column names mapped to group aesthetics
+export const TIME = '_time'
 export const VALUE = '_value'
 export const FILL = '__fill'
 export const SYMBOL = '__symbol'

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -385,3 +385,5 @@ export enum DomainLabel {
   X = 'xs',
   Y = 'ys',
 }
+
+export type AxisTicks = Date[] | number[]

--- a/giraffe/src/utils/PlotEnv.ts
+++ b/giraffe/src/utils/PlotEnv.ts
@@ -1,5 +1,4 @@
-import {getTicks} from './getTicks'
-import {getTextMetrics} from './getTextMetrics'
+import {getHorizontalTicks, getVerticalTicks} from './getTicks'
 import {getMargins} from './getMargins'
 import {extentOfExtents} from './extrema'
 import {identityMerge} from './identityMerge'
@@ -92,12 +91,11 @@ export class PlotEnv {
       return this.config.xTicks
     }
 
-    const getTicksMemoized = this.fns.get('xTicks', getTicks)
+    const getTicksMemoized = this.fns.get('xTicks', getHorizontalTicks)
 
     return getTicksMemoized(
       this.xDomain,
       this.config.width,
-      this.charMetrics.width,
       this.config.tickFont,
       this.xTickFormatter
     )
@@ -108,12 +106,11 @@ export class PlotEnv {
       return this.config.yTicks
     }
 
-    const getTicksMemoized = this.fns.get('yTicks', getTicks)
+    const getTicksMemoized = this.fns.get('yTicks', getVerticalTicks)
 
     return getTicksMemoized(
       this.yDomain,
       this.config.height,
-      this.charMetrics.height,
       this.config.tickFont,
       this.yTickFormatter
     )
@@ -306,13 +303,6 @@ export class PlotEnv {
     } else {
       this._yDomain = this.getYDomain()
     }
-  }
-
-  private get charMetrics() {
-    const getTextMetricsMemoized = this.fns.get('charMetrics', getTextMetrics)
-
-    // https://stackoverflow.com/questions/3949422/which-letter-of-the-english-alphabet-takes-up-most-pixels
-    return getTextMetricsMemoized(this.config.tickFont, 'W')
   }
 
   private get isXControlled() {

--- a/giraffe/src/utils/getTicks.test.ts
+++ b/giraffe/src/utils/getTicks.test.ts
@@ -1,34 +1,49 @@
 import {FormatterType} from '../types'
-import {getTicks} from './getTicks'
+import {getVerticalTicks, getHorizontalTicks} from './getTicks'
 
 jest.mock('./getTextMetrics')
 
 describe('getTicks', () => {
-  const charHeight = 12
   const font = '10px sans-serif'
 
   describe('vertical axis', () => {
     const laptopScreenHeight = 788
     const formatter = (num: number): string => `${num} foo`
     const domain = [0, 100]
-    const result = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+    const result = [
+      0,
+      5,
+      10,
+      15,
+      20,
+      25,
+      30,
+      35,
+      40,
+      45,
+      50,
+      55,
+      60,
+      65,
+      70,
+      75,
+      80,
+      85,
+      90,
+      95,
+      100,
+    ]
 
     it('should give the correct number of ticks', () => {
       expect(
-        getTicks(domain, laptopScreenHeight, charHeight, font, formatter)
+        getVerticalTicks(domain, laptopScreenHeight, font, formatter)
       ).toEqual(result)
     })
-    it('should handle extreme or unusual inputs', () => {
-      expect(getTicks(domain, 0, charHeight, font, formatter)).toEqual([])
-      expect(getTicks(domain, laptopScreenHeight, 0, font, formatter)).toEqual(
-        []
-      )
+    it('should handle 0 domain or screen height', () => {
+      expect(getVerticalTicks(domain, 0, font, formatter)).toEqual([])
       expect(
-        getTicks([0, 0], laptopScreenHeight, charHeight, font, formatter)
+        getVerticalTicks([0, 0], laptopScreenHeight, font, formatter)
       ).toEqual([0])
-      expect(
-        getTicks(domain, laptopScreenHeight, charHeight, font, formatter)
-      ).toEqual(result)
     })
   })
 
@@ -78,26 +93,15 @@ describe('getTicks', () => {
       1578357060000,
     ]
     it('should give the correct number of ticks', () => {
-      expect(getTicks(domain, axisLength, charHeight, font, formatter)).toEqual(
+      expect(getHorizontalTicks(domain, axisLength, font, formatter)).toEqual(
         result
       )
     })
-    it('should handle extreme or unusual inputs', () => {
-      expect(getTicks(domain, 0, charHeight, font, formatter)).toEqual([])
-      expect(getTicks([0, 0], axisLength, charHeight, font, formatter)).toEqual(
-        [0]
-      )
-      expect(getTicks(domain, axisLength, 0, font, formatter)).toEqual(result)
-      expect(
-        getTicks(domain, axisLength, 100000000000000000, font, formatter)
-      ).toEqual(result)
-      expect(getTicks(domain, axisLength, charHeight, font, formatter)).toEqual(
-        result
-      )
-      expect(
-        getTicks(domain, axisLength / 2, charHeight, font, formatter).length
-      ).toBeLessThan(result.length)
-      expect(getTicks(domain, 0, charHeight, font, formatter).length).toEqual(0)
+    it('should handle 0 domain or screen height', () => {
+      expect(getHorizontalTicks([0, 0], axisLength, font, formatter)).toEqual([
+        0,
+      ])
+      expect(getHorizontalTicks(domain, 0, font, formatter).length).toEqual(0)
     })
   })
 })

--- a/giraffe/src/utils/getTicks.test.ts
+++ b/giraffe/src/utils/getTicks.test.ts
@@ -1,10 +1,140 @@
 import {FormatterType} from '../types'
-import {getVerticalTicks, getHorizontalTicks} from './getTicks'
+import {TIME, VALUE} from '../constants/columnKeys'
+import {getTicks, getVerticalTicks, getHorizontalTicks} from './getTicks'
 
 jest.mock('./getTextMetrics')
 
-describe('getTicks', () => {
+describe('utils/getTicks', () => {
   const font = '10px sans-serif'
+
+  describe('getTicks', () => {
+    describe('time ticks', () => {
+      const columnKey = TIME
+
+      it('should handle fewer than 4 time ticks', () => {
+        const timeDomain = [1586382921737, 1586384061737]
+        const rangeLength = 1200
+        const tickSize = 110
+        const result = [1586383200000, 1586383500000, 1586383800000]
+        expect(getTicks(timeDomain, rangeLength, tickSize, columnKey)).toEqual(
+          result
+        )
+      })
+
+      it('should handle 4 to 10 time ticks', () => {
+        let timeDomain = [1586383757747, 1586384897747]
+        let rangeLength = 1131
+        let tickSize = 116
+        let result = [
+          1586383800000,
+          1586384100000,
+          1586384400000,
+          1586384700000,
+        ]
+        expect(getTicks(timeDomain, rangeLength, tickSize, columnKey)).toEqual(
+          result
+        )
+
+        timeDomain = [1586384617834, 1586385140120]
+        rangeLength = 1042
+        tickSize = 62
+        result = [
+          1586384640000,
+          1586384700000,
+          1586384760000,
+          1586384820000,
+          1586384880000,
+          1586384940000,
+          1586385000000,
+          1586385060000,
+          1586385120000,
+        ]
+        expect(getTicks(timeDomain, rangeLength, tickSize, columnKey)).toEqual(
+          result
+        )
+      })
+
+      it('should handle more than 10 ticks', () => {
+        const timeDomain = [1586384653177, 1586385793177]
+        const rangeLength = 1170
+        const tickSize = 39
+        const result = [
+          1586384700000,
+          1586384760000,
+          1586384820000,
+          1586384880000,
+          1586384940000,
+          1586385000000,
+          1586385060000,
+          1586385120000,
+          1586385180000,
+          1586385240000,
+          1586385300000,
+          1586385360000,
+          1586385420000,
+          1586385480000,
+          1586385540000,
+          1586385600000,
+          1586385660000,
+          1586385720000,
+          1586385780000,
+        ]
+        expect(getTicks(timeDomain, rangeLength, tickSize, columnKey)).toEqual(
+          result
+        )
+      })
+    })
+
+    describe('value ticks', () => {
+      const columnKey = VALUE
+
+      it('should handle fewer than 4 time ticks', () => {
+        const valueDomain = [1, 300]
+        const rangeLength = 1116
+        const tickSize = 172
+        const result = [100, 200, 300]
+        expect(getTicks(valueDomain, rangeLength, tickSize, columnKey)).toEqual(
+          result
+        )
+      })
+
+      it('should handle 4 to 10 time ticks', () => {
+        const valueDomain = [1, 300]
+        const rangeLength = 1116
+        const tickSize = 86
+        const result = [50, 100, 150, 200, 250, 300]
+        expect(getTicks(valueDomain, rangeLength, tickSize, columnKey)).toEqual(
+          result
+        )
+      })
+
+      it('should handle more than 10 ticks', () => {
+        const valueDomain = [1, 300]
+        const rangeLength = 1116
+        const tickSize = 47
+        const result = [
+          20,
+          40,
+          60,
+          80,
+          100,
+          120,
+          140,
+          160,
+          180,
+          200,
+          220,
+          240,
+          260,
+          280,
+          300,
+        ]
+        expect(getTicks(valueDomain, rangeLength, tickSize, columnKey)).toEqual(
+          result
+        )
+      })
+    })
+  })
 
   describe('vertical axis', () => {
     const laptopScreenHeight = 788

--- a/stories/src/index.stories.tsx
+++ b/stories/src/index.stories.tsx
@@ -31,7 +31,7 @@ storiesOf('XY Plot', module)
     const tickFont = tickFontKnob()
     const x = xKnob(table)
     const y = yKnob(table)
-    const yAxisLabel = text('Y Axis Label', 'foo')
+    const valueAxisLabel = text('Value Axis Label', 'foo')
     const xScale = xScaleKnob()
     const yScale = yScaleKnob()
     const timeZone = timeZoneKnob()
@@ -73,7 +73,10 @@ storiesOf('XY Plot', module)
       table,
       valueFormatters: {
         _time: timeFormatter({timeZone, format: timeFormat}),
-        [y]: y => `${y.toFixed(2)} ${yAxisLabel}`,
+        _value: val =>
+          `${val.toFixed(2)}${
+            valueAxisLabel ? ` ${valueAxisLabel}` : valueAxisLabel
+          }`,
       },
       xScale,
       yScale,
@@ -146,7 +149,7 @@ storiesOf('XY Plot', module)
       table,
       valueFormatters: {
         _time: timeFormatter({timeZone, format: timeFormat}),
-        [y]: y => `${Math.round(y)}%`,
+        _value: val => `${Math.round(val)}%`,
       },
       legendFont,
       tickFont,
@@ -191,7 +194,7 @@ storiesOf('XY Plot', module)
 
     const config: Config = {
       table,
-      valueFormatters: {[y]: y => `${Math.round(y)}%`},
+      valueFormatters: {_value: val => `${Math.round(val)}%`},
       legendFont,
       tickFont,
       showAxes,
@@ -233,7 +236,7 @@ storiesOf('XY Plot', module)
       yScale,
       tickFont,
       showAxes,
-      valueFormatters: {[y]: y => `${Math.round(y)}%`},
+      valueFormatters: {_value: val => `${Math.round(val)}%`},
       layers: [{type: 'heatmap', x, y, colors}],
     }
 


### PR DESCRIPTION
Closes https://app.zenhub.com/workspaces/applicationmonitoring-5e3b05772922e316b3a210a4/issues/influxdata/influxdb/17585

Separate the generation of vertical and horizontal ticks to allow different spacing. For each direction, ticks can be time ticks or value ticks.

x: time, y: value
<img width="1680" alt="Screen Shot 2020-04-08 at 4 37 32 PM" src="https://user-images.githubusercontent.com/10736577/78843332-5fb69a00-79b7-11ea-9df2-4af42b01c887.png">

y: time, x: value
<img width="1680" alt="Screen Shot 2020-04-08 at 4 38 00 PM" src="https://user-images.githubusercontent.com/10736577/78843356-6fce7980-79b7-11ea-958a-89551434a3f5.png">

