### PR TITLE
fix(types): moved types into the right location and imported into fromFlux

### DIFF
--- a/giraffe/src/index.ts
+++ b/giraffe/src/index.ts
@@ -40,6 +40,9 @@ export {
   NumericColumnData,
   RawFluxDataTableLayerConfig,
   Scale,
+  Schema,
+  SchemaValues,
   SingleStatLayerConfig,
   Table,
+  Tag,
 } from './types'

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -614,3 +614,17 @@ export interface BandIndexMap {
   minIndices: number[]
   maxIndices: number[]
 }
+
+export interface Tag {
+  [tagName: string]: string[]
+}
+
+export interface SchemaValues {
+  fields: string[]
+  tags: Tag
+  type?: string
+}
+
+export interface Schema {
+  [measurement: string]: SchemaValues
+}

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -2,25 +2,9 @@ import {csvParse, csvParseRows} from 'd3-dsv'
 import Papa from 'papaparse'
 import {get, groupBy} from 'lodash'
 
-import {Table, ColumnType} from '../types'
+import {Schema, Table, ColumnType} from '../types'
 import {assert} from './assert'
 import {newTable} from './newTable'
-
-export interface Tag {
-  [tagName: string]: string[]
-}
-
-export interface SchemaValues {
-  fields: string[]
-  tags: Tag
-  type?: string
-}
-
-export type Measurement = string
-
-export interface Schema {
-  [measurement: string]: SchemaValues
-}
 
 export interface FromFluxResult {
   schema: Schema


### PR DESCRIPTION
This PR is meant to clean up the TS issues and general bad practices of not localizing types by moving the newly declared Schema, TagValues and Tag interfaces into the `src/types` directory. This PR also removes the `Measurement` type since it is not being used