### PR TITLE
chore: add links to the Storybook demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Giraffe aims to distinguish itself with several features:
 - A [columnar](https://observablehq.com/@mbostock/manipulating-flat-arrays) interface for input data that enables efficient interop with Web Workers and [Apache Arrow](https://arrow.apache.org/)
 - Self-contained configs in the style of [Vega-Lite](https://vega.github.io/vega-lite/)
 
+## Demos
+
+[See the visualizations in action using Storybook](https://influxdata.github.io/giraffe)
+
 ## Getting Started [](#getting-started)
 
 #### Installation

--- a/giraffe/README.md
+++ b/giraffe/README.md
@@ -2,6 +2,10 @@
 
 A React-based visualization library powering the data visualizations in [InfluxDB 2.0](https://github.com/influxdata/influxdb/) UI.
 
+## Demos
+
+[See the visualizations in action using Storybook](https://influxdata.github.io/giraffe)
+
 ## Quick Start
 
 1. In your React code, import the `Plot` component and the `newTable` utility function


### PR DESCRIPTION
Point users to the demo page without requiring them to run Storybook locally.