### PR TITLE
fix: add unique key to custom layer element

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -9,8 +9,8 @@
     "build": "rm -rf dist && NODE_ENV=production rollup -c",
     "start": "rollup -cw",
     "lint": "eslint '{src,../stories/src}/**/*.{ts,tsx}'",
-    "prettier": "prettier --config ../.prettierrc.json --check '{.,../stories}/**/*.{ts,tsx}'",
-    "prettier:fix": "prettier --config ../.prettierrc.json --write '{.,../stories}/**/*.{ts,tsx}'",
+    "prettier": "prettier --config ../.prettierrc.json --check '{src,../stories/src}/**/*.{ts,tsx}'",
+    "prettier:fix": "prettier --config ../.prettierrc.json --write '{src,../stories/src}/**/*.{ts,tsx}'",
     "typecheck": "tsc --noEmit --pretty"
   },
   "devDependencies": {

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -95,6 +95,7 @@ export const SizedPlot: FunctionComponent<Props> = ({
           {config.layers.map((layerConfig, layerIndex) => {
             if (layerConfig.type === 'custom') {
               const renderProps = {
+                key: layerIndex,
                 width,
                 height,
                 innerWidth: env.innerWidth,

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -153,6 +153,7 @@ export interface ScatterLayerConfig {
 }
 
 export interface CustomLayerRenderProps {
+  key: string | number
   xScale: Scale<number, number>
   yScale: Scale<number, number>
   xDomain: number[]

--- a/stories/package.json
+++ b/stories/package.json
@@ -4,8 +4,8 @@
   "license": "MIT",
   "scripts": {
     "lint": "eslint '{src,../giraffe/src}/**/*.{ts,tsx}'",
-    "prettier": "prettier --config ../.prettierrc.json --check '{.,../giraffe}/**/*.{ts,tsx}'",
-    "prettier:fix": "prettier --config ../.prettierrc.json --write '{.,../giraffe}/**/*.{ts,tsx}'",
+    "prettier": "prettier --config ../.prettierrc.json --check '{src,../giraffe/src}/**/*.{ts,tsx}'",
+    "prettier:fix": "prettier --config ../.prettierrc.json --write '{src,../giraffe/src}/**/*.{ts,tsx}'",
     "typecheck": "tsc --noEmit --pretty",
     "start": "yarn -s run storybook",
     "storybook": "start-storybook -p 50000",

--- a/stories/src/customLayer.stories.tsx
+++ b/stories/src/customLayer.stories.tsx
@@ -16,9 +16,10 @@ storiesOf('Custom Layer', module).add('Highlighted Region', () => {
       },
       {
         type: 'custom',
-        render: ({yScale}) => {
+        render: ({key, yScale}) => {
           return (
             <div
+              key={key}
               style={{
                 width: '100%',
                 position: 'absolute',


### PR DESCRIPTION
Closes #183 

- Following best practices, adds a unique key to the custom layer element in a list of React elements.
- Minor tweak to the `prettier` script to only fix files that we care about.