### PR TITLE
feat: change "name" to "mainColumnName" for the primary line of Band Plot

### DIFF
--- a/giraffe/README.md
+++ b/giraffe/README.md
@@ -352,11 +352,11 @@ Giraffe comes with utility functions.
 
   - **shadeOpacity**: _number. Optional._ A value between 0 and 1 inclusive for the [_CanvasRenderingContext2D globalAlpha_](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalAlpha) of the shaded sections of each band.
 
-  - **name**: _string. Required._ A string indicating the name of the line for the middle part of each band. This **name** must match the result in the data. If no matching name with a result is found, that result will not be rendered.
+  - **mainColumnName**: _string. Required._ A string indicating the yield name of the line for the middle part of each band. This **mainColumnName** must match the result in the data. If no matching name within the data is found, that result will not be rendered. Only one yield name can be the **mainColumnName** per `<Plot>`.
 
-  - **upperColumnName**: _string. Optional._ A string indicating the shaded portion of each band that extends above the **name**d line.
+  - **upperColumnName**: _string. Optional._ A string indicating the shaded portion of each band that extends above the **mainColumnName** line.
 
-  - **lowerColumnName**: _string. Optional._ A string indicating the shaded portion of each band that extends below the **name**d line.
+  - **lowerColumnName**: _string. Optional._ A string indicating the shaded portion of each band that extends below the **mainColumnName** line.
 
 - **ScatterLayerConfig**: _Object_. Maximum one per `<Plot>`. Properties are:
 

--- a/giraffe/src/components/BandHoverLayer.tsx
+++ b/giraffe/src/components/BandHoverLayer.tsx
@@ -38,7 +38,7 @@ export const BandHoverLayer: FunctionComponent<Props> = ({
     fill: fillColKeys,
     lineWidth,
     lowerColumnName = '',
-    name: rowColumnName,
+    mainColumnName: rowColumnName,
     shadeOpacity,
     upperColumnName = '',
   } = config

--- a/giraffe/src/components/BandLayer.tsx
+++ b/giraffe/src/components/BandLayer.tsx
@@ -32,7 +32,7 @@ export const BandLayer: FunctionComponent<Props> = props => {
 
   const {
     lowerColumnName = '',
-    name: rowColumnName,
+    mainColumnName: rowColumnName,
     upperColumnName = '',
   } = config
 

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -307,7 +307,7 @@ export interface BandLayerConfig {
   lineOpacity?: number
   colors?: string[]
   shadeOpacity?: number
-  name: string
+  mainColumnName: string
   upperColumnName?: string
   lowerColumnName?: string
 }

--- a/giraffe/src/utils/PlotEnv.ts
+++ b/giraffe/src/utils/PlotEnv.ts
@@ -268,7 +268,7 @@ export class PlotEnv {
           layerConfig.fill,
           layerConfig.colors,
           layerConfig.lowerColumnName,
-          layerConfig.name,
+          layerConfig.mainColumnName,
           layerConfig.upperColumnName
         )
       }

--- a/stories/src/band.stories.tsx
+++ b/stories/src/band.stories.tsx
@@ -82,7 +82,7 @@ storiesOf('Band Chart', module)
       'auto'
     )
     const upperColumnName = text('upperColumnName', 'max')
-    const name = text('name', 'mean')
+    const mainColumnName = text('mainColumnName', 'mean')
     const lowerColumnName = text('lowerColumnName', 'min')
 
     const config: Config = {
@@ -114,7 +114,7 @@ storiesOf('Band Chart', module)
           hoverDimension,
           shadeOpacity,
           upperColumnName,
-          name,
+          mainColumnName,
           lowerColumnName,
         },
       ],
@@ -164,7 +164,7 @@ storiesOf('Band Chart', module)
       'auto'
     )
     const upperColumnName = text('upperColumnName', '')
-    const name = text('name', '')
+    const mainColumnName = text('mainColumnName', '')
     const lowerColumnName = text('lowerColumnName', '')
 
     const config: Config = {
@@ -196,7 +196,7 @@ storiesOf('Band Chart', module)
           hoverDimension,
           shadeOpacity,
           upperColumnName,
-          name,
+          mainColumnName,
           lowerColumnName,
         },
       ],


### PR DESCRIPTION
Part of idpe 8337

As part of saving BandViewProperties for dashboards, a "mainColumn" property was added to keep track of the primary line in Band Plot. To keep Giraffe's api easy to use and match up with similar properties in Cloud 2 and OSS, "name" should be called "mainColumnName". For reference, here are the back-end changes:

https://github.com/influxdata/idpe/pull/8559
https://github.com/influxdata/influxdb/pull/19550