### PR TITLE
feat: add Single Stat as a custom layer

### DIFF
--- a/giraffe/README.md
+++ b/giraffe/README.md
@@ -358,7 +358,7 @@ Giraffe comes with utility functions.
       &#60;/div&#62;
     </pre>
 
-  - **style**: _Object. Optional. Recommendation: do not include._ An object containing the key-value pairs used for inline styling `.giraffe-layer-single-stat` by setting its [style property](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style). If used, please be aware of existing default styles that may need to be overridden. See the `SINGLE_STAT_DEFAULT_STYLE` [here](./src/constants/singleStatStyles.ts).
+  - **style**: _Object. Optional. Recommendation: do not include._ An object containing the key-value pairs used for inline styling `.giraffe-layer-single-stat` by setting its [style property](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style). If used, please be aware of existing default styles that may need to be overridden. `backgroundColor` cannot be overridden and is controlled by the **backgroundColor** option (see above). See the `SINGLE_STAT_DEFAULT_STYLE` [here](./src/constants/singleStatStyles.ts).
 
   - **resizerStyle**: _Object. Optional. Recommendation: do not include._ An object containing the key-value pairs used for inline styling `.giraffe-single-stat--resizer` by setting its [style property](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style). If used, please be aware of existing default styles that may need to be overridden. See the `SINGLE_STAT_RESIZER_DEFAULT_STYLE` [here](./src/constants/singleStatStyles.ts).
 
@@ -366,9 +366,9 @@ Giraffe comes with utility functions.
 
   - **svgStyle**: _Object. Optional. Recommendation: do not include._ An object containing the key-value pairs used for inline styling `.giraffe-single-stat--svg` by setting its [style property](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style). This element has no existing default styling.
 
-  - **svgTextAttributes**: _Object. Optional. Recommendation: do not include._ An object containing the key-value pairs used for the element attributes of `.giraffe-single-stat--text`. If used please be aware of the existing default attributes that may need to be overridden. See the `SINGLE_STAT_SVG_TEXT_DEFAULT_ATTRIBUTES` [here](./src/constants/singleStatStyles.ts).
+  - **svgTextAttributes**: _Object. Optional. Recommendation: do not include._ An object containing the key-value pairs used for the element attributes of `.giraffe-single-stat--text`. If used please be aware of the existing default attributes that may need to be overridden. `opacity` cannot be overridden and is controlled by the **textOpacity** option (see above). See the `SINGLE_STAT_SVG_TEXT_DEFAULT_ATTRIBUTES` [here](./src/constants/singleStatStyles.ts).
 
-  - **svgTextStyle**: _Object. Optional. Recommendation: do not include._ An object containing the key-value pairs used for inline styling `.giraffe-single-stat--text` by setting its [style property](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style). If used, please be aware of existing default styles that may need to be overridden. See the `SINGLE_STAT_SVG_TEXT_DEFAULT_STYLE` [here](./src/constants/singleStatStyles.ts).
+  - **svgTextStyle**: _Object. Optional. Recommendation: do not include._ An object containing the key-value pairs used for inline styling `.giraffe-single-stat--text` by setting its [style property](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style). If used, please be aware of existing default styles that may need to be overridden. `fill` cannot be overridden and is controlled by the **textColor** option (see above). See the `SINGLE_STAT_SVG_TEXT_DEFAULT_STYLE` [here](./src/constants/singleStatStyles.ts).
 
 * **CustomLayerConfig**: _Object_. No limit per `<Plot>`.
 

--- a/giraffe/README.md
+++ b/giraffe/README.md
@@ -142,13 +142,13 @@ Here is an example of turning a result in comma separate values (CSV) from Flux 
 
 - **gridColor**: _string. Optional._ The _CSS color value_ of the grid lines. Applies to the inner horizontal and vertical rule lines. Excludes the axes and the border around the graph.
 
-- **gridOpacity**: _number. Optional. Recommendation: do not include. Defaults to 1 when excluded._ A value between 0 and 1 for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the grid lines. Applies to the inner horizontal and vertical rule lines. Excludes the axes and the border around the graph.
+- **gridOpacity**: _number. Optional. Recommendation: do not include. Defaults to 1 when excluded._ A value between 0 and 1 inclusive for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the grid lines. Applies to the inner horizontal and vertical rule lines. Excludes the axes and the border around the graph.
 
 - **showAxes**: _boolean. Optional. Recommendation: do not include. Defaults to true when excluded._ Indicates whether Plot axes should be visible. Applies to both x-axis and y-axis simultaneously.
 
 - **axisColor**: _string. Optional._ The _CSS color value_ of the axes and the border around the graph. Excludes the inner horizontal and vertical rule lines.
 
-- **axisOpacity**: _number. Optional. Recommendation: do not include. Defaults to 1 when excluded._ A value between 0 and 1 for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the axes and the border around the graph. Excludes the inner horizontal and vertical rule lines.
+- **axisOpacity**: _number. Optional. Recommendation: do not include. Defaults to 1 when excluded._ A value between 0 and 1 inclusive for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the axes and the border around the graph. Excludes the inner horizontal and vertical rule lines.
 
 - **xTicks**: _array[number, ...]. Optional._ An array of values representing tick marks on the x-axis. Actual data values and axis scaling may cause Plot to not render all of the given ticks, or Plot rendering may extend beyond all of the rendered ticks. When excluded, Giraffe attempts to use as many ticks as possible on the x-axis while keeping reasonable spacing between them.
 
@@ -265,7 +265,7 @@ Giraffe comes with utility functions.
 
   - **shadeBelow**: _boolean. Optional._ Uses **colors**. Indicates whether the area below each line should be shaded.
 
-  - **shadeBelowOpacity**: _number. Optional._ A value between 0 and 1 for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the shaded color below each line. No effect when **shadeBelow** is false or not included.
+  - **shadeBelowOpacity**: _number. Optional._ A value between 0 and 1 inclusive for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the shaded color below each line. No effect when **shadeBelow** is false or not included.
 
 - **ScatterLayerConfig**: _Object_. Maximum one per `<Plot>`. Properties are:
 
@@ -295,9 +295,9 @@ Giraffe comes with utility functions.
 
   - **colors**: _array[string, ...]. Optional._ An array of _CSS color values_ used as a gradient to give bars in each bin different colors based on the **fill** columns.
 
-  - **fillOpacity**: _number. Optional._ A value between 0 and 1 for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the shading inside the bins.
+  - **fillOpacity**: _number. Optional._ A value between 0 and 1 inclusive for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the shading inside the bins.
 
-  - **strokeOpacity**: _number. Optional._ A value between 0 and 1 for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the border of the bins. This is very hard to observe with human eyes unless the **fillOpacity** is near 0.
+  - **strokeOpacity**: _number. Optional._ A value between 0 and 1 inclusive for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the border of the bins. This is very hard to observe with human eyes unless the **fillOpacity** is near 0.
 
   - **strokeWidth**: _number. Optional._ The [_CanvasRenderingContext2D lineWidth_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineWidth) of the border of the bins. This is very hard to observe with human eyes unless the **fillOpacity** is near 0. A high value for **strokeWidth** will completely fill the bin with border color at an opacity indicated by **strokeOpacity**.
 
@@ -315,15 +315,62 @@ Giraffe comes with utility functions.
 
   - **colors**: _array[string, ...]. Optional._ An array of _CSS color values_ used as the color scheme in the heatmap. The color in index 0 is used to represent the "cold" area or background of the heatmap. The higher the index, the "hotter" the color will represent on the heatmap.
 
-  - **fillOpacity**: _number. Optional._ A value between 0 and 1 for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the shading inside the heat bins. Warning: low opacity is difficult to see visually and may be counterproductive for heatmaps.
+  - **fillOpacity**: _number. Optional._ A value between 0 and 1 inclusive for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the shading inside the heat bins. Warning: low opacity is difficult to see visually and may be counterproductive for heatmaps.
 
-  - **strokeOpacity**: _number. Optional._ A value between 0 and 1 for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the border of the heat bins. This is very hard to observe with human eyes unless the **fillOpacity** is near 0.
+  - **strokeOpacity**: _number. Optional._ A value between 0 and 1 inclusive for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the border of the heat bins. This is very hard to observe with human eyes unless the **fillOpacity** is near 0.
 
   - **strokeWidth**: _number. Optional._ The [_CanvasRenderingContext2D lineWidth_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineWidth) of the border of the bins. This is very hard to observe with human eyes unless the **fillOpacity** is near 0. A high value for **strokeWidth** will completely fill the heat bin with border color at an opacity indicated by **strokeOpacity**.
 
   - **strokePadding**: _number. Optional._ The space around all four sides of each heat bin. The amount of spacing is the _width_ and _height_ used in the [_CanvasRenderingContext2D rect_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/rect) function.
 
-- **CustomLayerConfig**: _Object_. No limit per `<Plot>`.
+- **SingleStatLayerConfig**: _Object_. No limit but generally one per `<Plot>`. Using more than one requires additional styling through configuration and is not recommended.
+
+  <br />A Single Stat layer is a pre-defined custom layer that displays a single value on top of any other plot type, or by itself, but usually displayed on top of (single) line graphs. The displayed value is the latest value by timestamp. If more than one value has the latest timestamp, then the first value in the [table](#data-properties) with the latest timestamp will be displayed. Currently, there is no guarantee which value will be considered the first value when there are multiple values with the same timestamp.
+
+  - **type**: _'single stat'. **Required**._ Specifies that this LayerConfig is a single stat layer.
+
+  - **prefix**: _string. **Required**._ The text that appears before the stat value. Use an empty string if no text is preferred.
+
+  - **suffix**: _string. **Required**._ The text that appears after the stat value. Use an empty string if no text is preferred.
+
+  - **decimalPlaces**: _Object. **Required**._
+
+    - **isEnforced**: _boolean. Optional. Defaults to false when not included._ Indicates whether the number of decimal places ("**digits**") will be enforced. When **isEnforced** is falsy or omitted, **digits** will be locked to 2 for stat values with a decimal and 0 for stat values that are integers, and the **digits** option will be ignored.
+    - **digits**: _number. Optional. Defaults to 0 when not included. Maximum 10._ When **digits** is a non-integer number, the decimal portion is ignored. Represents the number of decimal places to display in the stat value. Displayed stat value is subject to rounding and trailing 0 will be truncated. For example: **digits** is 2 and stat value is `1.299` which rounds to `1.30` and then becomes `1.3` when displayed.
+
+  - **textColor**: _string. **Required**._ The _CSS color value_ of the entire Single Stat to display including prefix, the stat value, and suffix.
+
+  - **textOpacity**: _number. Optional. Defaults to 1 when not included._ A value between 0 and 1 inclusive, specifying the [opacity](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/opacity) of the entire text for the Single Stat including prefix, the stat value, and suffix. 0 is fully transparent (invisible) while 1 is fully opaque.
+
+  - **backgroundColor**: _string. Optional. Recommendation: do not include. Defaults to transparent when not included._ The [CSS background color](https://developer.mozilla.org/en-US/docs/Web/CSS/background-color) of the background, which covers the area surrounded by the axes and border (whether displayed or not) of the `<Plot>`.
+
+  - **testID**: _string. Optional._ A string value for the `data-testid` prop on the element for the Single Stat. Primarily used for automated testing.
+
+    <br /> The following optional properties affect element attributes in the DOM tree of the Single Stat. Its structure looks like this
+
+    <pre>
+      &#60;div class="giraffe-layer giraffe-layer-single-stat"&#62;
+        &#60;div class="giraffe-single-stat--resizer"&#62;
+          &#60;svg class="giraffe-single-stat--svg"&#62;
+            &#60;text class="giraffe-single-stat--text"&#62;&#60;/text&#62;
+          &#60;/svg&#62;
+        &#60;/div&#62;
+      &#60;/div&#62;
+    </pre>
+
+  - **style**: _Object. Optional. Recommendation: do not include._ An object containing the key-value pairs used for inline styling `.giraffe-layer-single-stat` by setting its [style property](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style). If used, please be aware of existing default styles that may need to be overridden. See the `SINGLE_STAT_DEFAULT_STYLE` [here](./src/constants/singleStatStyles.ts).
+
+  - **resizerStyle**: _Object. Optional. Recommendation: do not include._ An object containing the key-value pairs used for inline styling `.giraffe-single-stat--resizer` by setting its [style property](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style). If used, please be aware of existing default styles that may need to be overridden. See the `SINGLE_STAT_RESIZER_DEFAULT_STYLE` [here](./src/constants/singleStatStyles.ts).
+
+  - **svgAttributes**: _Object. Optional. Recommendation: do not include._ An object containing the key-value pairs used for the element attributes of `.giraffe-single-stat--svg`. If used please be aware of the existing default attributes that may need to be overridden. See the `SINGLE_STAT_SVG_DEFAULT_ATTRIBUTES` [here](./src/constants/singleStatStyles.ts).
+
+  - **svgStyle**: _Object. Optional. Recommendation: do not include._ An object containing the key-value pairs used for inline styling `.giraffe-single-stat--svg` by setting its [style property](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style). This element has no existing default styling.
+
+  - **svgTextAttributes**: _Object. Optional. Recommendation: do not include._ An object containing the key-value pairs used for the element attributes of `.giraffe-single-stat--text`. If used please be aware of the existing default attributes that may need to be overridden. See the `SINGLE_STAT_SVG_TEXT_DEFAULT_ATTRIBUTES` [here](./src/constants/singleStatStyles.ts).
+
+  - **svgTextStyle**: _Object. Optional. Recommendation: do not include._ An object containing the key-value pairs used for inline styling `.giraffe-single-stat--text` by setting its [style property](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style). If used, please be aware of existing default styles that may need to be overridden. See the `SINGLE_STAT_SVG_TEXT_DEFAULT_STYLE` [here](./src/constants/singleStatStyles.ts).
+
+* **CustomLayerConfig**: _Object_. No limit per `<Plot>`.
 
   A custom layer is an overlay on the Plot that is not one of the above pre-defined plot types. A render callback function is passed in as the renderer for the custom layer. It has two properties:
 

--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -23,7 +23,7 @@
     "layer",
     "line",
     "plot",
-    "scatterplot",
+    "scatter",
     "stat",
     "time series",
     "timescale",

--- a/giraffe/src/components/LatestValueTransform.tsx
+++ b/giraffe/src/components/LatestValueTransform.tsx
@@ -1,0 +1,53 @@
+// Libraries
+import React, {useMemo, FunctionComponent} from 'react'
+import {Table} from '../types'
+
+// Utils
+import {getLatestValues} from '../utils/getLatestValues'
+import {isString} from '../utils/isString'
+
+interface Props {
+  table: Table
+  children: (latestValue: number) => JSX.Element
+  allowString: boolean
+  // If `quiet` is set and a latest value can't be found, this component will
+  // display nothing instead of an empty graph error message
+  quiet?: boolean
+}
+
+export const LatestValueTransform: FunctionComponent<Props> = ({
+  table,
+  quiet = false,
+  children,
+  allowString,
+}) => {
+  const latestValues = useMemo(() => getLatestValues(table), [table])
+
+  if (latestValues.length === 0 && quiet) {
+    return null
+  }
+
+  if (latestValues.length === 0) {
+    return (
+      <div>
+        <h4>No latest value found</h4>
+      </div>
+    )
+  }
+
+  const latestValue = latestValues[0]
+
+  if (isString(latestValue) && !allowString && quiet) {
+    return null
+  }
+
+  if (isString(latestValue) && !allowString) {
+    return (
+      <div>
+        <h4>String value cannot be displayed in this graph type</h4>
+      </div>
+    )
+  }
+
+  return children(latestValue)
+}

--- a/giraffe/src/components/SingleStatLayer.tsx
+++ b/giraffe/src/components/SingleStatLayer.tsx
@@ -1,0 +1,92 @@
+import React, {FunctionComponent} from 'react'
+import {
+  SINGLE_STAT_DEFAULT_STYLE,
+  SINGLE_STAT_DEFAULT_TEST_ID,
+  SINGLE_STAT_RESIZER_DEFAULT_STYLE,
+  SINGLE_STAT_SVG_DEFAULT_ATTRIBUTES,
+  SINGLE_STAT_SVG_TEXT_DEFAULT_ATTRIBUTES,
+  SINGLE_STAT_SVG_TEXT_DEFAULT_STYLE,
+} from '../constants/singleStatStyles'
+import {SingleStatLayerConfig} from '../types'
+import {formatStatValue} from '../utils/formatStatValue'
+
+interface Props {
+  stat: number
+  config: SingleStatLayerConfig
+}
+
+const getDefaultViewBox = (stat: string): string =>
+  `0 0 ${stat.length * 55} 100`
+
+export const SingleStatLayer: FunctionComponent<Props> = props => {
+  const {stat, config} = props
+  const {
+    backgroundColor = null,
+    decimalPlaces,
+    prefix,
+    resizerStyle = {},
+    style = {},
+    suffix,
+    svgAttributes = {viewBox: ''},
+    svgStyle = {},
+    svgTextAttributes = {},
+    svgTextStyle = {},
+    testID = SINGLE_STAT_DEFAULT_TEST_ID,
+    textColor,
+    textOpacity = 1,
+  } = config
+
+  const formattedValue = formatStatValue(stat, {decimalPlaces, prefix, suffix})
+
+  let viewBox = getDefaultViewBox(formattedValue)
+
+  if (svgAttributes.viewBox) {
+    viewBox =
+      typeof svgAttributes.viewBox === 'function'
+        ? svgAttributes.viewBox(formattedValue)
+        : svgAttributes.viewBox
+  }
+
+  return (
+    <div
+      className="giraffe-layer giraffe-layer-single-stat"
+      data-testid={testID}
+      style={{
+        ...SINGLE_STAT_DEFAULT_STYLE,
+        ...style,
+        backgroundColor: `${backgroundColor}`,
+      }}
+    >
+      <div
+        className="giraffe-single-stat--resizer"
+        style={{...SINGLE_STAT_RESIZER_DEFAULT_STYLE, ...resizerStyle}}
+      >
+        <svg
+          {...{
+            ...SINGLE_STAT_SVG_DEFAULT_ATTRIBUTES,
+            ...svgAttributes,
+            viewBox,
+          }}
+          className="giraffe-single-stat--svg"
+          style={{...svgStyle}}
+        >
+          <text
+            {...{
+              ...SINGLE_STAT_SVG_TEXT_DEFAULT_ATTRIBUTES,
+              ...svgTextAttributes,
+              opacity: textOpacity,
+            }}
+            className="giraffe-single-stat--text"
+            style={{
+              ...SINGLE_STAT_SVG_TEXT_DEFAULT_STYLE,
+              ...svgTextStyle,
+              fill: textColor,
+            }}
+          >
+            {formattedValue}
+          </text>
+        </svg>
+      </div>
+    </div>
+  )
+}

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -8,6 +8,8 @@ import {
   LineLayerConfig,
   ScatterLayerConfig,
   RectLayerConfig,
+  LayerTypes,
+  SpecTypes,
 } from '../types'
 import {SingleStatLayer} from './SingleStatLayer'
 import {LineLayer} from './LineLayer'
@@ -96,7 +98,7 @@ export const SizedPlot: FunctionComponent<Props> = ({
       >
         <div className="giraffe-layers" style={fullsizeStyle}>
           {config.layers.map((layerConfig, layerIndex) => {
-            if (layerConfig.type === 'custom') {
+            if (layerConfig.type === LayerTypes.Custom) {
               const renderProps = {
                 key: layerIndex,
                 width,
@@ -113,7 +115,7 @@ export const SizedPlot: FunctionComponent<Props> = ({
               return layerConfig.render(renderProps)
             }
 
-            if (layerConfig.type === 'single stat') {
+            if (layerConfig.type === LayerTypes.SingleStat) {
               return (
                 <LatestValueTransform
                   key={layerIndex}
@@ -144,7 +146,7 @@ export const SizedPlot: FunctionComponent<Props> = ({
             }
 
             switch (spec.type) {
-              case 'line':
+              case SpecTypes.Line:
                 return (
                   <LineLayer
                     key={layerIndex}
@@ -154,7 +156,7 @@ export const SizedPlot: FunctionComponent<Props> = ({
                   />
                 )
 
-              case 'scatter': {
+              case SpecTypes.Scatter: {
                 return (
                   <ScatterLayer
                     key={layerIndex}
@@ -165,7 +167,7 @@ export const SizedPlot: FunctionComponent<Props> = ({
                 )
               }
 
-              case 'rect': {
+              case SpecTypes.Rect: {
                 return (
                   <RectLayer
                     key={layerIndex}

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -4,10 +4,12 @@ import {useCallback, FunctionComponent, CSSProperties} from 'react'
 import {Axes} from './Axes'
 import {
   SizedConfig,
+  SingleStatLayerConfig,
   LineLayerConfig,
   ScatterLayerConfig,
   RectLayerConfig,
 } from '../types'
+import {SingleStatLayer} from './SingleStatLayer'
 import {LineLayer} from './LineLayer'
 import {ScatterLayer} from './ScatterLayer'
 import {RectLayer} from './RectLayer'
@@ -17,6 +19,7 @@ import {usePlotEnv} from '../utils/usePlotEnv'
 import {useMousePos} from '../utils/useMousePos'
 import {useDragEvent} from '../utils/useDragEvent'
 import {useForceUpdate} from '../utils/useForceUpdate'
+import {LatestValueTransform} from './LatestValueTransform'
 
 interface Props {
   config: SizedConfig
@@ -108,6 +111,23 @@ export const SizedPlot: FunctionComponent<Props> = ({
               }
 
               return layerConfig.render(renderProps)
+            }
+
+            if (layerConfig.type === 'single stat') {
+              return (
+                <LatestValueTransform
+                  key={layerIndex}
+                  table={config.table}
+                  allowString={true}
+                >
+                  {latestValue => (
+                    <SingleStatLayer
+                      stat={latestValue}
+                      config={layerConfig as SingleStatLayerConfig}
+                    />
+                  )}
+                </LatestValueTransform>
+              )
             }
 
             const spec = env.getSpec(layerIndex)

--- a/giraffe/src/constants/singleStatStyles.ts
+++ b/giraffe/src/constants/singleStatStyles.ts
@@ -1,0 +1,50 @@
+import CSS from 'csstype'
+
+export const LASER = '#00C9FF'
+
+export const SINGLE_STAT_DEFAULT_TEST_ID = 'giraffe-layer-single-stat'
+
+export const SINGLE_STAT_DEFAULT_STYLE: CSS.Properties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  overflow: 'hidden',
+  width: '100%',
+  height: '100%',
+  padding: '8px',
+  color: LASER,
+  userSelect: 'none',
+  MozUserSelect: 'none',
+  WebkitUserSelect: 'none',
+  msUserSelect: 'none',
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  borderRadius: '4px',
+}
+
+export const SINGLE_STAT_RESIZER_DEFAULT_STYLE: CSS.Properties = {
+  overflow: 'hidden',
+  width: '100%',
+  height: '100%',
+}
+
+export const SINGLE_STAT_SVG_DEFAULT_ATTRIBUTES = {
+  width: '100%',
+  height: '100%',
+}
+
+export const SINGLE_STAT_SVG_TEXT_DEFAULT_ATTRIBUTES = {
+  fontSize: '100',
+  y: '59%',
+  x: '50%',
+  dominantBaseline: 'middle',
+  textAnchor: 'middle',
+  opacity: 1,
+}
+
+export const SINGLE_STAT_SVG_TEXT_DEFAULT_STYLE: CSS.Properties = {
+  fill: LASER,
+}

--- a/giraffe/src/index.ts
+++ b/giraffe/src/index.ts
@@ -29,6 +29,7 @@ export {
   HistogramLayerConfig,
   HistogramPosition,
   LayerConfig,
+  LayerTypes,
   LineInterpolation,
   LineLayerConfig,
   LinePosition,

--- a/giraffe/src/index.ts
+++ b/giraffe/src/index.ts
@@ -17,6 +17,7 @@ export {lineTransform} from './transforms/line'
 
 // Constants
 export * from './constants/colorSchemes'
+export * from './constants/singleStatStyles'
 
 // Types
 export {
@@ -34,5 +35,6 @@ export {
   Margins,
   NumericColumnData,
   Scale,
+  SingleStatLayerConfig,
   Table,
 } from './types'

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -1,3 +1,5 @@
+import CSS from 'csstype'
+
 export type SizedConfig = Config & {width: number; height: number}
 
 export interface Config {
@@ -120,6 +122,7 @@ export type ColumnType = 'number' | 'string' | 'time' | 'boolean'
 
 export type LayerConfig =
   | CustomLayerConfig
+  | SingleStatLayerConfig
   | HeatmapLayerConfig
   | HistogramLayerConfig
   | LineLayerConfig
@@ -141,6 +144,34 @@ export interface CustomLayerRenderProps {
   innerWidth: number
   innerHeight: number
   columnFormatter: (colKey: string) => (x: any) => string
+}
+
+export interface SingleStatLayerConfig {
+  type: 'single stat'
+  prefix: string
+  suffix: string
+  decimalPlaces: SingleStatDecimalPlaces
+  textColor: string
+  textOpacity?: number
+  backgroundColor?: string
+  testID?: string
+  style?: CSS.Properties
+  resizerStyle?: CSS.Properties
+  svgAttributes?: SingleStatSVGAttributes
+  svgStyle?: CSS.Properties
+  svgTextAttributes?: SingleStatSVGAttributes
+  svgTextStyle?: CSS.Properties
+}
+
+export interface SingleStatDecimalPlaces {
+  isEnforced?: boolean
+  digits?: number
+}
+
+export type SingleStatSVGAttributeFunction = (stat: string) => string
+
+export interface SingleStatSVGAttributes {
+  [attributeName: string]: string | SingleStatSVGAttributeFunction
 }
 
 export interface HeatmapLayerConfig {

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -120,6 +120,15 @@ export type ColumnData = NumericColumnData | string[] | boolean[]
 
 export type ColumnType = 'number' | 'string' | 'time' | 'boolean'
 
+export enum LayerTypes {
+  Custom = 'custom',
+  SingleStat = 'single stat',
+  Heatmap = 'heatmap',
+  Histogram = 'histogram',
+  Line = 'line',
+  Scatter = 'scatter',
+}
+
 export type LayerConfig =
   | CustomLayerConfig
   | SingleStatLayerConfig
@@ -129,7 +138,7 @@ export type LayerConfig =
   | ScatterLayerConfig
 
 export interface CustomLayerConfig {
-  type: 'custom'
+  type: 'custom' // do not refactor or restrict to LayerTypes.Custom
   render: (p: CustomLayerRenderProps) => JSX.Element
 }
 
@@ -147,7 +156,7 @@ export interface CustomLayerRenderProps {
 }
 
 export interface SingleStatLayerConfig {
-  type: 'single stat'
+  type: 'single stat' // do not refactor or restrict to LayerTypes.SingleStat
   prefix: string
   suffix: string
   decimalPlaces: SingleStatDecimalPlaces
@@ -175,7 +184,7 @@ export interface SingleStatSVGAttributes {
 }
 
 export interface HeatmapLayerConfig {
-  type: 'heatmap'
+  type: 'heatmap' // do not refactor or restrict to LayerTypes.Heatmap
   x: string
   y: string
   binSize?: number
@@ -187,7 +196,7 @@ export interface HeatmapLayerConfig {
 }
 
 export interface HistogramLayerConfig {
-  type: 'histogram'
+  type: 'histogram' // do not refactor or restrict to LayerTypes.Histogram
   x: string
   position?: HistogramPosition
   binCount?: number
@@ -202,7 +211,7 @@ export interface HistogramLayerConfig {
 export type RectLayerConfig = HeatmapLayerConfig | HistogramLayerConfig
 
 export interface LineLayerConfig {
-  type: 'line'
+  type: 'line' // do not refactor or restrict to LayerTypes.Line
   x: string
   y: string
   fill?: string[]
@@ -217,7 +226,7 @@ export interface LineLayerConfig {
 }
 
 export interface ScatterLayerConfig {
-  type: 'scatter'
+  type: 'scatter' // do not refactor or restrict to LayerTypes.Scatter
   x: string
   y: string
   fill?: string[]
@@ -253,8 +262,14 @@ export interface ScatterLayerConfig {
 */
 export type LayerSpec = LineLayerSpec | ScatterLayerSpec | RectLayerSpec
 
+export enum SpecTypes {
+  Line = 'line',
+  Scatter = 'scatter',
+  Rect = 'rect',
+}
+
 export interface LineLayerSpec {
-  type: 'line'
+  type: 'line' // do not refactor or restrict to SpecTypes.Line
   inputTable: Table
   table: Table // has `FILL` column added
   lineData: LineData
@@ -273,7 +288,7 @@ export interface LineLayerSpec {
 }
 
 export interface ScatterLayerSpec {
-  type: 'scatter'
+  type: 'scatter' // do not refactor or restrict to SpecTypes.Scatter
   inputTable: Table
   table: Table // has `FILL` and `SYMBOL` columns added
   xDomain: number[]
@@ -293,7 +308,7 @@ export interface ScatterLayerSpec {
 }
 
 export interface RectLayerSpec {
-  type: 'rect'
+  type: 'rect' // do not refactor or restrict to SpecTypes.Rect
   inputTable: Table
   table: Table // has `X_MIN`, `X_MAX`, `Y_MIN`, `Y_MAX`, and `COUNT` columns, and maybe a `FILL` column
   binDimension: 'xy' | 'x'

--- a/giraffe/src/utils/PlotEnv.ts
+++ b/giraffe/src/utils/PlotEnv.ts
@@ -187,13 +187,21 @@ export class PlotEnv {
   }
 
   public get xTickFormatter(): Formatter {
-    const firstXMapping = this.getSpec(0).xColumnKey
+    const spec = this.getSpec(0)
+    if (!spec) {
+      return DEFAULT_FORMATTER
+    }
+    const firstXMapping = spec.xColumnKey
 
     return this.getFormatterForColumn(firstXMapping)
   }
 
   public get yTickFormatter(): Formatter {
-    const firstYMapping = this.getSpec(0).yColumnKey
+    const spec = this.getSpec(0)
+    if (!spec) {
+      return DEFAULT_FORMATTER
+    }
+    const firstYMapping = spec.yColumnKey
 
     return this.getFormatterForColumn(firstYMapping)
   }
@@ -262,6 +270,7 @@ export class PlotEnv {
       }
 
       case 'custom':
+      case 'single stat':
         return null
 
       default:

--- a/giraffe/src/utils/PlotEnv.ts
+++ b/giraffe/src/utils/PlotEnv.ts
@@ -17,13 +17,14 @@ import {
 } from '../constants'
 
 import {
-  SizedConfig,
-  Margins,
-  Scale,
-  LineLayerConfig,
-  LayerSpec,
   ColumnType,
   Formatter,
+  LayerSpec,
+  LayerTypes,
+  LineLayerConfig,
+  Margins,
+  Scale,
+  SizedConfig,
 } from '../types'
 
 const X_DOMAIN_AESTHETICS = ['x', 'xMin', 'xMax']
@@ -213,7 +214,7 @@ export class PlotEnv {
     const memoizedTransformKey = `${layerIndex}: ${layerConfig.type}`
 
     switch (layerConfig.type) {
-      case 'line': {
+      case LayerTypes.Line: {
         const transform = this.fns.get(memoizedTransformKey, lineTransform)
 
         return transform(
@@ -226,7 +227,7 @@ export class PlotEnv {
         )
       }
 
-      case 'scatter': {
+      case LayerTypes.Scatter: {
         const transform = this.fns.get(memoizedTransformKey, scatterTransform)
 
         return transform(
@@ -239,7 +240,7 @@ export class PlotEnv {
         )
       }
 
-      case 'histogram': {
+      case LayerTypes.Histogram: {
         const transform = this.fns.get(memoizedTransformKey, histogramTransform)
 
         return transform(
@@ -253,7 +254,7 @@ export class PlotEnv {
         )
       }
 
-      case 'heatmap': {
+      case LayerTypes.Heatmap: {
         const transform = this.fns.get(memoizedTransformKey, heatmapTransform)
 
         return transform(
@@ -269,12 +270,12 @@ export class PlotEnv {
         )
       }
 
-      case 'custom':
-      case 'single stat':
+      case LayerTypes.Custom:
+      case LayerTypes.SingleStat:
         return null
 
       default:
-        const unknownConfig: never = layerConfig
+        const unknownConfig = layerConfig
         const unknownType = (unknownConfig as any).type
 
         throw new Error(

--- a/giraffe/src/utils/PlotEnv.ts
+++ b/giraffe/src/utils/PlotEnv.ts
@@ -417,19 +417,24 @@ const areUncontrolledDomainsStale = (
     ...X_DOMAIN_AESTHETICS,
     ...Y_DOMAIN_AESTHETICS,
   ].some(aes =>
-    config.layers.some(
-      (layer, layerIndex) => layer[aes] !== prevConfig.layers[layerIndex][aes]
-    )
+    config.layers.some((layer, layerIndex) => {
+      if (layerIndex >= prevConfig.layers.length) {
+        return false
+      }
+      return layer[aes] !== prevConfig.layers[layerIndex][aes]
+    })
   )
 
   if (xyMappingsChanged) {
     return true
   }
 
-  const binCountChanged = config.layers.some(
-    (layer: any, layerIndex) =>
-      layer.binCount !== (prevConfig.layers[layerIndex] as any).binCount
-  )
+  const binCountChanged = config.layers.some((layer: any, layerIndex) => {
+    if (layerIndex >= prevConfig.layers.length) {
+      return false
+    }
+    return layer.binCount !== (prevConfig.layers[layerIndex] as any).binCount
+  })
 
   if (binCountChanged) {
     return true

--- a/giraffe/src/utils/extrema.ts
+++ b/giraffe/src/utils/extrema.ts
@@ -43,7 +43,7 @@ export const maxBy = <T>(f: (x: T) => number, xs: T[]): T => {
 export const extentOfExtents = (
   ...data: number[][]
 ): [number, number] | null => {
-  const result = extent(flatMap(d => extent(d), data))
+  const result = extent(flatMap(data, d => extent(d)))
 
   if (result.some(x => x === undefined)) {
     return null

--- a/giraffe/src/utils/fixtures/tooltip.ts
+++ b/giraffe/src/utils/fixtures/tooltip.ts
@@ -55,7 +55,7 @@ export const createSampleTable = (options: SampleTableOptions) => {
     VALUE_COL.push(num)
     CPU_COL.push(`${COLUMN_KEY}${Math.floor(i / recordsPerLine)}`)
     TIME_COL.push(now + (i % recordsPerLine) * 1000 * 60)
-    if (plotType === 'scatterplot') {
+    if (plotType === 'scatter') {
       SYMBOL_COL.push(i % 2)
       DISK_COL.push(`disk-${i % recordsPerLine}`)
       HOST_COL.push(`host-${i % 2}`)
@@ -65,7 +65,7 @@ export const createSampleTable = (options: SampleTableOptions) => {
     .addColumn('_time', 'time', TIME_COL)
     .addColumn('_value', 'number', VALUE_COL)
 
-  if (plotType === 'scatterplot') {
+  if (plotType === 'scatter') {
     return table
       .addColumn(POINT_KEY, 'string', DISK_COL)
       .addColumn('__symbol', 'string', SYMBOL_COL)

--- a/giraffe/src/utils/fixtures/tooltip.ts
+++ b/giraffe/src/utils/fixtures/tooltip.ts
@@ -1,4 +1,5 @@
 import {newTable} from '../newTable'
+import {LayerTypes} from '../../types'
 
 interface SampleTableOptions {
   include_negative?: boolean
@@ -55,7 +56,7 @@ export const createSampleTable = (options: SampleTableOptions) => {
     VALUE_COL.push(num)
     CPU_COL.push(`${COLUMN_KEY}${Math.floor(i / recordsPerLine)}`)
     TIME_COL.push(now + (i % recordsPerLine) * 1000 * 60)
-    if (plotType === 'scatter') {
+    if (plotType === LayerTypes.Scatter) {
       SYMBOL_COL.push(i % 2)
       DISK_COL.push(`disk-${i % recordsPerLine}`)
       HOST_COL.push(`host-${i % 2}`)
@@ -65,7 +66,7 @@ export const createSampleTable = (options: SampleTableOptions) => {
     .addColumn('_time', 'time', TIME_COL)
     .addColumn('_value', 'number', VALUE_COL)
 
-  if (plotType === 'scatter') {
+  if (plotType === LayerTypes.Scatter) {
     return table
       .addColumn(POINT_KEY, 'string', DISK_COL)
       .addColumn('__symbol', 'string', SYMBOL_COL)

--- a/giraffe/src/utils/flatMap.ts
+++ b/giraffe/src/utils/flatMap.ts
@@ -2,8 +2,8 @@
   Equivalent to `flatten(xs.map(f))`.
 */
 export const flatMap = <X, Y>(
-  f: (x: X, i: number, xs: X[]) => Y[],
-  xs: X[]
+  xs: X[],
+  f: (x: X, i: number, xs: X[]) => Y[]
 ): Y[] => {
   const result = []
   const yss = xs.map(f)

--- a/giraffe/src/utils/formatStatValue.test.ts
+++ b/giraffe/src/utils/formatStatValue.test.ts
@@ -1,0 +1,183 @@
+import {formatStatValue} from './formatStatValue'
+
+describe('formatStatValue', () => {
+  let prefix: string
+  let value: number | string
+  let suffix: string
+
+  describe('handles bad input gracefully', () => {
+    test('handles undefined', () => {
+      prefix = 'LOL'
+      value = undefined
+      suffix = ' is funny'
+
+      const errorResult = formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+      expect(typeof errorResult === 'string').toEqual(true)
+      expect(errorResult).not.toEqual(`${prefix}${value}${suffix}`)
+    })
+
+    test('handles null', () => {
+      prefix = ':-('
+      value = null
+      suffix = ' is not funny'
+
+      const errorResult = formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+      expect(typeof errorResult === 'string').toEqual(true)
+      expect(errorResult).not.toEqual(`${prefix}${value}${suffix}`)
+    })
+  })
+
+  test('formats NaN', () => {
+    prefix = 'My nanny is '
+    value = NaN
+    suffix = ''
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}${value}${suffix}`)
+  })
+
+  test('formats Infinity', () => {
+    prefix = 'To '
+    value = Infinity
+    suffix = ' and beyond'
+
+    const INFINITY_SYMBOL = '∞'
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}${INFINITY_SYMBOL}${suffix}`)
+  })
+
+  test('formats negative Infinity', () => {
+    prefix = 'To '
+    value = -Infinity
+    suffix = ' and beyond'
+
+    const INFINITY_SYMBOL = '∞'
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}-${INFINITY_SYMBOL}${suffix}`)
+  })
+
+  test('formats 0 with trailing decimal 0s', () => {
+    prefix = ''
+    value = 0
+    let trailingDecimals = 2
+    suffix = ''
+
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: trailingDecimals},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}0.00${suffix}`)
+
+    trailingDecimals = 10
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: trailingDecimals},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}0.0000000000${suffix}`)
+  })
+
+  test('formats an integer value', () => {
+    prefix = 'we have '
+    value = 123
+    suffix = ' abc'
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}${value}${suffix}`)
+
+    value = -1
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}${value}${suffix}`)
+
+    value = 123456789
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 0},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}123,456,789${suffix}`)
+  })
+
+  test('formats a float value', () => {
+    prefix = 'abc '
+    value = 123.456789
+    suffix = ' yoyoyo'
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 6},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}${value}${suffix}`)
+
+    value = -9.012345678911111111111111111111111111111111111
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 20},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}-9.0123456789${suffix}`)
+  })
+
+  test('formats an empty string value', () => {
+    prefix = ''
+    value = ''
+    suffix = ''
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 3},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}${value}${suffix}`)
+  })
+
+  test('formats a non-empty string value', () => {
+    prefix = 'Negative '
+    value = '-666.666'
+    suffix = ' is Evil'
+    expect(
+      formatStatValue(value, {
+        decimalPlaces: {isEnforced: true, digits: 3},
+        prefix,
+        suffix,
+      })
+    ).toEqual(`${prefix}${value}${suffix}`)
+  })
+})

--- a/giraffe/src/utils/formatStatValue.ts
+++ b/giraffe/src/utils/formatStatValue.ts
@@ -1,0 +1,54 @@
+import {isNumber} from './isNumber'
+import {isString} from './isString'
+import {preventNegativeZero} from './preventNegativeZero'
+
+import {SingleStatDecimalPlaces} from '../types'
+
+const MAX_DECIMAL_PLACES = 10
+
+interface FormatStatValueOptions {
+  decimalPlaces?: SingleStatDecimalPlaces
+  prefix?: string
+  suffix?: string
+}
+
+const getAutoDigits = (value: number | string): number => {
+  const decimalIndex = value.toString().indexOf('.')
+
+  return decimalIndex === -1 ? 0 : 2
+}
+
+export const formatStatValue = (
+  value: number | string,
+  {decimalPlaces, prefix, suffix}: FormatStatValueOptions = {}
+): string => {
+  let localeFormattedValue: undefined | string | number
+
+  if (isNumber(value)) {
+    let digits: number
+
+    if (decimalPlaces && decimalPlaces.isEnforced) {
+      digits = decimalPlaces.digits
+    } else {
+      digits = getAutoDigits(value)
+    }
+
+    const roundedValue = Number(value).toFixed(digits)
+
+    localeFormattedValue =
+      Number(roundedValue) === 0
+        ? roundedValue
+        : Number(roundedValue).toLocaleString(undefined, {
+            maximumFractionDigits: MAX_DECIMAL_PLACES,
+          })
+  } else if (isString(value)) {
+    localeFormattedValue = value
+  } else {
+    return 'Data cannot be displayed'
+  }
+
+  localeFormattedValue = preventNegativeZero(localeFormattedValue)
+  const formattedValue = `${prefix || ''}${localeFormattedValue}${suffix || ''}`
+
+  return formattedValue
+}

--- a/giraffe/src/utils/getJavaScriptTag.test.ts
+++ b/giraffe/src/utils/getJavaScriptTag.test.ts
@@ -1,0 +1,39 @@
+import {getJavaScriptTag} from './getJavaScriptTag'
+
+describe('getJavaScriptTag', () => {
+  test('get tag for Undefined', () => {
+    expect(getJavaScriptTag(undefined)).toEqual('[object Undefined]')
+  })
+
+  test('get tag for Null', () => {
+    expect(getJavaScriptTag(null)).toEqual('[object Null]')
+  })
+
+  test('get tag for Object', () => {
+    expect(getJavaScriptTag({})).toEqual('[object Object]')
+  })
+
+  test('get tag for Array', () => {
+    expect(getJavaScriptTag([])).toEqual('[object Array]')
+  })
+
+  test('get tag for Function', () => {
+    expect(getJavaScriptTag(() => {})).toEqual('[object Function]')
+  })
+
+  test('get tag for String', () => {
+    expect(getJavaScriptTag('')).toEqual('[object String]')
+  })
+
+  test('get tag for Number', () => {
+    expect(getJavaScriptTag(1)).toEqual('[object Number]')
+  })
+
+  test('get tag for Boolean', () => {
+    expect(getJavaScriptTag(true)).toEqual('[object Boolean]')
+  })
+
+  test('get tag for Symbol', () => {
+    expect(getJavaScriptTag(Symbol())).toEqual('[object Symbol]')
+  })
+})

--- a/giraffe/src/utils/getJavaScriptTag.ts
+++ b/giraffe/src/utils/getJavaScriptTag.ts
@@ -1,0 +1,6 @@
+export const getJavaScriptTag = (value: any): string => {
+  if (value == null) {
+    return value === undefined ? '[object Undefined]' : '[object Null]'
+  }
+  return Object.prototype.toString.call(value)
+}

--- a/giraffe/src/utils/getLatestValues.test.ts
+++ b/giraffe/src/utils/getLatestValues.test.ts
@@ -63,10 +63,29 @@ describe('getLatestValues', () => {
         startTime + interval,
         startTime + interval * 2,
       ])
-      .addColumn(yColKey, 'number', [0, 1.67, 2.32])
+      .addColumn(yColKey, 'number', [0, 4.67, 2.32])
     const result = getLatestValues(table)
 
     expect(Array.isArray(result)).toEqual(true)
     expect(result[0]).toEqual(2.32)
+  })
+
+  test('ignores columns with invalid types', () => {
+    const xColKey = '_time'
+    const yColKey = '_value'
+    const startTime = Date.now()
+    const interval = 100
+    const table = newTable(3)
+      .addColumn(xColKey, 'time', [
+        startTime,
+        startTime + interval,
+        startTime + interval * 2,
+      ])
+      .addColumn(yColKey, 'number', [2.32, 4.67, 0.01])
+      .addColumn('didItWork', 'boolean', [true, false, true])
+    const result = getLatestValues(table)
+
+    expect(Array.isArray(result)).toEqual(true)
+    expect(result[0]).toEqual(0.01)
   })
 })

--- a/giraffe/src/utils/getLatestValues.test.ts
+++ b/giraffe/src/utils/getLatestValues.test.ts
@@ -1,0 +1,72 @@
+import {getLatestValues} from './getLatestValues'
+import {newTable} from '../utils/newTable'
+
+describe('getLatestValues', () => {
+  test('gives an empty array when table is empty', () => {
+    const table = newTable(0)
+    const result = getLatestValues(table)
+
+    expect(Array.isArray(result)).toEqual(true)
+    expect(result.length).toEqual(0)
+  })
+
+  test('finds the value when timestamp column is missing and only 1 row exists in the table', () => {
+    const yColKey = '_value'
+    const table = newTable(1).addColumn(yColKey, 'number', [3.99])
+    const result = getLatestValues(table)
+
+    expect(Array.isArray(result)).toEqual(true)
+    expect(result[0]).toEqual(3.99)
+  })
+
+  test('gives an empty array when timestamp column is missing and there are multiple rows in the table', () => {
+    const yColKey = '_value'
+    const table = newTable(4).addColumn(yColKey, 'number', [
+      0,
+      1.67,
+      2.32,
+      3.99,
+    ])
+    const result = getLatestValues(table)
+
+    expect(Array.isArray(result)).toEqual(true)
+    expect(result.length).toEqual(0)
+  })
+
+  test('finds the correct value even when timestamp column is not ordered', () => {
+    const xColKey = '_time'
+    const yColKey = '_value'
+    const startTime = Date.now()
+    const interval = 100
+    const table = newTable(4)
+      .addColumn(xColKey, 'time', [
+        startTime + interval * 4,
+        startTime - interval,
+        startTime + interval * 5,
+        startTime + interval * 2,
+      ])
+      .addColumn(yColKey, 'number', [0, 1.67, 2.32, 3.97])
+    const result = getLatestValues(table)
+
+    expect(Array.isArray(result)).toEqual(true)
+    expect(result[0]).toEqual(2.32)
+  })
+
+  test('finds the value associated with the most recent timestamp', () => {
+    const xColKey = '_time'
+    const yColKey = '_value'
+    const startTime = Date.now()
+    const interval = 100
+    const table = newTable(3)
+      .addColumn(xColKey, 'time', [
+        startTime,
+        startTime + interval,
+        startTime + interval * 2,
+      ])
+      .addColumn(yColKey, 'number', [0, 1.67, 2.32])
+    const result = getLatestValues(table)
+
+    expect(Array.isArray(result)).toEqual(true)
+    expect(result[0]).toEqual(2.32)
+  })
+})

--- a/giraffe/src/utils/getLatestValues.ts
+++ b/giraffe/src/utils/getLatestValues.ts
@@ -1,0 +1,127 @@
+import {range} from './range'
+import {isString} from './isString'
+import {flatMap} from './flatMap'
+import {Table, NumericColumnData} from '../types'
+
+/*
+  Return a list of the maximum elements in `xs`, where the magnitude of each
+  element is computed using the passed function `d`.
+*/
+const maxesBy = <X>(xs: X[], d: (x: X) => number): X[] => {
+  let maxes = []
+  let maxDist = -Infinity
+
+  for (const x of xs) {
+    const dist = d(x)
+
+    if (dist > maxDist) {
+      maxes = [x]
+      maxDist = dist
+    } else if (dist === maxDist && dist !== -Infinity) {
+      maxes.push(x)
+    }
+  }
+
+  return maxes
+}
+
+const EXCLUDED_COLUMNS = new Set([
+  '_start',
+  '_stop',
+  '_time',
+  'table',
+  'result',
+  '',
+])
+
+/*
+  Determine if the values in a column should be considered in `latestValues`.
+*/
+const isValueCol = (table: Table, colKey: string): boolean => {
+  const columnType = table.getColumnType(colKey)
+  const columnName = table.getColumnName(colKey)
+
+  return (
+    (columnType === 'number' ||
+      columnType === 'time' ||
+      columnType === 'string') &&
+    !EXCLUDED_COLUMNS.has(columnName)
+  )
+}
+
+/*
+  We sort the column keys that we pluck latest values from, so that:
+
+  - Columns named `_value` have precedence
+  - The returned latest values are in a somewhat stable order
+*/
+const sortTableKeys = (keyA: string, keyB: string): number => {
+  if (keyA.includes('_value')) {
+    return -1
+  } else if (keyB.includes('_value')) {
+    return 1
+  } else {
+    return keyA.localeCompare(keyB)
+  }
+}
+
+/*
+  Return a list of the most recent numeric values present in a `Table`.
+
+  This utility searches any numeric column to find values, and uses the `_time`
+  column as their associated timestamp.
+
+  If the table only has one row, then a time column is not needed.
+*/
+export const getLatestValues = (table: Table): number[] => {
+  const valueColsData = table.columnKeys
+    .sort((a, b) => sortTableKeys(a, b))
+    .filter(k => isValueCol(table, k))
+    .map(k => table.getColumn(k)) as number[][]
+
+  if (!valueColsData.length) {
+    return []
+  }
+
+  const columnKeys = table.columnKeys
+
+  // Fallback to `_stop` column if `_time` column missing otherwise return empty array.
+  let timeColData: NumericColumnData = []
+
+  if (columnKeys.includes('_time')) {
+    timeColData = table.getColumn('_time', 'number')
+  } else if (columnKeys.includes('_stop')) {
+    timeColData = table.getColumn('_stop', 'number')
+  }
+  if (!timeColData && table.length !== 1) {
+    return []
+  }
+
+  const d = (i: number) => {
+    const time = timeColData[i]
+
+    if (
+      time &&
+      valueColsData.some(colData => {
+        return Number.isFinite(colData[i]) || isString(colData[i])
+      })
+    ) {
+      return time
+    }
+
+    return -Infinity
+  }
+
+  const latestRowIndices =
+    table.length === 1 ? [0] : maxesBy(range(0, table.length), d)
+
+  const latestValues = flatMap(latestRowIndices, i =>
+    valueColsData.map(colData => colData[i])
+  )
+
+  const definedLatestValues = latestValues.filter(
+    x => Number.isFinite(x) || isString(x)
+  )
+
+  return definedLatestValues
+}

--- a/giraffe/src/utils/getLatestValues.ts
+++ b/giraffe/src/utils/getLatestValues.ts
@@ -75,8 +75,8 @@ const sortTableKeys = (keyA: string, keyB: string): number => {
 */
 export const getLatestValues = (table: Table): number[] => {
   const valueColsData = table.columnKeys
-    .sort((a, b) => sortTableKeys(a, b))
     .filter(k => isValueCol(table, k))
+    .sort((a, b) => sortTableKeys(a, b))
     .map(k => table.getColumn(k)) as number[][]
 
   if (!valueColsData.length) {

--- a/giraffe/src/utils/isNumber.test.ts
+++ b/giraffe/src/utils/isNumber.test.ts
@@ -1,0 +1,44 @@
+import {isNumber} from './isNumber'
+
+describe('isNumber', () => {
+  test('the value created from the Number constructor is a number', () => {
+    const value = new Number()
+
+    expect(typeof value === 'object').toEqual(true)
+    expect(isNumber(value)).toEqual(true)
+  })
+
+  test('the value created from the Number function is a number', () => {
+    const value = Number()
+
+    expect(typeof value !== 'object').toEqual(true)
+    expect(isNumber(value)).toEqual(true)
+  })
+
+  test('a literal number is a number', () => {
+    expect(isNumber(1)).toEqual(true)
+    expect(isNumber(123456789)).toEqual(true)
+    expect(isNumber(0)).toEqual(true)
+    expect(isNumber(-4567.89)).toEqual(true)
+  })
+
+  test('Infinity and negative Infinity are numbers', () => {
+    expect(isNumber(Infinity)).toEqual(true)
+    expect(isNumber(-Infinity)).toEqual(true)
+  })
+
+  test('the value NaN is a number', () => {
+    expect(isNumber(NaN)).toEqual(true)
+  })
+
+  test('everything else is not a number', () => {
+    expect(isNumber(undefined)).toEqual(false)
+    expect(isNumber(null)).toEqual(false)
+    expect(isNumber({})).toEqual(false)
+    expect(isNumber([])).toEqual(false)
+    expect(isNumber('123')).toEqual(false)
+    expect(isNumber('-0')).toEqual(false)
+    expect(isNumber(() => 123)).toEqual(false)
+    expect(isNumber(Symbol())).toEqual(false)
+  })
+})

--- a/giraffe/src/utils/isNumber.ts
+++ b/giraffe/src/utils/isNumber.ts
@@ -1,0 +1,12 @@
+import {getJavaScriptTag} from './getJavaScriptTag'
+
+const isObjectLike = (value: any): boolean => {
+  return typeof value === 'object' && value !== null
+}
+
+export const isNumber = (value: any): boolean => {
+  return (
+    typeof value === 'number' ||
+    (isObjectLike(value) && getJavaScriptTag(value) == '[object Number]')
+  )
+}

--- a/giraffe/src/utils/isString.test.ts
+++ b/giraffe/src/utils/isString.test.ts
@@ -1,0 +1,40 @@
+import {isString} from './isString'
+
+describe('isString', () => {
+  test('the value created from the String constructor is a string', () => {
+    const value = new String()
+
+    expect(typeof value === 'object').toEqual(true)
+    expect(isString(value)).toEqual(true)
+  })
+
+  test('the value created from the String function is a string', () => {
+    const value = String()
+
+    expect(typeof value !== 'object').toEqual(true)
+    expect(isString(value)).toEqual(true)
+  })
+
+  test('a literal string is a string', () => {
+    expect(
+      isString('@#$^@#$@ ; \n\nerer /.,.. abc one two three!!!!! #_+[]')
+    ).toEqual(true)
+    expect(isString('123456789')).toEqual(true)
+    expect(isString('0')).toEqual(true)
+    expect(isString('-4567.89')).toEqual(true)
+  })
+
+  test('everything else is not a string', () => {
+    expect(isString(undefined)).toEqual(false)
+    expect(isString(null)).toEqual(false)
+    expect(isString({})).toEqual(false)
+    expect(isString([])).toEqual(false)
+    expect(isString(123)).toEqual(false)
+    expect(isString(-0)).toEqual(false)
+    expect(isString(NaN)).toEqual(false)
+    expect(isString(Infinity)).toEqual(false)
+    expect(isString(-Infinity)).toEqual(false)
+    expect(isString(() => 'return value is a string!')).toEqual(false)
+    expect(isString(Symbol())).toEqual(false)
+  })
+})

--- a/giraffe/src/utils/isString.ts
+++ b/giraffe/src/utils/isString.ts
@@ -1,0 +1,12 @@
+import {getJavaScriptTag} from './getJavaScriptTag'
+
+export const isString = (value: any): boolean => {
+  const type = typeof value
+  return (
+    type === 'string' ||
+    (type === 'object' &&
+      value != null &&
+      !Array.isArray(value) &&
+      getJavaScriptTag(value) == '[object String]')
+  )
+}

--- a/giraffe/src/utils/preventNegativeZero.test.ts
+++ b/giraffe/src/utils/preventNegativeZero.test.ts
@@ -1,0 +1,43 @@
+import {preventNegativeZero} from './preventNegativeZero'
+
+describe('preventNegativeZero', () => {
+  it('should not alter non-zero numbers', () => {
+    expect(preventNegativeZero(1)).toEqual(1)
+    expect(preventNegativeZero(0.000000000001)).toEqual(0.000000000001)
+    expect(preventNegativeZero(-456.78)).toEqual(-456.78)
+
+    let nonZeroString = '0.000000000000000000000000001'
+    expect(preventNegativeZero(nonZeroString)).toEqual(nonZeroString)
+
+    nonZeroString = '1234567890'
+    expect(preventNegativeZero(nonZeroString)).toEqual(nonZeroString)
+
+    nonZeroString = '-123456789.0001'
+    expect(preventNegativeZero(nonZeroString)).toEqual(nonZeroString)
+  })
+  it('should handle negative zero as a number', () => {
+    expect(preventNegativeZero(-0)).toEqual(0)
+    expect(preventNegativeZero(-0.0)).toEqual(0)
+
+    // prettier-ignore
+    expect(preventNegativeZero(-0.00)).toEqual(0)
+    // prettier-ignore
+    expect(preventNegativeZero(-0.000)).toEqual(0)
+    // prettier-ignore
+    expect(preventNegativeZero(-0.0000)).toEqual(0)
+    // prettier-ignore
+    expect(preventNegativeZero(-0.00)).toEqual(0.00)
+    // prettier-ignore
+    expect(preventNegativeZero(-0.000)).toEqual(0.000)
+    // prettier-ignore
+    expect(preventNegativeZero(-0.0000)).toEqual(0.0000)
+  })
+  it('should handle negative zero as a string', () => {
+    expect(preventNegativeZero('-0')).toEqual('0')
+    expect(preventNegativeZero('-0.0')).toEqual('0.0')
+    expect(preventNegativeZero('-0.00000000')).toEqual('0.00000000')
+
+    expect(preventNegativeZero('-0.0')).not.toEqual('0')
+    expect(preventNegativeZero('-0.00000000')).not.toEqual('0')
+  })
+})

--- a/giraffe/src/utils/preventNegativeZero.ts
+++ b/giraffe/src/utils/preventNegativeZero.ts
@@ -1,0 +1,9 @@
+export const preventNegativeZero = (
+  value: number | string
+): number | string => {
+  // eslint-disable-next-line no-compare-neg-zero
+  if (Number(value) === -0) {
+    return typeof value === 'number' ? 0 : value.replace(/-/g, '')
+  }
+  return value
+}

--- a/giraffe/src/utils/range.test.ts
+++ b/giraffe/src/utils/range.test.ts
@@ -1,0 +1,82 @@
+import {range} from './range'
+
+describe('range creates an array from start to end using an increment or decrement', () => {
+  const emptyRange = []
+  const MAX_INTEGER = 1.7976931348623157e308
+
+  describe('uses increment when end is greater than start', () => {
+    test('uses an increment of 1 when not specified or explicitly undefined', () => {
+      expect(range(0, 5)).toEqual([0, 1, 2, 3, 4])
+      expect(range(0, 5, undefined)).toEqual([0, 1, 2, 3, 4])
+    })
+
+    test('uses an increment of 0 when increment is NaN or null', () => {
+      expect(range(0, 5, NaN)).toEqual([0, 0, 0, 0, 0])
+      expect(range(0, 5, null)).toEqual([0, 0, 0, 0, 0])
+    })
+
+    test('uses a max integer for increment when increment is Infinity', () => {
+      expect(range(0, MAX_INTEGER, Infinity)).toEqual([0])
+    })
+
+    test('throws an error when start is negative Infinity, end is Infinity, or both', () => {
+      expect(() => range(0, Infinity)).toThrow()
+      expect(() => range(-Infinity, 0)).toThrow()
+      expect(() => range(-Infinity, Infinity)).toThrow()
+    })
+
+    test('uses the increment when specified', () => {
+      expect(range(0, 10, 2)).toEqual([0, 2, 4, 6, 8])
+    })
+  })
+
+  describe('uses decrement when start is greater than end', () => {
+    test('returns empty range when decrement is not specified, explicitly undefined, null, or NaN', () => {
+      expect(range(5, 0)).toEqual(emptyRange)
+      expect(range(5, 0, undefined)).toEqual(emptyRange)
+      expect(range(5, 0, NaN)).toEqual(emptyRange)
+      expect(range(5, 0, null)).toEqual(emptyRange)
+    })
+
+    test('uses a max integer for decrement when decrement is -Infinity', () => {
+      expect(range(0, -MAX_INTEGER, -Infinity)).toEqual([0])
+    })
+
+    test('throws an error when start is Infinity, end is negative Infinity, or both', () => {
+      expect(() => range(Infinity, 0, -1)).toThrow()
+      expect(() => range(0, -Infinity, -1)).toThrow()
+      expect(() => range(Infinity, -Infinity, -1)).toThrow()
+    })
+
+    test('uses the decrement when specified', () => {
+      expect(range(5, 0, -1)).toEqual([5, 4, 3, 2, 1])
+    })
+  })
+
+  test('gives a range that includes start and excludes end', () => {
+    expect(range(0, 1)).toEqual([0])
+    expect(range(-1, -2, -1)).toEqual([-1])
+  })
+
+  test('gives an empty range when start and end are equal', () => {
+    expect(range(0, 0)).toEqual(emptyRange)
+    expect(range(20, 20)).toEqual(emptyRange)
+    expect(range(-1, -1)).toEqual(emptyRange)
+    expect(range(-5, -5, -1)).toEqual(emptyRange)
+  })
+
+  test('interprets start as 0 when start is NaN', () => {
+    expect(range(NaN, 5)).toEqual([0, 1, 2, 3, 4])
+    expect(range(NaN, -5, -1)).toEqual([0, -1, -2, -3, -4])
+  })
+
+  test('interprets end as 0 when end is NaN', () => {
+    expect(range(-5, NaN)).toEqual([-5, -4, -3, -2, -1])
+    expect(range(5, NaN, -1)).toEqual([5, 4, 3, 2, 1])
+  })
+
+  test('interprets start and end as 0 when both are NaN', () => {
+    expect(range(NaN, NaN)).toEqual(emptyRange)
+    expect(range(NaN, NaN, -1)).toEqual(emptyRange)
+  })
+})

--- a/giraffe/src/utils/range.ts
+++ b/giraffe/src/utils/range.ts
@@ -1,0 +1,90 @@
+import {getJavaScriptTag} from './getJavaScriptTag'
+
+const INFINITY = 1 / 0
+const MAX_INTEGER = 1.7976931348623157e308
+const NotANumber = 0 / 0
+const reTrim = /^\s+|\s+$/g
+const reIsBadHex = /^[-+]0x[0-9a-f]+$/i
+const reIsBinary = /^0b[01]+$/i
+const reIsOctal = /^0o[0-7]+$/i
+const freeParseInt = parseInt
+
+const isSymbol = (value: any): boolean => {
+  const type = typeof value
+  return (
+    type == 'symbol' ||
+    (type === 'object' &&
+      value != null &&
+      getJavaScriptTag(value) == '[object Symbol]')
+  )
+}
+const isObject = (value: any): boolean => {
+  const type = typeof value
+  return value != null && (type === 'object' || type === 'function')
+}
+
+const toNumber = (value: any): number => {
+  if (typeof value === 'number') {
+    return value
+  }
+  if (isSymbol(value)) {
+    return NotANumber
+  }
+  if (isObject(value)) {
+    const other = typeof value.valueOf === 'function' ? value.valueOf() : value
+    value = isObject(other) ? `${other}` : other
+  }
+  if (typeof value !== 'string') {
+    return value === 0 ? value : +value
+  }
+  value = value.replace(reTrim, '')
+  const isBinary = reIsBinary.test(value)
+  return isBinary || reIsOctal.test(value)
+    ? freeParseInt(value.slice(2), isBinary ? 2 : 8)
+    : reIsBadHex.test(value)
+    ? NotANumber
+    : +value
+}
+
+const toFinite = (value: any): number => {
+  if (!value) {
+    return value === 0 ? value : 0
+  }
+  value = toNumber(value)
+  if (value === INFINITY || value === -INFINITY) {
+    const sign = value < 0 ? -1 : 1
+    return sign * MAX_INTEGER
+  }
+  return value === value ? value : 0
+}
+
+const baseRange = (start: number, end: number, step: number): Array<number> => {
+  let index = 0
+  let length = Math.max(Math.ceil((end - start) / (step || 1)), 0)
+  const result = new Array(length)
+
+  while (length) {
+    length -= 1
+    result[index] = start
+    index += 1
+    start += step
+  }
+  return result
+}
+
+const createRange = () => {
+  return (start: number, end: number, step = 1) => {
+    // Ensure the sign of `-0` is preserved.
+    start = toFinite(start)
+    if (end === undefined) {
+      end = start
+      start = 0
+    } else {
+      end = toFinite(end)
+    }
+    step = step === undefined ? (start < end ? 1 : -1) : toFinite(step)
+    return baseRange(start, end, step)
+  }
+}
+
+export const range = createRange()

--- a/giraffe/src/utils/tooltip.test.ts
+++ b/giraffe/src/utils/tooltip.test.ts
@@ -262,7 +262,7 @@ describe('getPointsTooltipData', () => {
         numberOfRecords,
         recordsPerLine,
         hoveredRowIndices,
-        plotType: 'scatterplot',
+        plotType: 'scatter',
       })
       result = getPointsTooltipData(
         hoveredRowIndices,

--- a/giraffe/src/utils/tooltip.test.ts
+++ b/giraffe/src/utils/tooltip.test.ts
@@ -13,7 +13,7 @@ import {
   POINT_KEY,
   HOST_KEY,
 } from './fixtures/tooltip'
-import {LineLayerSpec, ScatterLayerSpec} from '../types'
+import {LayerTypes, LineLayerSpec, ScatterLayerSpec} from '../types'
 
 describe('getPointsTooltipData', () => {
   let sampleTable
@@ -262,7 +262,7 @@ describe('getPointsTooltipData', () => {
         numberOfRecords,
         recordsPerLine,
         hoveredRowIndices,
-        plotType: 'scatter',
+        plotType: LayerTypes.Scatter,
       })
       result = getPointsTooltipData(
         hoveredRowIndices,

--- a/stories/src/customLayer.stories.tsx
+++ b/stories/src/customLayer.stories.tsx
@@ -1,43 +1,71 @@
 import * as React from 'react'
 import {storiesOf} from '@storybook/react'
-import {Config, Plot} from '../../giraffe/src'
+import {withKnobs, text} from '@storybook/addon-knobs'
+import {Config, Plot, LASER} from '../../giraffe/src'
 
 import {PlotContainer} from './helpers'
 import {CPU} from './data/cpu'
+import {singleStatTable} from './data/singleStatLayer'
 
-storiesOf('Custom Layer', module).add('Highlighted Region', () => {
-  const config: Config = {
-    table: CPU,
-    layers: [
-      {
-        type: 'scatter',
-        x: '_time',
-        y: '_value',
-      },
-      {
-        type: 'custom',
-        render: ({key, yScale}) => {
-          return (
-            <div
-              key={key}
-              style={{
-                width: '100%',
-                position: 'absolute',
-                top: `${yScale(20)}px`,
-                height: `${yScale(10) - yScale(20)}px`,
-                background: 'tomato',
-                opacity: 0.3,
-              }}
-            />
-          )
+storiesOf('Custom Layer', module)
+  .addDecorator(withKnobs)
+  .add('Highlighted Region', () => {
+    const config: Config = {
+      table: CPU,
+      layers: [
+        {
+          type: 'scatter',
+          x: '_time',
+          y: '_value',
         },
-      },
-    ],
-  }
+        {
+          type: 'custom',
+          render: ({key, yScale}) => {
+            return (
+              <div
+                key={key}
+                style={{
+                  width: '100%',
+                  position: 'absolute',
+                  top: `${yScale(20)}px`,
+                  height: `${yScale(10) - yScale(20)}px`,
+                  background: 'tomato',
+                  opacity: 0.3,
+                }}
+              />
+            )
+          },
+        },
+      ],
+    }
 
-  return (
-    <PlotContainer>
-      <Plot config={config} />
-    </PlotContainer>
-  )
-})
+    return (
+      <PlotContainer>
+        <Plot config={config} />
+      </PlotContainer>
+    )
+  })
+  .add('Single Stat', () => {
+    const decimalPlaces = Number(text('Decimal Places', '4'))
+    const config: Config = {
+      table: singleStatTable,
+      showAxes: false,
+      layers: [
+        {
+          type: 'single stat',
+          prefix: '',
+          suffix: '',
+          decimalPlaces: {
+            isEnforced: true,
+            digits: decimalPlaces,
+          },
+          textColor: LASER,
+        },
+      ],
+    }
+    return (
+      <PlotContainer>
+        <Plot config={config} />
+      </PlotContainer>
+    )
+  })

--- a/stories/src/customLayer.stories.tsx
+++ b/stories/src/customLayer.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {storiesOf} from '@storybook/react'
-import {withKnobs, text} from '@storybook/addon-knobs'
+import {withKnobs, number, text} from '@storybook/addon-knobs'
 import {Config, Plot, LASER} from '../../giraffe/src'
 
 import {PlotContainer} from './helpers'
@@ -47,19 +47,28 @@ storiesOf('Custom Layer', module)
   })
   .add('Single Stat', () => {
     const decimalPlaces = Number(text('Decimal Places', '4'))
+    const textOpacity = number('Single Stat Opacity', 1, {
+      range: true,
+      min: 0,
+      max: 1,
+      step: 0.01,
+    })
+    const prefix = text('Prefix', '')
+    const suffix = text('Suffix', '')
     const config: Config = {
       table: singleStatTable,
       showAxes: false,
       layers: [
         {
           type: 'single stat',
-          prefix: '',
-          suffix: '',
+          prefix,
+          suffix,
           decimalPlaces: {
             isEnforced: true,
             digits: decimalPlaces,
           },
           textColor: LASER,
+          textOpacity,
         },
       ],
     }

--- a/stories/src/data/singleStatLayer.ts
+++ b/stories/src/data/singleStatLayer.ts
@@ -1,9 +1,9 @@
 import {newTable} from '../../../giraffe/src'
 
 const now = Date.now()
-const numberOfRecords = 80
+const numberOfRecords = 20
 const recordsPerLine = 20
-const maxValue = 100
+const maxValue = 10
 
 const TIME_COL = []
 const VALUE_COL = []
@@ -18,7 +18,7 @@ for (let i = 0; i < numberOfRecords; i += 1) {
   TIME_COL.push(now + (i % recordsPerLine) * 1000 * 60)
 }
 
-export const stackedLineTable = newTable(numberOfRecords)
+export const singleStatTable = newTable(numberOfRecords)
   .addColumn('_time', 'time', TIME_COL)
   .addColumn('_value', 'number', VALUE_COL)
   .addColumn('cpu', 'string', CPU_COL)

--- a/stories/src/index.stories.tsx
+++ b/stories/src/index.stories.tsx
@@ -2,7 +2,14 @@ import * as React from 'react'
 import {storiesOf} from '@storybook/react'
 import {withKnobs, number, select, boolean, text} from '@storybook/addon-knobs'
 
-import {Config, Plot, MAGMA, timeFormatter, LASER} from '../../giraffe/src'
+import {
+  Config,
+  Plot,
+  MAGMA,
+  timeFormatter,
+  LASER,
+  LayerConfig,
+} from '../../giraffe/src'
 import {stackedLineTable} from './data/stackedLineLayer'
 import {singleStatTable} from './data/singleStatLayer'
 
@@ -180,6 +187,7 @@ storiesOf('XY Plot', module)
     )
   })
   .add('Line Layer + Single Stat', () => {
+    const includeSingleStatLayer = boolean('Single Stat', true)
     const decimalPlaces = Number(text('Decimal Places', '2'))
     const table = singleStatTable
     const colors = colorSchemeKnob()
@@ -225,6 +233,35 @@ storiesOf('XY Plot', module)
       'auto'
     )
 
+    const layers = [
+      {
+        type: 'line',
+        x,
+        y,
+        fill,
+        position,
+        interpolation,
+        colors,
+        lineWidth,
+        hoverDimension,
+        shadeBelow,
+        shadeBelowOpacity,
+      },
+    ] as LayerConfig[]
+
+    if (includeSingleStatLayer) {
+      layers.push({
+        type: 'single stat',
+        prefix: '',
+        suffix: '',
+        decimalPlaces: {
+          isEnforced: true,
+          digits: decimalPlaces,
+        },
+        textColor: LASER,
+      })
+    }
+
     const config: Config = {
       table,
       valueFormatters: {
@@ -239,31 +276,7 @@ storiesOf('XY Plot', module)
       legendFont,
       tickFont,
       showAxes,
-      layers: [
-        {
-          type: 'line',
-          x,
-          y,
-          fill,
-          position,
-          interpolation,
-          colors,
-          lineWidth,
-          hoverDimension,
-          shadeBelow,
-          shadeBelowOpacity,
-        },
-        {
-          type: 'single stat',
-          prefix: '',
-          suffix: '',
-          decimalPlaces: {
-            isEnforced: true,
-            digits: decimalPlaces,
-          },
-          textColor: LASER,
-        },
-      ],
+      layers,
     }
 
     return (

--- a/stories/src/index.stories.tsx
+++ b/stories/src/index.stories.tsx
@@ -294,7 +294,7 @@ storiesOf('XY Plot', module)
       </PlotContainer>
     )
   })
-  .add('Scatterplot', () => {
+  .add('Scatter Plot', () => {
     const table = tableKnob()
     const colors = colorSchemeKnob()
     const legendFont = legendFontKnob()

--- a/stories/src/index.stories.tsx
+++ b/stories/src/index.stories.tsx
@@ -2,8 +2,9 @@ import * as React from 'react'
 import {storiesOf} from '@storybook/react'
 import {withKnobs, number, select, boolean, text} from '@storybook/addon-knobs'
 
-import {Config, Plot, MAGMA, timeFormatter} from '../../giraffe/src'
-import {stackedLineLayer} from './data/stackedLineLayer'
+import {Config, Plot, MAGMA, timeFormatter, LASER} from '../../giraffe/src'
+import {stackedLineTable} from './data/stackedLineLayer'
+import {singleStatTable} from './data/singleStatLayer'
 
 import {
   PlotContainer,
@@ -25,7 +26,7 @@ import {
 storiesOf('XY Plot', module)
   .addDecorator(withKnobs)
   .add('Stacked Line Layer', () => {
-    const table = tableKnob(stackedLineLayer)
+    const table = tableKnob(stackedLineTable)
     const colors = colorSchemeKnob()
     const legendFont = legendFontKnob()
     const tickFont = tickFontKnob()
@@ -168,6 +169,99 @@ storiesOf('XY Plot', module)
           hoverDimension,
           shadeBelow,
           shadeBelowOpacity,
+        },
+      ],
+    }
+
+    return (
+      <PlotContainer>
+        <Plot config={config} />
+      </PlotContainer>
+    )
+  })
+  .add('Line Layer + Single Stat', () => {
+    const decimalPlaces = Number(text('Decimal Places', '2'))
+    const table = singleStatTable
+    const colors = colorSchemeKnob()
+    const legendFont = legendFontKnob()
+    const tickFont = tickFontKnob()
+    const x = xKnob(table)
+    const y = yKnob(table)
+    const valueAxisLabel = text('Value Axis Label', 'foo')
+    const xScale = xScaleKnob()
+    const yScale = yScaleKnob()
+    const timeZone = timeZoneKnob()
+    const timeFormat = select(
+      'Time Format',
+      {
+        'DD/MM/YYYY HH:mm:ss.sss': 'DD/MM/YYYY HH:mm:ss.sss',
+        'MM/DD/YYYY HH:mm:ss.sss': 'MM/DD/YYYY HH:mm:ss.sss',
+        'YYYY/MM/DD HH:mm:ss': 'YYYY/MM/DD HH:mm:ss',
+        'YYYY-MM-DD HH:mm:ss ZZ': 'YYYY-MM-DD HH:mm:ss ZZ',
+        'hh:mm a': 'hh:mm a',
+        'HH:mm': 'HH:mm',
+        'HH:mm:ss': 'HH:mm:ss',
+        'HH:mm:ss ZZ': 'HH:mm:ss ZZ',
+        'HH:mm:ss.sss': 'HH:mm:ss.sss',
+        'MMMM D, YYYY HH:mm:ss': 'MMMM D, YYYY HH:mm:ss',
+        'dddd, MMMM D, YYYY HH:mm:ss': 'dddd, MMMM D, YYYY HH:mm:ss',
+      },
+      'YYYY-MM-DD HH:mm:ss ZZ'
+    )
+    const fill = fillKnob(table, 'cpu')
+    const position = select(
+      'Line Position',
+      {stacked: 'stacked', overlaid: 'overlaid'},
+      'overlaid'
+    )
+    const interpolation = interpolationKnob()
+    const showAxes = showAxesKnob()
+    const lineWidth = number('Line Width', 1)
+    const shadeBelow = boolean('Shade Area', false)
+    const shadeBelowOpacity = number('Area Opacity', 0.1)
+    const hoverDimension = select(
+      'Hover Dimension',
+      {auto: 'auto', x: 'x', y: 'y', xy: 'xy'},
+      'auto'
+    )
+
+    const config: Config = {
+      table,
+      valueFormatters: {
+        _time: timeFormatter({timeZone, format: timeFormat}),
+        _value: val =>
+          `${val.toFixed(2)}${
+            valueAxisLabel ? ` ${valueAxisLabel}` : valueAxisLabel
+          }`,
+      },
+      xScale,
+      yScale,
+      legendFont,
+      tickFont,
+      showAxes,
+      layers: [
+        {
+          type: 'line',
+          x,
+          y,
+          fill,
+          position,
+          interpolation,
+          colors,
+          lineWidth,
+          hoverDimension,
+          shadeBelow,
+          shadeBelowOpacity,
+        },
+        {
+          type: 'single stat',
+          prefix: '',
+          suffix: '',
+          decimalPlaces: {
+            isEnforced: true,
+            digits: decimalPlaces,
+          },
+          textColor: LASER,
         },
       ],
     }

--- a/stories/src/index.stories.tsx
+++ b/stories/src/index.stories.tsx
@@ -189,6 +189,14 @@ storiesOf('XY Plot', module)
   .add('Line Layer + Single Stat', () => {
     const includeSingleStatLayer = boolean('Single Stat', true)
     const decimalPlaces = Number(text('Decimal Places', '2'))
+    const textOpacity = number('Single Stat Opacity', 1, {
+      range: true,
+      min: 0,
+      max: 1,
+      step: 0.01,
+    })
+    const prefix = text('Prefix', '')
+    const suffix = text('Suffix', '')
     const table = singleStatTable
     const colors = colorSchemeKnob()
     const legendFont = legendFontKnob()
@@ -252,13 +260,14 @@ storiesOf('XY Plot', module)
     if (includeSingleStatLayer) {
       layers.push({
         type: 'single stat',
-        prefix: '',
-        suffix: '',
+        prefix,
+        suffix,
         decimalPlaces: {
           isEnforced: true,
           digits: decimalPlaces,
         },
         textColor: LASER,
+        textOpacity,
       })
     }
 


### PR DESCRIPTION
Closes #169 

Adds Single Stat as a custom layer

Single Stat by itself
<img width="1680" alt="Screen Shot 2020-06-04 at 10 53 24 AM" src="https://user-images.githubusercontent.com/10736577/83793632-b0621080-a651-11ea-83c5-9fd1d5c34bae.png">

Single Stat with line graph
<img width="1680" alt="Screen Shot 2020-06-04 at 10 53 36 AM" src="https://user-images.githubusercontent.com/10736577/83793652-b6f08800-a651-11ea-831d-ded0ddd76b20.png">

Single Stat at maximum decimal places with line graph
<img width="1680" alt="Screen Shot 2020-06-04 at 10 54 57 AM" src="https://user-images.githubusercontent.com/10736577/83793782-e3a49f80-a651-11ea-90a7-901ae2b07a0b.png">

