### PR TITLE
chore: add sizing and positioning to Single Stat stories

### DIFF
--- a/stories/src/customLayer.stories.tsx
+++ b/stories/src/customLayer.stories.tsx
@@ -53,6 +53,24 @@ storiesOf('Custom Layer', module)
       max: 1,
       step: 0.01,
     })
+    const viewBoxWidth = number('SVG viewBox width', 55, {
+      range: true,
+      min: 0,
+      max: 1000,
+      step: 1,
+    })
+    const viewBoxX = number('SVG viewBox x', 0, {
+      range: true,
+      min: -500,
+      max: 500,
+      step: 1,
+    })
+    const viewBoxY = number('SVG viewBox y', 0, {
+      range: true,
+      min: -500,
+      max: 500,
+      step: 1,
+    })
     const prefix = text('Prefix', '')
     const suffix = text('Suffix', '')
     const config: Config = {
@@ -69,6 +87,10 @@ storiesOf('Custom Layer', module)
           },
           textColor: LASER,
           textOpacity,
+          svgAttributes: {
+            viewBox: stat =>
+              `${viewBoxX} ${viewBoxY} ${stat.length * viewBoxWidth} 100`,
+          },
         },
       ],
     }

--- a/stories/src/index.stories.tsx
+++ b/stories/src/index.stories.tsx
@@ -195,6 +195,24 @@ storiesOf('XY Plot', module)
       max: 1,
       step: 0.01,
     })
+    const viewBoxWidth = number('SVG viewBox width', 55, {
+      range: true,
+      min: 0,
+      max: 1000,
+      step: 1,
+    })
+    const viewBoxX = number('SVG viewBox x', 0, {
+      range: true,
+      min: -500,
+      max: 500,
+      step: 1,
+    })
+    const viewBoxY = number('SVG viewBox y', 0, {
+      range: true,
+      min: -500,
+      max: 500,
+      step: 1,
+    })
     const prefix = text('Prefix', '')
     const suffix = text('Suffix', '')
     const table = singleStatTable
@@ -268,6 +286,10 @@ storiesOf('XY Plot', module)
         },
         textColor: LASER,
         textOpacity,
+        svgAttributes: {
+          viewBox: stat =>
+            `${viewBoxX} ${viewBoxY} ${stat.length * viewBoxWidth} 100`,
+        },
       })
     }
 


### PR DESCRIPTION
Demonstrates Single Stat's new superhero powers:
- controls its own size
- controls its own position

When combined with a line graph, they become the Avengers.

<img width="1680" alt="Screen Shot 2020-06-12 at 4 40 49 PM" src="https://user-images.githubusercontent.com/10736577/84554154-851f9700-accb-11ea-968e-78eac12b0002.png">
