### PR TITLE
fix: determine correct hover indices when line lengths are different

### DIFF
--- a/giraffe/src/components/BandLayer.tsx
+++ b/giraffe/src/components/BandLayer.tsx
@@ -8,7 +8,11 @@ import {useCanvas} from '../utils/useCanvas'
 import {drawBands} from '../utils/drawBands'
 import {useHoverPointIndices} from '../utils/useHoverPointIndices'
 import {FILL} from '../constants/columnKeys'
-import {getBandHoverIndices, getLineLengths} from '../utils/getBandHoverIndices'
+import {
+  getBandHoverIndices,
+  getLineLengths,
+  getMinMaxOfBands,
+} from '../utils/getBandHoverIndices'
 import {groupLineIndicesIntoBands} from '../transforms/band'
 
 export interface Props extends LayerProps {
@@ -78,6 +82,27 @@ export const BandLayer: FunctionComponent<Props> = props => {
     )
   })
 
+  // Get the min and max indices of the corresponding hovered line(s)
+  //   by using an 'x' dimension hover
+  const hoverAsXIndices = useHoverPointIndices(
+    'x',
+    hoverX,
+    hoverY,
+    spec.table.getColumn(config.x, 'number'),
+    spec.table.getColumn(config.y, 'number'),
+    spec.table.getColumn(FILL, 'number'),
+    xScale,
+    yScale,
+    width,
+    height
+  )
+
+  const minMaxOfBands = getMinMaxOfBands(
+    hoverAsXIndices,
+    groupColData,
+    groupLineIndicesIntoBands(spec.columnGroupMaps.fill)
+  )
+
   const hoverRowIndices = useHoverPointIndices(
     hoverDimension,
     hoverX,
@@ -92,11 +117,12 @@ export const BandLayer: FunctionComponent<Props> = props => {
   )
 
   const lineLengths = getLineLengths(spec.lineData)
+
   const bandHoverIndices = getBandHoverIndices(
     lineLengths,
     hoverRowIndices,
     hoverXYColumnData.groupColData,
-    groupLineIndicesIntoBands(spec.columnGroupMaps.fill)
+    minMaxOfBands
   )
 
   const hasHoverData = hoverRowIndices && hoverRowIndices.length > 0

--- a/giraffe/src/components/BandLayer.tsx
+++ b/giraffe/src/components/BandLayer.tsx
@@ -8,7 +8,7 @@ import {useCanvas} from '../utils/useCanvas'
 import {drawBands} from '../utils/drawBands'
 import {useHoverPointIndices} from '../utils/useHoverPointIndices'
 import {FILL} from '../constants/columnKeys'
-import {getBandHoverIndices} from '../utils/getBandHoverIndices'
+import {getBandHoverIndices, getLineLengths} from '../utils/getBandHoverIndices'
 import {groupLineIndicesIntoBands} from '../transforms/band'
 
 export interface Props extends LayerProps {
@@ -91,11 +91,9 @@ export const BandLayer: FunctionComponent<Props> = props => {
     height
   )
 
-  const lineLength = spec.columnGroupMaps.fill.mappings.length
-    ? spec.table.length / spec.columnGroupMaps.fill.mappings.length
-    : 0
+  const lineLengths = getLineLengths(spec.lineData)
   const bandHoverIndices = getBandHoverIndices(
-    lineLength,
+    lineLengths,
     hoverRowIndices,
     hoverXYColumnData.groupColData,
     groupLineIndicesIntoBands(spec.columnGroupMaps.fill)

--- a/giraffe/src/utils/getBandHoverIndices.test.ts
+++ b/giraffe/src/utils/getBandHoverIndices.test.ts
@@ -1,0 +1,77 @@
+import {getLineLengths} from './getBandHoverIndices'
+
+describe('getBandHoverIndices', () => {
+  describe('getLineLengths', () => {
+    it('handles empty data', () => {
+      expect(getLineLengths({})).toEqual({})
+    })
+
+    it('creates a map of line lengths and starting indices from line data with same lengths', () => {
+      const lineData = {
+        0: {
+          fill: 'rgb(49, 192, 246)',
+          xs: [1597715835000, 1597715850000, 1597715865000],
+          ys: [1.4, 1.1988011988011988, 0.8],
+        },
+        1: {
+          fill: 'rgb(140, 66, 177)',
+          xs: [1597715835000, 1597715850000, 1597715865000],
+          ys: [1.4, 1.001001001001001, 0.8],
+        },
+        2: {
+          fill: 'rgb(255, 126, 39)',
+          xs: [1597715835000, 1597715850000, 1597715865000],
+          ys: [1.4, 1.0999010999010999, 0.8],
+        },
+      }
+      const result = getLineLengths(lineData)
+      expect(Object.keys(result).length).toEqual(Object.keys(lineData).length)
+      expect(result[0].length).toEqual(3)
+      expect(result[0].startIndex).toEqual(0)
+      expect(result[1].length).toEqual(3)
+      expect(result[1].startIndex).toEqual(3)
+      expect(result[2].length).toEqual(3)
+      expect(result[2].startIndex).toEqual(6)
+    })
+
+    it('creates a map of line lengths and starting indices from line data with different lengths', () => {
+      const lineData = {
+        0: {
+          fill: 'rgb(49, 192, 246)',
+          xs: [1597715835000, 1597715850000, 1597715865000],
+          ys: [1.4, 1.1988011988011988, 0.8],
+        },
+        1: {
+          fill: 'rgb(140, 66, 177)',
+          xs: [1597715835000, 1597715850000, 1597715865000, 1597715880000],
+          ys: [1.4, 1.001001001001001, 0.8, 1.2987012987012987],
+        },
+        2: {
+          fill: 'rgb(255, 126, 39)',
+          xs: [
+            1597715835000,
+            1597715850000,
+            1597715865000,
+            1597715880000,
+            1597715895000,
+          ],
+          ys: [
+            1.4,
+            1.0999010999010999,
+            0.8,
+            1.2987012987012987,
+            1.0005005005005005,
+          ],
+        },
+      }
+      const result = getLineLengths(lineData)
+      expect(Object.keys(result).length).toEqual(Object.keys(lineData).length)
+      expect(result[0].length).toEqual(3)
+      expect(result[0].startIndex).toEqual(0)
+      expect(result[1].length).toEqual(4)
+      expect(result[1].startIndex).toEqual(3)
+      expect(result[2].length).toEqual(5)
+      expect(result[2].startIndex).toEqual(7)
+    })
+  })
+})

--- a/stories/src/band.stories.tsx
+++ b/stories/src/band.stories.tsx
@@ -75,9 +75,11 @@ storiesOf('Band Chart', module)
       valueFormatters: {
         _time: timeFormatter({timeZone, format: timeFormat}),
         _value: val =>
-          `${val.toFixed(2)}${
-            valueAxisLabel ? ` ${valueAxisLabel}` : valueAxisLabel
-          }`,
+          typeof val === 'number'
+            ? `${val.toFixed(2)}${
+                valueAxisLabel ? ` ${valueAxisLabel}` : valueAxisLabel
+              }`
+            : val,
       },
       xScale,
       yScale,
@@ -151,9 +153,11 @@ storiesOf('Band Chart', module)
       valueFormatters: {
         _time: timeFormatter({timeZone, format: timeFormat}),
         _value: val =>
-          `${val.toFixed(2)}${
-            valueAxisLabel ? ` ${valueAxisLabel}` : valueAxisLabel
-          }`,
+          typeof val === 'number'
+            ? `${val.toFixed(2)}${
+                valueAxisLabel ? ` ${valueAxisLabel}` : valueAxisLabel
+              }`
+            : val,
       },
       xScale,
       yScale,


### PR DESCRIPTION
When line data has different lengths, Band Chart should correctly calculate the hovered indices of the hovered points