### PR TITLE
fix: constrain bin count in heatmap to numbers that will not throw an error

### DIFF
--- a/giraffe/src/transforms/heatmap.test.ts
+++ b/giraffe/src/transforms/heatmap.test.ts
@@ -1,4 +1,4 @@
-import {heatmapTransform} from './heatmap'
+import {heatmapTransform, bin2d} from './heatmap'
 import {newTable} from '../utils/newTable'
 
 describe('heatmapTransform', () => {
@@ -13,6 +13,123 @@ describe('heatmapTransform', () => {
         'papayawhip',
         'tomato',
       ])
+    }).not.toThrow()
+  })
+
+  test('does not crash when bin size is the largest among bin size, width, and height', () => {
+    const xColKey = '_time'
+    const yColKey = '_value'
+    const currentTime = Date.now()
+    const interval = 100
+    const table = newTable(3)
+      .addColumn(xColKey, 'time', [
+        currentTime,
+        currentTime + interval,
+        currentTime + interval * 2,
+      ])
+      .addColumn(yColKey, 'number', [0, 1, 2])
+
+    const width = 987
+    const height = 788
+    const binSize = Math.max(width, height) + 1
+    expect(() => {
+      bin2d(
+        table,
+        xColKey,
+        yColKey,
+        [currentTime, currentTime + interval * 2],
+        [0, 2],
+        width,
+        height,
+        binSize
+      )
+    }).not.toThrow()
+  })
+
+  test('does not crash when bin size is 0, negative, NaN, negative Infinity, positive Infinity', () => {
+    const xColKey = '_time'
+    const yColKey = '_value'
+    const currentTime = Date.now()
+    const interval = 100
+    const table = newTable(3)
+      .addColumn(xColKey, 'time', [
+        currentTime,
+        currentTime + interval,
+        currentTime + interval * 2,
+      ])
+      .addColumn(yColKey, 'number', [0, 1, 2])
+
+    const width = 987
+    const height = 788
+
+    let binSize = 0
+    expect(() => {
+      bin2d(
+        table,
+        xColKey,
+        yColKey,
+        [currentTime, currentTime + interval * 2],
+        [0, 2],
+        width,
+        height,
+        binSize
+      )
+    }).not.toThrow()
+
+    binSize = -1
+    expect(() => {
+      bin2d(
+        table,
+        xColKey,
+        yColKey,
+        [currentTime, currentTime + interval * 2],
+        [0, 2],
+        width,
+        height,
+        binSize
+      )
+    }).not.toThrow()
+
+    binSize = NaN
+    expect(() => {
+      bin2d(
+        table,
+        xColKey,
+        yColKey,
+        [currentTime, currentTime + interval * 2],
+        [0, 2],
+        width,
+        height,
+        binSize
+      )
+    }).not.toThrow()
+
+    binSize = -Infinity
+    expect(() => {
+      bin2d(
+        table,
+        xColKey,
+        yColKey,
+        [currentTime, currentTime + interval * 2],
+        [0, 2],
+        width,
+        height,
+        binSize
+      )
+    }).not.toThrow()
+
+    binSize = Infinity
+    expect(() => {
+      bin2d(
+        table,
+        xColKey,
+        yColKey,
+        [currentTime, currentTime + interval * 2],
+        [0, 2],
+        width,
+        height,
+        binSize
+      )
     }).not.toThrow()
   })
 })

--- a/giraffe/src/transforms/heatmap.test.ts
+++ b/giraffe/src/transforms/heatmap.test.ts
@@ -19,25 +19,27 @@ describe('heatmapTransform', () => {
   test('does not crash when bin size is the largest among bin size, width, and height', () => {
     const xColKey = '_time'
     const yColKey = '_value'
-    const currentTime = Date.now()
+    const startTime = Date.now()
     const interval = 100
     const table = newTable(3)
       .addColumn(xColKey, 'time', [
-        currentTime,
-        currentTime + interval,
-        currentTime + interval * 2,
+        startTime,
+        startTime + interval,
+        startTime + interval * 2,
       ])
       .addColumn(yColKey, 'number', [0, 1, 2])
 
     const width = 987
     const height = 788
     const binSize = Math.max(width, height) + 1
+
+    expect(Math.max(width, height, binSize)).toEqual(binSize)
     expect(() => {
       bin2d(
         table,
         xColKey,
         yColKey,
-        [currentTime, currentTime + interval * 2],
+        [startTime, startTime + interval * 2],
         [0, 2],
         width,
         height,
@@ -46,29 +48,43 @@ describe('heatmapTransform', () => {
     }).not.toThrow()
   })
 
-  test('does not crash when bin size is 0, negative, NaN, negative Infinity, positive Infinity', () => {
+  test('does not crash when bin size is negative 0, positive 0, negative, NaN, negative Infinity, or positive Infinity', () => {
     const xColKey = '_time'
     const yColKey = '_value'
-    const currentTime = Date.now()
+    const startTime = Date.now()
     const interval = 100
     const table = newTable(3)
       .addColumn(xColKey, 'time', [
-        currentTime,
-        currentTime + interval,
-        currentTime + interval * 2,
+        startTime,
+        startTime + interval,
+        startTime + interval * 2,
       ])
       .addColumn(yColKey, 'number', [0, 1, 2])
 
     const width = 987
     const height = 788
 
-    let binSize = 0
+    let binSize = -0
     expect(() => {
       bin2d(
         table,
         xColKey,
         yColKey,
-        [currentTime, currentTime + interval * 2],
+        [startTime, startTime + interval * 2],
+        [0, 2],
+        width,
+        height,
+        binSize
+      )
+    }).not.toThrow()
+
+    binSize = +0
+    expect(() => {
+      bin2d(
+        table,
+        xColKey,
+        yColKey,
+        [startTime, startTime + interval * 2],
         [0, 2],
         width,
         height,
@@ -82,7 +98,7 @@ describe('heatmapTransform', () => {
         table,
         xColKey,
         yColKey,
-        [currentTime, currentTime + interval * 2],
+        [startTime, startTime + interval * 2],
         [0, 2],
         width,
         height,
@@ -96,7 +112,7 @@ describe('heatmapTransform', () => {
         table,
         xColKey,
         yColKey,
-        [currentTime, currentTime + interval * 2],
+        [startTime, startTime + interval * 2],
         [0, 2],
         width,
         height,
@@ -110,7 +126,7 @@ describe('heatmapTransform', () => {
         table,
         xColKey,
         yColKey,
-        [currentTime, currentTime + interval * 2],
+        [startTime, startTime + interval * 2],
         [0, 2],
         width,
         height,
@@ -124,7 +140,7 @@ describe('heatmapTransform', () => {
         table,
         xColKey,
         yColKey,
-        [currentTime, currentTime + interval * 2],
+        [startTime, startTime + interval * 2],
         [0, 2],
         width,
         height,

--- a/giraffe/src/transforms/heatmap.ts
+++ b/giraffe/src/transforms/heatmap.ts
@@ -72,9 +72,11 @@ export const bin2d = (
   const xColType = table.getColumnType(xColKey) as 'time' | 'number'
   const yColType = table.getColumnType(yColKey) as 'time' | 'number'
 
-  const xBinCount = Math.floor(width / binSize)
-  const yBinCount = Math.floor(height / binSize)
-
+  const xBinCount = Math.max(Math.floor(width / (binSize > 0 ? binSize : 1)), 1)
+  const yBinCount = Math.max(
+    Math.floor(height / (binSize > 0 ? binSize : 1)),
+    1
+  )
   // Count occurences in each bin in a `xBinCount` by `yBinCount` matrix
   //
   //                 4th y bin


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/18182

In heatmap, use only reasonable numbers for bin count (the number of possible heat "blobs") on any axis so that they cannot be NaN, 0, negative, negative Infinity, or positive Infinity