### PR TITLE
fix: prevent 24-hour and UTC format from displaying "24" for the hours

### DIFF
--- a/giraffe/src/utils/formatters.test.ts
+++ b/giraffe/src/utils/formatters.test.ts
@@ -104,7 +104,7 @@ describe('timeFormatter', () => {
     )
   })
 
-  test('24 hour format and UTC format should not show "24" for midnight', () => {
+  test('24 hour format and UTC format without "a" should not show "24" for midnight', () => {
     const utcFormatterWithFormat = timeFormatter({
       timeZone: 'UTC',
       format: 'YYYY-MM-DD HH:mm:ss ZZ',
@@ -118,10 +118,33 @@ describe('timeFormatter', () => {
     let midnight = new Date('2019-01-01T00:00Z')
     expect(utcFormatterWithFormat(midnight)).toEqual('2019-01-01 00:00:00 UTC')
 
+    midnight = new Date('2019-01-01T24:00Z')
+    expect(utcFormatterWithFormat(midnight)).toEqual('2019-01-02 00:00:00 UTC')
+
     midnight = new Date('2019-01-01T23:00Z')
     expect(nonUTCFormatterWithFormat(midnight)).toEqual(
       '2019-01-02 00:00:00 GMT+1'
     )
+  })
+
+  test('24 hour format and UTC format without "a" should display correctly', () => {
+    const utcFormatterWithFormat = timeFormatter({
+      timeZone: 'UTC',
+      format: 'YYYY-MM-DD HH:mm:ss ZZ',
+    })
+    const nonUTCFormatterWithFormat = timeFormatter({
+      timeZone: 'Europe/Berlin',
+      format: 'YYYY-MM-DD HH:mm:ss ZZ',
+      hour12: false,
+    })
+
+    let date = new Date('2019-01-01T15:00Z')
+    expect(utcFormatterWithFormat(date)).toEqual('2019-01-01 15:00:00 UTC')
+    expect(nonUTCFormatterWithFormat(date)).toEqual('2019-01-01 16:00:00 GMT+1')
+
+    date = new Date('2019-01-01T07:00Z')
+    expect(utcFormatterWithFormat(date)).toEqual('2019-01-01 07:00:00 UTC')
+    expect(nonUTCFormatterWithFormat(date)).toEqual('2019-01-01 08:00:00 GMT+1')
   })
 
   test('can format times with format strings', () => {

--- a/giraffe/src/utils/formatters.test.ts
+++ b/giraffe/src/utils/formatters.test.ts
@@ -104,6 +104,26 @@ describe('timeFormatter', () => {
     )
   })
 
+  test('24 hour format and UTC format should not show "24" for midnight', () => {
+    const utcFormatterWithFormat = timeFormatter({
+      timeZone: 'UTC',
+      format: 'YYYY-MM-DD HH:mm:ss ZZ',
+    })
+    const nonUTCFormatterWithFormat = timeFormatter({
+      timeZone: 'Europe/Berlin',
+      format: 'YYYY-MM-DD HH:mm:ss ZZ',
+      hour12: false,
+    })
+
+    let midnight = new Date('2019-01-01T00:00Z')
+    expect(utcFormatterWithFormat(midnight)).toEqual('2019-01-01 00:00:00 UTC')
+
+    midnight = new Date('2019-01-01T23:00Z')
+    expect(nonUTCFormatterWithFormat(midnight)).toEqual(
+      '2019-01-02 00:00:00 GMT+1'
+    )
+  })
+
   test('can format times with format strings', () => {
     const tests = [
       ['YYYY-MM-DD HH:mm:ss', '2019-01-01 00:00:00'],

--- a/giraffe/src/utils/formatters.ts
+++ b/giraffe/src/utils/formatters.ts
@@ -152,6 +152,9 @@ export const timeFormatter = ({
     HH: options => {
       const {hour, lhour} = options
       const hasMeridiem = / a/i
+      const is24hourFormat =
+        is24hourLocale || UTC_TIME_ZONE.test(timeZone) || hour12 === false
+
       if (hasMeridiem.test(format)) {
         if (Number(lhour) === 0) {
           return '12'
@@ -161,7 +164,7 @@ export const timeFormatter = ({
         }
         return String(Number(lhour))
       }
-      if (is24hourLocale || UTC_TIME_ZONE.test(timeZone) || hour12 === false) {
+      if (is24hourFormat) {
         const numericalHour = Number(lhour) % 24
         return numericalHour < 10 ? `0${numericalHour}` : `${numericalHour}`
       }

--- a/stories/src/csv.stories.tsx
+++ b/stories/src/csv.stories.tsx
@@ -6,17 +6,17 @@ import {Config, Plot, timeFormatter, fromFlux} from '../../giraffe/src'
 
 import {
   PlotContainer,
-  xKnob,
-  yKnob,
-  xScaleKnob,
-  yScaleKnob,
-  fillKnob,
   colorSchemeKnob,
-  legendFontKnob,
-  tickFontKnob,
-  showAxesKnob,
+  findStringColumns,
   interpolationKnob,
+  legendFontKnob,
+  showAxesKnob,
+  tickFontKnob,
   timeZoneKnob,
+  xKnob,
+  xScaleKnob,
+  yKnob,
+  yScaleKnob,
 } from './helpers'
 
 storiesOf('CSV from Flux', module)
@@ -39,7 +39,9 @@ storiesOf('CSV from Flux', module)
         'MM/DD/YYYY HH:mm:ss.sss': 'MM/DD/YYYY HH:mm:ss.sss',
         'YYYY/MM/DD HH:mm:ss': 'YYYY/MM/DD HH:mm:ss',
         'YYYY-MM-DD HH:mm:ss ZZ': 'YYYY-MM-DD HH:mm:ss ZZ',
+        'YYYY-MM-DD HH:mm:ss a ZZ': 'YYYY-MM-DD HH:mm:ss a ZZ',
         'hh:mm a': 'hh:mm a',
+        'hh:mm': 'hh:mm',
         'HH:mm': 'HH:mm',
         'HH:mm:ss': 'HH:mm:ss',
         'HH:mm:ss ZZ': 'HH:mm:ss ZZ',
@@ -49,7 +51,6 @@ storiesOf('CSV from Flux', module)
       },
       'YYYY-MM-DD HH:mm:ss ZZ'
     )
-    const fill = fillKnob(table, ['cpu'])
     const interpolation = interpolationKnob()
     const showAxes = showAxesKnob()
     const lineWidth = number('Line Width', 1)
@@ -77,7 +78,7 @@ storiesOf('CSV from Flux', module)
           type: 'line',
           x,
           y,
-          fill,
+          fill: findStringColumns(table),
           interpolation,
           colors,
           lineWidth,


### PR DESCRIPTION
Closes idpe #8310

Prevents 24-hour and UTC format without "a" from displaying "24" for the hours