### PR TITLE
fix(fromFlux): flagging the fromFlux as a separate version to integrate into the UI

### DIFF
--- a/giraffe/src/index.ts
+++ b/giraffe/src/index.ts
@@ -2,7 +2,7 @@
 export {Plot} from './components/Plot'
 
 // Utils
-export {fromFlux, FromFluxResult} from './utils/fromFlux'
+export {fromFlux, fromFluxWithSchema, FromFluxResult} from './utils/fromFlux'
 export {fromRows} from './utils/fromRows'
 export {newTable} from './utils/newTable'
 export {

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -616,7 +616,7 @@ export interface BandIndexMap {
 }
 
 export interface Tag {
-  [tagName: string]: string[]
+  [tagName: string]: Set<string | number>
 }
 
 export interface SchemaValues {

--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -231,7 +231,11 @@ there",5
 
     const {schema} = fromFluxWithSchema(resp)
     expect(schema).toStrictEqual({
-      mem: {type: 'string', fields: ['active'], tags: {host: ['oox4k.local']}},
+      mem: {
+        type: 'string',
+        fields: ['active'],
+        tags: {host: new Set(['oox4k.local'])},
+      },
     })
   })
   it('should return a schema without duplicates across multiple tables', () => {
@@ -254,7 +258,11 @@ there",5
 
     const {schema} = fromFluxWithSchema(resp)
     expect(schema).toStrictEqual({
-      mem: {type: 'string', fields: ['active'], tags: {host: ['oox4k.local']}},
+      mem: {
+        type: 'string',
+        fields: ['active'],
+        tags: {host: new Set(['oox4k.local'])},
+      },
     })
   })
 
@@ -278,11 +286,15 @@ there",5
 
     const {schema} = fromFluxWithSchema(resp)
     expect(schema).toStrictEqual({
-      mem: {type: 'string', fields: ['active'], tags: {host: ['oox4k.local']}},
+      mem: {
+        type: 'string',
+        fields: ['active'],
+        tags: {host: new Set(['oox4k.local'])},
+      },
       measurement_name: {
         type: 'string',
         fields: ['field_name'],
-        tags: {host: ['tag_value']},
+        tags: {host: new Set(['tag_value'])},
       },
     })
   })

--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -1,4 +1,4 @@
-import {fromFlux} from './fromFlux'
+import {fromFlux, fromFluxWithSchema} from './fromFlux'
 
 describe('fromFlux', () => {
   test('can parse a Flux CSV with mismatched schemas', () => {
@@ -188,7 +188,7 @@ there",5
   })
 
   it('fromFlux should return an empty object when an empty string is passed in', () => {
-    const {schema} = fromFlux('')
+    const {schema} = fromFluxWithSchema('')
     expect(schema).toStrictEqual({})
   })
   it('should return an empty object if the response has no _measurement header', () => {
@@ -201,7 +201,7 @@ there",5
 ,max,0,2018-12-10T19:00:00Z,2018-12-10T19:21:52.748859Z,2018-12-10T19:11:58Z,5115428864,active,mem,.local
   `
 
-    const {schema} = fromFlux(resp)
+    const {schema} = fromFluxWithSchema(resp)
     expect(schema).toStrictEqual({})
   })
   it('should return a schema with no fields or tags if only the measurement is passed in', () => {
@@ -214,7 +214,7 @@ there",5
 ,max,0,2018-12-10T19:00:00Z,2018-12-10T19:21:52.748859Z,2018-12-10T19:11:58Z,5115428864,measurement_name
   `
 
-    const {schema} = fromFlux(resp)
+    const {schema} = fromFluxWithSchema(resp)
     expect(schema).toStrictEqual({
       measurement_name: {type: 'string', fields: [], tags: {}},
     })
@@ -229,7 +229,7 @@ there",5
 ,max,0,2018-12-10T19:00:00Z,2018-12-10T19:21:52.748859Z,2018-12-10T19:11:58Z,5115428864,active,mem,oox4k.local
   `
 
-    const {schema} = fromFlux(resp)
+    const {schema} = fromFluxWithSchema(resp)
     expect(schema).toStrictEqual({
       mem: {type: 'string', fields: ['active'], tags: {host: ['oox4k.local']}},
     })
@@ -252,7 +252,7 @@ there",5
 ,max,0,2018-12-10T19:00:00Z,2018-12-10T19:21:52.748859Z,2018-12-10T19:11:58Z,5115428864,active,mem,oox4k.local
 `
 
-    const {schema} = fromFlux(resp)
+    const {schema} = fromFluxWithSchema(resp)
     expect(schema).toStrictEqual({
       mem: {type: 'string', fields: ['active'], tags: {host: ['oox4k.local']}},
     })
@@ -276,7 +276,7 @@ there",5
 ,max,0,2018-12-10T19:00:00Z,2018-12-10T19:21:52.748859Z,2018-12-10T19:11:58Z,5115428864,field_name,measurement_name,tag_value
 `
 
-    const {schema} = fromFlux(resp)
+    const {schema} = fromFluxWithSchema(resp)
     expect(schema).toStrictEqual({
       mem: {type: 'string', fields: ['active'], tags: {host: ['oox4k.local']}},
       measurement_name: {

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -39,9 +39,7 @@ const formatSchemaByChunk = (chunk: string, schema: Schema): void => {
   const nonAnnotationData = Papa.parse(nonAnnotationLines).data
   const annotationD = Papa.parse(annotationLines).data
   const headerRow = nonAnnotationData[0]
-
   const tableColIndex = headerRow.findIndex(h => h === 'table')
-
   interface TableGroup {
     [tableId: string]: string[]
   }

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -321,7 +321,7 @@ const formatSchemaByGroupKey = (groupKey, schema: Schema) => {
           const currentValues: Set<string | number> = acc[k]
           acc[k] = new Set([...currentValues, ...values])
         } else {
-          acc[k] = new Set(values)
+          acc[k] = new Set([values])
         }
       }
       return acc


### PR DESCRIPTION
### Background

This PR resolves the issue that stemmed from the new parser addition by doing two things:  

- Keeping the new additions in a separate parser that should replace the existing one once proven stable
- Updated some of the schema building logic in order to reduce nested loops

### Issue

The issue that the created can be found here:

https://github.com/influxdata/idpe/issues/8467

### Solution

The issue primarily stemmed from here:

https://github.com/influxdata/giraffe/compare/fix/fromFlux?expand=1#diff-2386bd719c19aac4f8ff42434a17cd08L271-L278

By changing the datatype and reducing the nested looping that was previously taking place, I was able to ensure that data is parsed correctly and efficiently, with a max parsing differential of ~7s using a 27mb data set based on the raw data output by the issue linked above