### PR TITLE
fix: use separator for large numbers

### DIFF
--- a/giraffe/src/utils/formatStatValue.test.ts
+++ b/giraffe/src/utils/formatStatValue.test.ts
@@ -223,4 +223,25 @@ describe('formatStatValue', () => {
       formatStatValue(value, {decimalPlaces: {isEnforced: true, digits: 3}})
     ).toEqual('2.000')
   })
+
+  test('has commas as separator for large numbers', () => {
+    value = 1234567
+    expect(formatStatValue(value)).toEqual('1,234,567')
+    expect(
+      formatStatValue(value, {decimalPlaces: {isEnforced: true, digits: 4}})
+    ).toEqual('1,234,567.0000')
+
+    value = 1_234_567
+    expect(formatStatValue(value)).toEqual('1,234,567')
+
+    value = 1234567.0
+    expect(
+      formatStatValue(value, {decimalPlaces: {isEnforced: true, digits: 4}})
+    ).toEqual('1,234,567.0000')
+
+    value = 1000000.0
+    expect(
+      formatStatValue(value, {decimalPlaces: {isEnforced: true, digits: 1}})
+    ).toEqual('1,000,000.0')
+  })
 })

--- a/giraffe/src/utils/formatStatValue.ts
+++ b/giraffe/src/utils/formatStatValue.ts
@@ -35,19 +35,16 @@ export const formatStatValue = (
   digits = Math.min(digits, MAX_DECIMAL_PLACES)
 
   if (isNumber(value)) {
-    const roundedValueAndDecimal = Number(value)
+    const [wholeNumber, fractionalNumber] = Number(value)
       .toFixed(digits)
       .split('.')
 
-    localeFormattedValue = Number(roundedValueAndDecimal[0]).toLocaleString(
-      undefined,
-      {
-        maximumFractionDigits: MAX_DECIMAL_PLACES,
-      }
-    )
+    localeFormattedValue = Number(wholeNumber).toLocaleString(undefined, {
+      maximumFractionDigits: MAX_DECIMAL_PLACES,
+    })
 
-    if (roundedValueAndDecimal.length > 1) {
-      localeFormattedValue += `.${roundedValueAndDecimal[1]}`
+    if (fractionalNumber) {
+      localeFormattedValue += `.${fractionalNumber}`
     }
   } else if (isString(value)) {
     localeFormattedValue = value

--- a/giraffe/src/utils/formatStatValue.ts
+++ b/giraffe/src/utils/formatStatValue.ts
@@ -35,14 +35,20 @@ export const formatStatValue = (
   digits = Math.min(digits, MAX_DECIMAL_PLACES)
 
   if (isNumber(value)) {
-    const roundedValue = Number(value).toFixed(digits)
-    const endsWithZero = /\.[1-9]{0,}0{1,}$/
+    const roundedValueAndDecimal = Number(value)
+      .toFixed(digits)
+      .split('.')
 
-    localeFormattedValue = endsWithZero.test(roundedValue)
-      ? roundedValue
-      : Number(roundedValue).toLocaleString(undefined, {
-          maximumFractionDigits: MAX_DECIMAL_PLACES,
-        })
+    localeFormattedValue = Number(roundedValueAndDecimal[0]).toLocaleString(
+      undefined,
+      {
+        maximumFractionDigits: MAX_DECIMAL_PLACES,
+      }
+    )
+
+    if (roundedValueAndDecimal.length > 1) {
+      localeFormattedValue += `.${roundedValueAndDecimal[1]}`
+    }
   } else if (isString(value)) {
     localeFormattedValue = value
   } else {


### PR DESCRIPTION
Closes #295 

Allows large numbers that end with decimal 0 to have numeric separators.
<img width="1680" alt="Screen Shot 2020-09-25 at 6 55 58 PM" src="https://user-images.githubusercontent.com/10736577/94327639-2f60b900-ff61-11ea-8439-5ac611a4352b.png">


