### PR TITLE
fix(types): repair Table and Column type to match implementation

### DIFF
--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -93,8 +93,8 @@ export interface Formatter {
 
 export interface Table {
   getColumn: GetColumn
-  getColumnName: (columnKey: string) => string
-  getColumnType: (columnKey: string) => ColumnType
+  getColumnName: (columnKey: string) => string | null // null if the column is not available
+  getColumnType: (columnKey: string) => ColumnType | null // null if the column is not available
   columnKeys: string[]
   length: number
   addColumn: (

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -16,7 +16,7 @@ export interface FromFluxResult {
 }
 
 type Column =
-  | {name: string; type: 'number'; data: number[]}
+  | {name: string; type: 'number'; data: Array<number | null>} //  parses empty numeric values as null
   | {name: string; type: 'time'; data: number[]}
   | {name: string; type: 'boolean'; data: boolean[]}
   | {name: string; type: 'string'; data: string[]}


### PR DESCRIPTION
This PR repairs type definitions to match the implementation
 * Table type changed to match SimpleTable implementation
 * Column type changed to match existing test `parses empty numeric values as null` defined in `fromFlux.test.ts`

These changes were discovered during the optimized integration of influxdb-client-js and giraffe.