### PR TITLE
feat(util): add queryTable

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -33,6 +33,7 @@
     "visualization"
   ],
   "devDependencies": {
+    "@influxdata/influxdb-client": "^1.6.0",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^8.1.0",
     "@types/d3-array": "^2.0.0",
@@ -68,6 +69,7 @@
     "leaflet-ant-path": "^1.3.0",
     "leaflet.markercluster": "^1.4.1",
     "memoize-one": "^5.0.2",
+    "nock": "^13.0.4",
     "node-sass": "^4.14.1",
     "papaparse": "^5.3.0",
     "prettier": "^1.19.1",

--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -33,7 +33,7 @@
     "visualization"
   ],
   "devDependencies": {
-    "@influxdata/influxdb-client": "^1.6.0",
+    "@influxdata/influxdb-client": "^1.7.0",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^8.1.0",
     "@types/d3-array": "^2.0.0",

--- a/giraffe/src/index.ts
+++ b/giraffe/src/index.ts
@@ -12,6 +12,7 @@ export {
   timeFormatter,
 } from './utils/formatters'
 export {getDomainDataFromLines} from './utils/lineData'
+export * from './utils/queryTable'
 
 // Transforms
 export {lineTransform} from './transforms/line'

--- a/giraffe/src/utils/newTable.ts
+++ b/giraffe/src/utils/newTable.ts
@@ -12,10 +12,20 @@ class SimpleTable implements Table {
       type: ColumnType
       data: ColumnData
     }
-  } = {}
+  }
 
-  constructor(length: number) {
+  constructor(
+    length: number,
+    columns: {
+      [colKey: string]: {
+        name: string
+        type: ColumnType
+        data: ColumnData
+      }
+    } = {}
+  ) {
     this.length = length
+    this.columns = columns
   }
 
   get columnKeys(): string[] {
@@ -113,7 +123,16 @@ class SimpleTable implements Table {
   }
 }
 
-export const newTable = (length: number): Table => new SimpleTable(length)
+export const newTable = (
+  length: number,
+  columns: {
+    [colKey: string]: {
+      name: string
+      type: ColumnType
+      data: ColumnData
+    }
+  } = {}
+): Table => new SimpleTable(length, columns)
 
 export const newTableFromConfig = (config: Config): Table => {
   if (!config) {

--- a/giraffe/src/utils/newTable.ts
+++ b/giraffe/src/utils/newTable.ts
@@ -22,7 +22,7 @@ class SimpleTable implements Table {
         type: ColumnType
         data: ColumnData
       }
-    } = {}
+    }
   ) {
     this.length = length
     this.columns = columns
@@ -107,9 +107,7 @@ class SimpleTable implements Table {
       )
     }
 
-    const table = new SimpleTable(this.length)
-
-    table.columns = {
+    const table = new SimpleTable(this.length, {
       ...this.columns,
       [columnKey]: {
         name: name || columnKey,
@@ -117,7 +115,7 @@ class SimpleTable implements Table {
         type,
         data,
       },
-    }
+    })
 
     return table
   }

--- a/giraffe/src/utils/queryTable.test.ts
+++ b/giraffe/src/utils/queryTable.test.ts
@@ -1,0 +1,187 @@
+import {queryTable} from './queryTable'
+// @influxdata/influxdb-client uses node transport in tests (tests run in node), therefore nock is used to mock HTTP
+import nock from 'nock'
+import {InfluxDB} from '@influxdata/influxdb-client'
+
+const url = 'http://test'
+const queryApi = new InfluxDB({url}).getQueryApi('whatever')
+
+describe('queryTable', () => {
+  beforeEach(() => {
+    nock.disableNetConnect()
+  })
+  afterEach(() => {
+    nock.cleanAll()
+    nock.enableNetConnect()
+  })
+  it('can parse a Flux CSV with mismatched schemas', async () => {
+    const CSV = `#group,false,false,true,true,false,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
+,,0,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:33Z,10,usage_guest,cpu,cpu-total,oox4k.local
+,,1,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:43Z,20,usage_guest,cpu,cpu-total,oox4k.local
+
+#group,false,false,true,true,false,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
+,,2,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:33Z,thirty,usage_guest,cpu,cpu0,oox4k.local
+,,3,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:43Z,fourty,usage_guest,cpu,cpu0,oox4k.local`
+
+    nock(url)
+      .post(/.*/)
+      .reply(200, CSV)
+    const table = await queryTable(queryApi, 'ignored')
+
+    expect(table.getColumn('result', 'string')).toEqual([
+      '_result',
+      '_result',
+      '_result',
+      '_result',
+    ])
+
+    expect(table.getColumn('_start', 'time')).toEqual([
+      1549064312524,
+      1549064312524,
+      1549064312524,
+      1549064312524,
+    ])
+
+    expect(table.getColumn('_stop', 'time')).toEqual([
+      1549064342524,
+      1549064342524,
+      1549064342524,
+      1549064342524,
+    ])
+
+    expect(table.getColumn('_time', 'time')).toEqual([
+      1549064313000,
+      1549064323000,
+      1549064313000,
+      1549064323000,
+    ])
+
+    expect(table.getColumn('_value (number)', 'number')).toEqual([
+      10,
+      20,
+      undefined,
+      undefined,
+    ])
+
+    expect(table.getColumn('_value (string)', 'string')).toEqual([
+      undefined,
+      undefined,
+      'thirty',
+      'fourty',
+    ])
+
+    expect(table.getColumn('_field', 'string')).toEqual([
+      'usage_guest',
+      'usage_guest',
+      'usage_guest',
+      'usage_guest',
+    ])
+
+    expect(table.getColumn('_measurement', 'string')).toEqual([
+      'cpu',
+      'cpu',
+      'cpu',
+      'cpu',
+    ])
+
+    expect(table.getColumn('cpu', 'string')).toEqual([
+      'cpu-total',
+      'cpu-total',
+      'cpu0',
+      'cpu0',
+    ])
+
+    expect(table.getColumn('host', 'string')).toEqual([
+      'oox4k.local',
+      'oox4k.local',
+      'oox4k.local',
+      'oox4k.local',
+    ])
+
+    expect(table.getColumn('table', 'number')).toEqual([0, 1, 2, 3])
+
+    expect(table.getColumnName('_value (number)')).toEqual('_value')
+
+    expect(table.getColumnName('_value (string)')).toEqual('_value')
+  })
+
+  it('uses the default annotation to fill in empty values', async () => {
+    const CSV = `#group,false,false,true,true,true,true
+#datatype,string,long,string,string,long,long
+#default,_result,,,cpu,,6
+,result,table,a,b,c,d
+,,1,usage_guest,,4,
+,,1,usage_guest,,5,`
+
+    nock(url)
+      .post(/.*/)
+      .reply(200, CSV)
+    const actual = await queryTable(queryApi, 'ignored')
+
+    expect(actual.getColumn('result')).toEqual(['_result', '_result'])
+    expect(actual.getColumn('a')).toEqual(['usage_guest', 'usage_guest'])
+    expect(actual.getColumn('b')).toEqual(['cpu', 'cpu'])
+    expect(actual.getColumn('c')).toEqual([4, 5])
+    expect(actual.getColumn('d')).toEqual([6, 6])
+  })
+
+  it('parses empty numeric values as null', async () => {
+    const CSV = `#group,false,false,true,true,false,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
+,,0,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:33Z,10,usage_guest,cpu,cpu-total,oox4k.local
+,,1,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:43Z,,usage_guest,cpu,cpu-total,oox4k.local`
+
+    nock(url)
+      .post(/.*/)
+      .reply(200, CSV)
+    const table = await queryTable(queryApi, 'ignored')
+
+    expect(table.getColumn('_value')).toEqual([10, null])
+  })
+
+  it('handles newlines inside string values', async () => {
+    const CSV = `#group,false,false,false,false
+#datatype,string,long,string,long
+#default,_result,,,
+,result,table,message,value
+,,0,howdy,5
+,,0,"hello
+
+there",5
+,,0,hi,6
+
+#group,false,false,false,false
+#datatype,string,long,string,long
+#default,_result,,,
+,result,table,message,value
+,,1,howdy,5
+,,1,"hello
+
+there",5
+,,1,hi,6`
+
+    nock(url)
+      .post(/.*/)
+      .reply(200, CSV)
+    const table = await queryTable(queryApi, 'ignored')
+
+    expect(table.getColumn('value')).toEqual([5, 5, 6, 5, 5, 6])
+
+    expect(table.getColumn('message')).toEqual([
+      'howdy',
+      'hello\n\nthere',
+      'hi',
+      'howdy',
+      'hello\n\nthere',
+      'hi',
+    ])
+  })
+})

--- a/giraffe/src/utils/queryTable.ts
+++ b/giraffe/src/utils/queryTable.ts
@@ -1,0 +1,251 @@
+import {
+  ParameterizedQuery,
+  QueryApi,
+  FluxTableMetaData,
+  ColumnType as ClientColumnType,
+  Cancellable,
+  FluxResultObserver,
+} from '@influxdata/influxdb-client'
+import {Table, ColumnType, ColumnData} from '../types'
+import {newTable} from './newTable'
+
+/**
+ * Stores data and metadata of a result column.
+ */
+interface ColumnStore {
+  /** column name */
+  name: string
+  /** column type */
+  type: ColumnType
+  /** column data */
+  data: ColumnData
+  /** converts string to column value */
+  toValue: (row: string[]) => number | string | boolean | null
+  /** marker to indicate that this column can have multiple keys  */
+  multipleTypes?: true
+  /** it this column part of the group key */
+  group?: boolean
+}
+
+function toTableColumns(
+  columns: Record<string, ColumnStore>,
+  tableLength: number
+): Record<string, ColumnStore> {
+  return Object.keys(columns).reduce((acc, val) => {
+    const col = columns[val]
+    if (!col.multipleTypes) {
+      acc[val] = col
+      ;(col.data as any).length = tableLength // extend the array length, required (and tested)
+    }
+    return acc
+  }, {} as Record<string, ColumnStore>)
+}
+
+/**
+ * AcceptRowFunction allows to accept/reject specific rows or terminate processing.
+ * @param row CSV data row
+ * @param tableMeta CSV table metadata including column definition
+ * @return true to accept row, false to skip row, undefined means stop processing
+ **/
+export type AcceptRowFunction = (
+  row: string[],
+  tableMeta: FluxTableMetaData
+) => true | false | undefined
+
+/**
+ * Contains parameters that optimize/drive creation of the query result Table.
+ */
+export interface TableOptions {
+  /**
+   * Accept allows to accept/reject specific rows or terminate processing.
+   **/
+  accept?: AcceptRowFunction
+  /** column keys to collect in the table, undefined means all columns */
+  columns?: string[]
+}
+
+/**
+ * Create an accept function that stops processing
+ * after the specified count of rows is processed.
+ * @param size maximum processed rows
+ */
+export function maxTableLength(max: number): AcceptRowFunction {
+  let size = 0
+  return () => {
+    if (size >= max) return undefined // stop processing
+    size++
+    return true
+  }
+}
+
+/**
+ * Creates influxdb-client-js's FluxResultObserver that collects row results to a Table instance
+ * @param resolve called when the Table is collected
+ * @param reject called upon error
+ * @param tableOptions tableOptions allow to filter or even stop the processing of rows, or restrict the columns to collect
+ * @return FluxResultObserver that collects rows to a table instance
+ */
+export function createFluxResultObserver(
+  resolve: (value: Table) => void,
+  reject: (reason?: any) => void,
+  tableOptions: TableOptions = {}
+): FluxResultObserver<string[]> {
+  const {accept = () => true, columns: onlyColumns} = tableOptions
+  const columns: Record<string, ColumnStore> = {}
+  let dataColumns: ColumnStore[]
+  let lastTableMeta: FluxTableMetaData = undefined
+  let tableSize = 0
+  let cancellable: Cancellable
+  return {
+    next(row: string[], tableMeta: FluxTableMetaData) {
+      switch (accept(row, tableMeta)) {
+        case true:
+          break
+        case false:
+          return
+        default:
+          cancellable.cancel()
+      }
+      if (tableMeta !== lastTableMeta) {
+        dataColumns = []
+        for (const metaCol of tableMeta.columns) {
+          const type = toGiraffeColumnType(metaCol.dataType)
+          if (onlyColumns && !onlyColumns.includes(metaCol.label)) {
+            continue // exclude this column
+          }
+
+          // handle the rare situation of having columns with the same name, but different type
+          let columnKey = metaCol.label
+          let existingColumn = columns[columnKey]
+          if (existingColumn) {
+            if (existingColumn.multipleTypes) {
+              // multiple column types of the same name already found
+              // use type-specific column key
+              columnKey = `${metaCol.label} (${type})`
+              existingColumn = columns[columnKey]
+            } else if (existingColumn.type !== type) {
+              // move the existing key to a type-specific key
+              columns[
+                `${existingColumn.name} (${existingColumn.type})`
+              ] = existingColumn
+              // occupy the column by a multiType virtual column
+              columns[metaCol.label] = {
+                name: metaCol.label,
+                type: existingColumn.type,
+                data: [],
+                multipleTypes: true,
+                toValue: () => '',
+              }
+              //
+              columnKey = `${metaCol.label} (${type})`
+              existingColumn = columns[columnKey]
+            }
+          }
+          const column = {
+            name: metaCol.label,
+            type,
+            data: existingColumn ? existingColumn.data : [],
+            group: metaCol.group,
+            toValue: toValueFn(metaCol.index, type, metaCol.defaultValue),
+          }
+
+          dataColumns.push(column)
+          columns[columnKey] = column
+        }
+        lastTableMeta = tableMeta
+      }
+      for (let i = 0; i < dataColumns.length; i++) {
+        const column = dataColumns[i]
+        column.data[tableSize] = column.toValue(row) as
+          | string
+          | number
+          | boolean // TODO wrong type definition in giraffe
+      }
+      tableSize++
+    },
+    complete() {
+      resolve(newTable(tableSize, toTableColumns(columns, tableSize)))
+    },
+    error(e: Error) {
+      if (e?.name === 'AbortError') {
+        resolve(newTable(tableSize, toTableColumns(columns, tableSize)))
+      }
+      reject(e)
+    },
+    useCancellable(val: Cancellable) {
+      cancellable = val
+    },
+  }
+}
+
+/**
+ * Executes a flux query and iterrativelly collects results into a giraffe's Table depending on the TableOptions supplied.
+ *
+ * @param queryApi InfluxDB client's QueryApi instance
+ * @param query query to execute
+ * @param tableOptions tableOptions allows to filter or even stop the processing of rows, or restrict the columns to collect
+ * @return Promise  with query results
+ */
+export function queryTable(
+  queryApi: QueryApi,
+  query: string | ParameterizedQuery,
+  tableOptions: TableOptions = {}
+): Promise<Table> {
+  return new Promise<Table>((resolve, reject) => {
+    queryApi.queryRows(
+      query,
+      createFluxResultObserver(resolve, reject, tableOptions)
+    )
+  })
+}
+
+/**
+ * Creates a function that returns a column value from row data.
+ *
+ * @param rowIndex index of a string value in the row data
+ * @param type column type
+ * @param def default value
+ * @returns column value to store in a table
+ */
+function toValueFn(
+  rowIndex: number,
+  type: ColumnType,
+  def: string
+): (row: string[]) => number | string | boolean | null {
+  switch (type) {
+    case 'boolean':
+      return (row: string[]) =>
+        (row[rowIndex] === '' ? def : row[rowIndex]) === 'true'
+    case 'number':
+      return (row: string[]) => {
+        const val = row[rowIndex] === '' ? def : row[rowIndex]
+        return val === '' ? null : Number(val)
+      }
+    case 'time':
+      return (row: string[]) =>
+        Date.parse(row[rowIndex] === '' ? def : row[rowIndex])
+    default:
+      return (row: string[]) => (row[rowIndex] === '' ? def : row[rowIndex])
+  }
+}
+
+/**
+ * Converts between columns types.
+ *
+ * @param clientType @influxdata/influxdb-client column type
+ * @returns @influxdata/giraffe column type
+ */
+function toGiraffeColumnType(clientType: ClientColumnType): ColumnType {
+  // from: 'boolean' | 'unsignedLong' | 'long' | 'double' | 'string' | 'base64Binary' | 'dateTime:RFC3339' | 'duration'
+  // to:   'number' | 'string' | 'time' | 'boolean'
+  switch (clientType) {
+    case 'boolean':
+      return 'boolean'
+    case 'unsignedLong':
+    case 'long':
+    case 'double':
+      return 'number'
+    default:
+      return clientType.startsWith('dateTime') ? 'time' : 'string'
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,10 +1129,10 @@
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
-"@influxdata/influxdb-client@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/influxdb-client/-/influxdb-client-1.6.0.tgz#46da50714742dd73c99c66f0e7379be9212477b0"
-  integrity sha512-1WHusKmW88P//diAiAXDuO8Fpe5ju7e4QQCKcoPRZstXCGhICYPg8mcIBmurDJMHIUTziCZZjYxR+9jlyXuNaA==
+"@influxdata/influxdb-client@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/influxdb-client/-/influxdb-client-1.7.0.tgz#42e5ec002eff8c59182cb52765b7f94dac382a56"
+  integrity sha512-Qa4vV5W2NroETreVA2wvVlfZV12sda5S7Z57Kn5/5J4XDhglrFo5IOWbvEne+ROgPCvZ1ufHdrdbjobm+n0BSg==
 
 "@jest/console@^24.7.1":
   version "24.7.1"
@@ -8348,6 +8348,7 @@ lodash.reduce@^4.3.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
   integrity sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=
+
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,6 +1129,11 @@
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
+"@influxdata/influxdb-client@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/influxdb-client/-/influxdb-client-1.6.0.tgz#46da50714742dd73c99c66f0e7379be9212477b0"
+  integrity sha512-1WHusKmW88P//diAiAXDuO8Fpe5ju7e4QQCKcoPRZstXCGhICYPg8mcIBmurDJMHIUTziCZZjYxR+9jlyXuNaA==
+
 "@jest/console@^24.7.1":
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"
@@ -7897,7 +7902,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stringify-safe@5.0.x, json-stringify-safe@~5.0.1:
+json-stringify-safe@5.0.x, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -8343,6 +8348,10 @@ lodash.reduce@^4.3.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
   integrity sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
 lodash.some@^4.6.0:
   version "4.6.0"
@@ -8991,6 +9000,16 @@ no-case@^2.2.0:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
+
+nock@^13.0.4:
+  version "13.0.4"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.0.4.tgz#9fb74db35d0aa056322e3c45be14b99105cd7510"
+  integrity sha512-alqTV8Qt7TUbc74x1pKRLSENzfjp4nywovcJgi/1aXDiUxXdt7TkruSTF5MDWPP7UoPVgea4F9ghVdmX0xxnSA==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash.set "^4.3.2"
+    propagate "^2.0.0"
 
 node-ask@^1.0.1:
   version "1.0.1"
@@ -10542,6 +10561,11 @@ prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, 
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 property-information@^5.0.0, property-information@^5.0.1:
   version "5.1.0"


### PR DESCRIPTION
__Proposal:__
This PR adds a new 'queryTable' function that executes flux query (against InfluxDB server) and collects results into a Table instance which can be then directly used in giraffe's Plot. This `queryTable` function is implemented using the official InfluxDB v2 client library, which
- uses fetch [readable stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Using_readable_streams) to read data as they go with minimized memory footprint (comparing to receiving the whole CSV response as text)
- allows aborting data retrieval, for example after reaching maximum table rows 
- provides efficient flux response processing, my measurements show up to 50% better processing time than fromFlux(CSV_RESPONSE_TEXT).table
- is fully tested

Moreover, the giraffe rollup distribution completely tree-shakes @influxdata/influxdb-client, since the new code only depends on 'influxdb-client' interfaces.

__Current behavior:__
This library currently does not explain how to get the data to render, it assumes that the user already knows. The fact is that the effective retrieval and processing of response data is not trivial.

__Desired behavior:__
I'd like to have a function that queries InfluxDB and returns a Table that is directly suitable for use in giraffe. This function will also ensure that (by default) at most 100_000 query rows are returned to avoid 'out of memory' issues in the browser.

```
const api = new InfluxDB({url, token}).getQueryApi(org)
const table = await queryTable(api, 'from(bucket: "my-bucket") |> range(start: -30d)' /*, {maxTableRows: 100000} */)
```

__Alternatives considered:__

```
const queryApi = new InfluxDB({url, token}).getQueryApi(org)
const text = await queryApi.queryRaw( 'from(bucket: "my-bucket") |> range(start: -30d)')
const table = fromFlux(text).table
```
works fine, but the solution provided herein is better, because
- it aborts the processing of big results
- it uses an optimized and fully tested code that parses CSV response on the fly

__Use case:__
Why is this important (helps with prioritizing requests)?
From a user perspective, it connects giraffe visualizations to real data from InfluxDB.

__TODO:__
- once we agree that this should be part of giraffe, a top-level readme should be updated with the usage of `queryTable` .