### PR TITLE
feat: add legendOpacity to the Tooltip

### DIFF
--- a/giraffe/README.md
+++ b/giraffe/README.md
@@ -282,6 +282,10 @@ Here is an example of turning a result in comma separate values (CSV) from Flux 
 
 - **legendColumns**: _array[string, ...]. Optional._ When included, this array will determine which column key names that should be included in the legend (tooltip). If this option is included as an empty array, the legend will be empty.
 
+- **legendOpacity**: _number. Optional. Defaults to 1.0 when excluded._ The [_CSS opacity_](https://developer.mozilla.org/en-US/docs/Web/CSS/opacity) of the entire `<Tooltip>` element (or legend). 0 means the legend is invisible, while 1.0 means the legend covers anything underneath.
+
+- **legendOrientationThreshold**: _number. Optional. Defaults to undefined when excluded._ The number of columns in the legend that will determine the direction of columns in the legend. When _undefined_ or when the total number of columns is less than or equal to it, the columns in the tooltip will display horizontally. When the total number of columns is greater, the columns will display vertically.
+
 ## Utility Functions
 
 Giraffe comes with utility functions.

--- a/giraffe/src/components/Tooltip.tsx
+++ b/giraffe/src/components/Tooltip.tsx
@@ -28,7 +28,7 @@ export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
     if (legendOpacity >= 0 && legendOpacity <= 1.0) {
       return legendOpacity
     }
-    return undefined
+    return 1.0
   }, [legendOpacity])
 
   const columns = columnsWhitelist

--- a/giraffe/src/components/Tooltip.tsx
+++ b/giraffe/src/components/Tooltip.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {FunctionComponent} from 'react'
+import {FunctionComponent, useMemo} from 'react'
 import {createPortal} from 'react-dom'
 
 import {TooltipData, Config} from '../types'
@@ -20,8 +20,16 @@ export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
     legendBackgroundColor: backgroundColor,
     legendBorder: border,
     legendColumns: columnsWhitelist,
+    legendOpacity,
     legendOrientationThreshold: orientationThreshold,
   } = config
+
+  const tooltipOpacity = useMemo(() => {
+    if (legendOpacity >= 0 && legendOpacity <= 1.0) {
+      return legendOpacity
+    }
+    return undefined
+  }, [legendOpacity])
 
   const columns = columnsWhitelist
     ? data.filter(column => columnsWhitelist.includes(column.key))
@@ -120,6 +128,7 @@ export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
     <div
       className="giraffe-tooltip"
       style={{
+        opacity: tooltipOpacity,
         border,
         font,
         backgroundColor,

--- a/giraffe/src/components/Tooltip.tsx
+++ b/giraffe/src/components/Tooltip.tsx
@@ -4,6 +4,7 @@ import {createPortal} from 'react-dom'
 
 import {TooltipData, Config} from '../types'
 import {useTooltipElement} from '../utils/useTooltipElement'
+import {TOOLTIP_MAXIMUM_OPACITY, TOOLTIP_MINIMUM_OPACITY} from '../constants'
 
 interface Props {
   data: TooltipData
@@ -25,10 +26,13 @@ export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
   } = config
 
   const tooltipOpacity = useMemo(() => {
-    if (legendOpacity >= 0 && legendOpacity <= 1.0) {
+    if (
+      legendOpacity >= TOOLTIP_MINIMUM_OPACITY &&
+      legendOpacity <= TOOLTIP_MAXIMUM_OPACITY
+    ) {
       return legendOpacity
     }
-    return 1.0
+    return TOOLTIP_MAXIMUM_OPACITY
   }, [legendOpacity])
 
   const columns = columnsWhitelist

--- a/giraffe/src/constants/index.ts
+++ b/giraffe/src/constants/index.ts
@@ -124,3 +124,7 @@ export const ALL_SYMBOL_TYPES: SymbolType[] = [
  * the same number of total lines as Line Plot.
  */
 export const BAND_COLOR_SCALE_CONSTANT = 3
+
+export const TOOLTIP_MINIMUM_OPACITY = 0
+
+export const TOOLTIP_MAXIMUM_OPACITY = 1.0

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -62,7 +62,7 @@ export interface Config {
   legendCrosshairColor?: string
   legendColumns?: string[]
   legendMessage?: string
-  // Number of series after which the legend will be displayed in "rotated" fashion
+  legendOpacity?: number
   legendOrientationThreshold?: number
 
   // The type of the y-axis column

--- a/stories/src/band.stories.tsx
+++ b/stories/src/band.stories.tsx
@@ -87,6 +87,12 @@ storiesOf('Band Chart', module)
     const upperColumnName = text('upperColumnName', 'max')
     const mainColumnName = text('mainColumnName', 'mean')
     const lowerColumnName = text('lowerColumnName', 'min')
+    const legendOpacity = number('Legend Opacity', 1.0, {
+      range: true,
+      min: 0,
+      max: 1.0,
+      step: 0.05,
+    })
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
 
     const config: Config = {
@@ -105,6 +111,7 @@ storiesOf('Band Chart', module)
       legendFont,
       tickFont,
       showAxes,
+      legendOpacity,
       legendOrientationThreshold,
       layers: [
         {
@@ -171,6 +178,12 @@ storiesOf('Band Chart', module)
     const upperColumnName = text('upperColumnName', '')
     const mainColumnName = text('mainColumnName', '')
     const lowerColumnName = text('lowerColumnName', '')
+    const legendOpacity = number('Legend Opacity', 1.0, {
+      range: true,
+      min: 0,
+      max: 1.0,
+      step: 0.05,
+    })
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
 
     const config: Config = {
@@ -189,6 +202,7 @@ storiesOf('Band Chart', module)
       legendFont,
       tickFont,
       showAxes,
+      legendOpacity,
       legendOrientationThreshold,
       layers: [
         {

--- a/stories/src/index.stories.tsx
+++ b/stories/src/index.stories.tsx
@@ -78,6 +78,12 @@ storiesOf('XY Plot', module)
       {auto: 'auto', x: 'x', y: 'y', xy: 'xy'},
       'auto'
     )
+    const legendOpacity = number('Legend Opacity', 1.0, {
+      range: true,
+      min: 0,
+      max: 1.0,
+      step: 0.05,
+    })
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
 
     const config: Config = {
@@ -94,6 +100,7 @@ storiesOf('XY Plot', module)
       legendFont,
       tickFont,
       showAxes,
+      legendOpacity,
       legendOrientationThreshold,
       layers: [
         {
@@ -156,6 +163,12 @@ storiesOf('XY Plot', module)
       {auto: 'auto', x: 'x', y: 'y', xy: 'xy'},
       'auto'
     )
+    const legendOpacity = number('Legend Opacity', 1.0, {
+      range: true,
+      min: 0,
+      max: 1.0,
+      step: 0.05,
+    })
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
 
     const config: Config = {
@@ -165,6 +178,7 @@ storiesOf('XY Plot', module)
         _value: val => `${Math.round(val)}%`,
       },
       legendFont,
+      legendOpacity,
       legendOrientationThreshold,
       tickFont,
       showAxes,


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/17227

As part of adjusting the Tooltip's columns, we allow the user to set the opacity of the tooltip so that large tooltips can be useful while still allowing visibility to the graph underneath.

Here is an example of opacity set to 0.5 (half)
<img width="1680" alt="Screen Shot 2020-09-18 at 4 48 25 PM" src="https://user-images.githubusercontent.com/10736577/93653740-1b501100-f9cf-11ea-9a2f-0731e69d6cb1.png">
