### PR TITLE
feat(schema-parser): updated fromFlux to return formatted schema when parsing data

### DIFF
--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -186,4 +186,104 @@ there",5
       'hi',
     ])
   })
+
+  it('fromFlux should return an empty object when an empty string is passed in', () => {
+    const {schema} = fromFlux('')
+    expect(schema).toStrictEqual({})
+  })
+  it('should return an empty object if the response has no _measurement header', () => {
+    const resp = `#group,false,false,false,false,false,false,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#default,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,host
+,max,0,2018-12-10T18:21:52.748859Z,2018-12-10T18:30:00Z,2018-12-10T18:29:58Z,4906213376,active,mem,.local
+,max,0,2018-12-10T18:30:00Z,2018-12-10T19:00:00Z,2018-12-10T18:54:08Z,5860683776,active,mem,.local
+,max,0,2018-12-10T19:00:00Z,2018-12-10T19:21:52.748859Z,2018-12-10T19:11:58Z,5115428864,active,mem,.local
+  `
+
+    const {schema} = fromFlux(resp)
+    expect(schema).toStrictEqual({})
+  })
+  it('should return a schema with no fields or tags if only the measurement is passed in', () => {
+    const resp = `#group,false,false,false,false,false,false,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#default,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_measurement
+,max,0,2018-12-10T18:21:52.748859Z,2018-12-10T18:30:00Z,2018-12-10T18:29:58Z,4906213376,measurement_name
+,max,0,2018-12-10T18:30:00Z,2018-12-10T19:00:00Z,2018-12-10T18:54:08Z,5860683776,measurement_name
+,max,0,2018-12-10T19:00:00Z,2018-12-10T19:21:52.748859Z,2018-12-10T19:11:58Z,5115428864,measurement_name
+  `
+
+    const {schema} = fromFlux(resp)
+    expect(schema).toStrictEqual({
+      measurement_name: {type: 'string', fields: [], tags: {}},
+    })
+  })
+  it('should return a schema with unique fields and tags if there are duplicates', () => {
+    const resp = `#group,false,false,false,false,false,false,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#default,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,host
+,max,0,2018-12-10T18:21:52.748859Z,2018-12-10T18:30:00Z,2018-12-10T18:29:58Z,4906213376,active,mem,oox4k.local
+,max,0,2018-12-10T18:30:00Z,2018-12-10T19:00:00Z,2018-12-10T18:54:08Z,5860683776,active,mem,oox4k.local
+,max,0,2018-12-10T19:00:00Z,2018-12-10T19:21:52.748859Z,2018-12-10T19:11:58Z,5115428864,active,mem,oox4k.local
+  `
+
+    const {schema} = fromFlux(resp)
+    expect(schema).toStrictEqual({
+      mem: {type: 'string', fields: ['active'], tags: {host: ['oox4k.local']}},
+    })
+  })
+  it('should return a schema without duplicates across multiple tables', () => {
+    const resp = `#group,false,false,false,false,false,false,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#default,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,host
+,max,0,2018-12-10T18:21:52.748859Z,2018-12-10T18:30:00Z,2018-12-10T18:29:58Z,4906213376,active,mem,oox4k.local
+,max,0,2018-12-10T18:30:00Z,2018-12-10T19:00:00Z,2018-12-10T18:54:08Z,5860683776,active,mem,oox4k.local
+,max,0,2018-12-10T19:00:00Z,2018-12-10T19:21:52.748859Z,2018-12-10T19:11:58Z,5115428864,active,mem,oox4k.local
+
+#group,false,false,false,false,false,false,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#default,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,host
+,max,0,2018-12-10T18:21:52.748859Z,2018-12-10T18:30:00Z,2018-12-10T18:29:58Z,4906213376,active,mem,oox4k.local
+,max,0,2018-12-10T18:30:00Z,2018-12-10T19:00:00Z,2018-12-10T18:54:08Z,5860683776,active,mem,oox4k.local
+,max,0,2018-12-10T19:00:00Z,2018-12-10T19:21:52.748859Z,2018-12-10T19:11:58Z,5115428864,active,mem,oox4k.local
+`
+
+    const {schema} = fromFlux(resp)
+    expect(schema).toStrictEqual({
+      mem: {type: 'string', fields: ['active'], tags: {host: ['oox4k.local']}},
+    })
+  })
+
+  it('should return a single schema with multiple measurements, fields and tags across multiple tables', () => {
+    const resp = `#group,false,false,false,false,false,false,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#default,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,host
+,max,0,2018-12-10T18:21:52.748859Z,2018-12-10T18:30:00Z,2018-12-10T18:29:58Z,4906213376,active,mem,oox4k.local
+,max,0,2018-12-10T18:30:00Z,2018-12-10T19:00:00Z,2018-12-10T18:54:08Z,5860683776,active,mem,oox4k.local
+,max,0,2018-12-10T19:00:00Z,2018-12-10T19:21:52.748859Z,2018-12-10T19:11:58Z,5115428864,active,mem,oox4k.local
+
+#group,false,false,false,false,false,false,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#default,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,host
+,max,0,2018-12-10T18:21:52.748859Z,2018-12-10T18:30:00Z,2018-12-10T18:29:58Z,4906213376,field_name,measurement_name,tag_value
+,max,0,2018-12-10T18:30:00Z,2018-12-10T19:00:00Z,2018-12-10T18:54:08Z,5860683776,field_name,measurement_name,tag_value
+,max,0,2018-12-10T19:00:00Z,2018-12-10T19:21:52.748859Z,2018-12-10T19:11:58Z,5115428864,field_name,measurement_name,tag_value
+`
+
+    const {schema} = fromFlux(resp)
+    expect(schema).toStrictEqual({
+      mem: {type: 'string', fields: ['active'], tags: {host: ['oox4k.local']}},
+      measurement_name: {
+        type: 'string',
+        fields: ['field_name'],
+        tags: {host: ['tag_value']},
+      },
+    })
+  })
 })


### PR DESCRIPTION
The purpose of this PR is to update the fromFlux parser in Giraffe in order to return a formatted `Schema` of the data being returned. This Schema is the basis for the in-progress Query Builder that is being integrated into Flows on the influxDB UI.

### Why

The reason that we are updating the `fromFlux` parser in Giraffe rather than creating a new flux parser is in order to reduce the eventual drift that may occur in having multiple parsers in multiple repos. 

The reason we need the flux results returned in a specific way is so that the UI can accurately map query results in a way that is accessible and predictable for the UI when mapping out the new query builder. This work is related to the current work in progress that can be found here:

https://github.com/influxdata/influxdb/pull/19450