### PR TITLE
chore: update demo page version to match release

### DIFF
--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "0.0.1",
+  "version": "0.22.0",
   "license": "MIT",
   "scripts": {
     "lint": "eslint '{src,../giraffe/src}/**/*.{ts,tsx}'",


### PR DESCRIPTION
Updates the version of this page: https://influxdata.github.io/giraffe

to match the published release