### PR TITLE
chore(getColumn): export GetColumn interface

### DIFF
--- a/giraffe/src/index.ts
+++ b/giraffe/src/index.ts
@@ -32,6 +32,7 @@ export {
   Formatter,
   GaugeTheme,
   GaugeLayerConfig,
+  GetColumn,
   HistogramLayerConfig,
   HistogramPosition,
   LayerConfig,


### PR DESCRIPTION
This PR adds GetColumn as an exported interface 