### PR TITLE
fix: improve rendering when lines, mins, and maxes are different lengths

### DIFF
--- a/giraffe/src/components/BandLayer.tsx
+++ b/giraffe/src/components/BandLayer.tsx
@@ -13,7 +13,10 @@ import {
   getLineLengths,
   getMinMaxOfBands,
 } from '../utils/getBandHoverIndices'
-import {groupLineIndicesIntoBands} from '../transforms/band'
+import {
+  groupLineIndicesIntoBands,
+  alignMinMaxWithBand,
+} from '../transforms/band'
 
 export interface Props extends LayerProps {
   spec: BandLayerSpec
@@ -27,7 +30,11 @@ export const BandLayer: FunctionComponent<Props> = props => {
   const {config, spec, width, height, xScale, yScale, hoverX, hoverY} = props
 
   const simplifiedLineData = useMemo(
-    () => simplifyLineData(spec.lineData, xScale, yScale),
+    () =>
+      alignMinMaxWithBand(
+        simplifyLineData(spec.lineData, xScale, yScale),
+        spec.bandIndexMap
+      ),
     [spec.lineData, xScale, yScale]
   )
 

--- a/giraffe/src/utils/drawBands.ts
+++ b/giraffe/src/utils/drawBands.ts
@@ -36,9 +36,10 @@ export const drawBands = ({
     if (min) {
       const {xs: xs_min, ys: ys_min} = min
       const minAreaGenerator = area<number>()
-        .y0((i: any) => band.ys[i])
-        .y1((i: any) => ys_min[i])
-        .x((i: any) => xs_min[i])
+        .y1((i: any) => band.ys[i])
+        .y0((i: any) => ys_min[i])
+        .x1((i: any) => band.xs[i])
+        .x0((i: any) => xs_min[i])
         .context(context)
         .defined((i: any) => isDefined(xs_min[i]) && isDefined(ys_min[i]))
         .curve(CURVES[interpolation] || curveLinear)
@@ -53,9 +54,10 @@ export const drawBands = ({
     if (max) {
       const {xs: xs_max, ys: ys_max} = max
       const maxAreaGenerator = area<number>()
-        .y0((i: any) => ys_max[i])
-        .y1((i: any) => band.ys[i])
-        .x((i: any) => xs_max[i])
+        .y1((i: any) => ys_max[i])
+        .y0((i: any) => band.ys[i])
+        .x1((i: any) => xs_max[i])
+        .x0((i: any) => band.xs[i])
         .context(context)
         .defined((i: any) => isDefined(xs_max[i]) && isDefined(ys_max[i]))
         .curve(CURVES[interpolation] || curveLinear)

--- a/giraffe/src/utils/getBandHoverIndices.ts
+++ b/giraffe/src/utils/getBandHoverIndices.ts
@@ -1,4 +1,5 @@
 import {NumericColumnData, BandIndexMap, LineData} from '../types'
+import {isDefined} from './isDefined'
 
 interface MinMaxOfBands {
   [index: string]: {
@@ -46,15 +47,15 @@ export const getMinMaxOfBands = (
       maxIndex: null,
       minIndex: null,
     }
-    if (typeof band.max === 'number') {
+    if (isDefined(band.max)) {
       minMaxOfBands[band.row].maxCol = band.max
-      if (typeof hoverColumnToIndexMap[band.max] === 'number') {
+      if (isDefined(hoverColumnToIndexMap[band.max])) {
         minMaxOfBands[band.row].maxIndex = hoverColumnToIndexMap[band.max]
       }
     }
-    if (typeof band.min === 'number') {
+    if (isDefined(band.min)) {
       minMaxOfBands[band.row].minCol = band.min
-      if (typeof hoverColumnToIndexMap[band.min] === 'number') {
+      if (isDefined(hoverColumnToIndexMap[band.min])) {
         minMaxOfBands[band.row].minIndex = hoverColumnToIndexMap[band.min]
       }
     }

--- a/stories/src/band.stories.tsx
+++ b/stories/src/band.stories.tsx
@@ -10,7 +10,6 @@ import {
   PlotContainer,
   xScaleKnob,
   yScaleKnob,
-  fillKnob,
   colorSchemeKnob,
   legendFontKnob,
   tickFontKnob,
@@ -57,13 +56,11 @@ storiesOf('Band Chart', module)
       'YYYY-MM-DD HH:mm:ss ZZ'
     )
     const fromFluxTable = fromFlux(staticData).table
-    const fill = fillKnob(fromFluxTable, findStringColumns(fromFluxTable))
-
     const interpolation = interpolationKnob()
     const showAxes = showAxesKnob()
-    const lineWidth = number('Line Width', 1)
-    const lineOpacity = number('Line Opacity', 1)
-    const shadeOpacity = number('Area Opacity', 0.1)
+    const lineWidth = number('Line Width', 3)
+    const lineOpacity = number('Line Opacity', 0.7)
+    const shadeOpacity = number('Shade Opacity', 0.3)
     const hoverDimension = select(
       'Hover Dimension',
       {auto: 'auto', x: 'x', y: 'y', xy: 'xy'},
@@ -91,7 +88,7 @@ storiesOf('Band Chart', module)
           type: 'band',
           x: '_time',
           y: '_value',
-          fill,
+          fill: findStringColumns(fromFluxTable),
           interpolation,
           colors,
           lineWidth,
@@ -135,13 +132,11 @@ storiesOf('Band Chart', module)
       'YYYY-MM-DD HH:mm:ss ZZ'
     )
     const fromFluxTable = fromFlux(customCSV).table
-    const fill = fillKnob(fromFluxTable, findStringColumns(fromFluxTable))
-
     const interpolation = interpolationKnob()
     const showAxes = showAxesKnob()
-    const lineWidth = number('Line Width', 1)
-    const lineOpacity = number('Line Opacity', 1)
-    const shadeOpacity = number('Area Opacity', 0.1)
+    const lineWidth = number('Line Width', 3)
+    const lineOpacity = number('Line Opacity', 0.7)
+    const shadeOpacity = number('Shade Opacity', 0.3)
     const hoverDimension = select(
       'Hover Dimension',
       {auto: 'auto', x: 'x', y: 'y', xy: 'xy'},
@@ -169,7 +164,7 @@ storiesOf('Band Chart', module)
           type: 'band',
           x: '_time',
           y: '_value',
-          fill,
+          fill: findStringColumns(fromFluxTable),
           interpolation,
           colors,
           lineWidth,


### PR DESCRIPTION
Improvements for #228 

When a line's total number of data points are a different length than the number of mins and maxes for that line, rendering of the band is misaligned. The fix is to fill in empty spots to make them all equal length arrays of data points. This will align the rendering.

Misaligned (BEFORE):
<img width="1680" alt="Screen Shot 2020-08-20 at 4 38 25 PM" src="https://user-images.githubusercontent.com/10736577/90836182-97d5ce00-e303-11ea-8497-3b3d7225cea0.png">



Fixed (AFTER):
<img width="1680" alt="Screen Shot 2020-08-20 at 4 35 40 PM" src="https://user-images.githubusercontent.com/10736577/90836206-9efcdc00-e303-11ea-9f97-7f781163e60b.png">


