### PR TITLE
feat(fromFlux-original-type): added a reference to the original dataType in SimpleTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A React-based visualization library powering the data visualizations in the [InfluxDB 2.0](https://github.com/influxdata/influxdb/) UI.
 
-(*This library is currently in pre-beta.*)
+(_This library is currently in pre-beta._)
 
 ## 🦒 Features
 
@@ -46,7 +46,7 @@ npm install @influxdata/giraffe
 
 2. Build the config object.
 
-   The following properties are *required*:
+   The following properties are _required_:
 
    - `table` is data built using the newTable utilty function (also built from Flux results, see [Flux example](./README.md#example-using-flux))
    - `layers` is an array of objects that describe how to render the data.
@@ -60,17 +60,17 @@ npm install @influxdata/giraffe
    - legend (tooltip): labeling and styling
 
    For details on all configuration properties, see the [configuration guide](./giraffe/README.md#config).
-   
+
    **Example**
-   
+
    Here is an example of building the config object while skipping optional properties:
 
   <pre>
   // Example table and layer
 
   const table = newTable(3)
-    .addColumn('_time', 'time', [1589838401244, 1589838461244, 1589838521244])
-    .addColumn('_value', 'number', [2.58, 7.11, 4.79])
+    .addColumn('_time', 'dateTime:RFC3339', 'time', [1589838401244, 1589838461244, 1589838521244])
+    .addColumn('_value', 'double', 'number', [2.58, 7.11, 4.79])
 
   const lineLayer = {
     type: "line",

--- a/giraffe/README.md
+++ b/giraffe/README.md
@@ -36,8 +36,8 @@ A React-based visualization library powering the data visualizations in [InfluxD
   // Example table and layer
 
   const table = newTable(5)
-    .addColumn('_time', 'time', [1589838401244, 1589838461244, 1589838521244, 1589838581244, 1589838641244])
-    .addColumn('_value', 'number', [2.58, 7.11, 4.79, 8.89, 2.23])
+    .addColumn('_time', 'dateTime:RFC3339', 'time', [1589838401244, 1589838461244, 1589838521244, 1589838581244, 1589838641244])
+    .addColumn('_value', 'double', 'number', [2.58, 7.11, 4.79, 8.89, 2.23])
 
   const lineLayer = {
     type: "line",

--- a/giraffe/src/index.ts
+++ b/giraffe/src/index.ts
@@ -29,6 +29,7 @@ export {
   ColumnType,
   Config,
   DomainLabel,
+  FluxDataType,
   Formatter,
   GaugeTheme,
   GaugeLayerConfig,

--- a/giraffe/src/transforms/band.ts
+++ b/giraffe/src/transforms/band.ts
@@ -427,7 +427,7 @@ export const bandTransform = (
     fillColKeys
   )
 
-  const table = inputTable.addColumn(FILL, 'number', fillColumn)
+  const table = inputTable.addColumn(FILL, 'system', 'number', fillColumn)
   const xCol = table.getColumn(xColumnKey, 'number')
   const yCol = table.getColumn(yColumnKey, 'number')
   const bandIndexMap = getBandIndexMap(

--- a/giraffe/src/transforms/heatmap.test.ts
+++ b/giraffe/src/transforms/heatmap.test.ts
@@ -5,8 +5,8 @@ describe('heatmapTransform', () => {
   test('does not crash when passed zero-width domain', () => {
     // x domain of this table has a zero-width domain
     const table = newTable(3)
-      .addColumn('x', 'number', [1, 1, 1])
-      .addColumn('y', 'number', [0, 1, 2])
+      .addColumn('x', 'long', 'number', [1, 1, 1])
+      .addColumn('y', 'long', 'number', [0, 1, 2])
 
     expect(() => {
       heatmapTransform(table, 'x', 'y', null, null, 100, 100, 10, [
@@ -22,12 +22,12 @@ describe('heatmapTransform', () => {
     const startTime = Date.now()
     const interval = 100
     const table = newTable(3)
-      .addColumn(xColKey, 'time', [
+      .addColumn(xColKey, 'dateTime:RFC3339', 'time', [
         startTime,
         startTime + interval,
         startTime + interval * 2,
       ])
-      .addColumn(yColKey, 'number', [0, 1, 2])
+      .addColumn(yColKey, 'long', 'number', [0, 1, 2])
 
     const width = 987
     const height = 788
@@ -54,12 +54,12 @@ describe('heatmapTransform', () => {
     const startTime = Date.now()
     const interval = 100
     const table = newTable(3)
-      .addColumn(xColKey, 'time', [
+      .addColumn(xColKey, 'dateTime:RFC3339', 'time', [
         startTime,
         startTime + interval,
         startTime + interval * 2,
       ])
-      .addColumn(yColKey, 'number', [0, 1, 2])
+      .addColumn(yColKey, 'long', 'number', [0, 1, 2])
 
     const width = 987
     const height = 788

--- a/giraffe/src/transforms/heatmap.ts
+++ b/giraffe/src/transforms/heatmap.ts
@@ -70,6 +70,16 @@ export const bin2d = (
   const xColData = table.getColumn(xColKey, 'number')
   const yColData = table.getColumn(yColKey, 'number')
   const xColType = table.getColumnType(xColKey) as 'time' | 'number'
+  const xOriginalColType = table.getOriginalColumnType(xColKey) as
+    | 'dateTime:RFC3339'
+    | 'long'
+    | 'double'
+    | 'unsignedLong'
+  const yOriginalColType = table.getOriginalColumnType(yColKey) as
+    | 'dateTime:RFC3339'
+    | 'long'
+    | 'double'
+    | 'unsignedLong'
   const yColType = table.getColumnType(yColKey) as 'time' | 'number'
 
   const xBinCount = Math.max(Math.floor(width / (binSize > 0 ? binSize : 1)), 1)
@@ -136,11 +146,11 @@ export const bin2d = (
   }
 
   const heatmapTable = newTable(xMinData.length)
-    .addColumn(X_MIN, xColType, xMinData)
-    .addColumn(X_MAX, xColType, xMaxData)
-    .addColumn(Y_MIN, yColType, yMinData)
-    .addColumn(Y_MAX, yColType, yMaxData)
-    .addColumn(COUNT, 'number', countData)
+    .addColumn(X_MIN, xOriginalColType, xColType, xMinData)
+    .addColumn(X_MAX, xOriginalColType, xColType, xMaxData)
+    .addColumn(Y_MIN, yOriginalColType, yColType, yMinData)
+    .addColumn(Y_MAX, yOriginalColType, yColType, yMaxData)
+    .addColumn(COUNT, 'system', 'number', countData)
 
   return heatmapTable
 }

--- a/giraffe/src/transforms/histogram.test.ts
+++ b/giraffe/src/transforms/histogram.test.ts
@@ -9,8 +9,8 @@ const valueData = [70, 56, 60, 100, 76, 0, 63, 48, 79, 67]
 describe('bin', () => {
   test('with a single group', () => {
     const table = newTable(10)
-      .addColumn('_value', 'number', valueData)
-      .addColumn(FILL, 'number', [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+      .addColumn('_value', 'double', 'number', valueData)
+      .addColumn(FILL, 'double', 'number', [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
     const actual = bin(table, '_value', extent(valueData), 5, 'stacked')
 
@@ -24,8 +24,8 @@ describe('bin', () => {
 
   test('with four groups', () => {
     const table = newTable(10)
-      .addColumn('_value', 'number', valueData)
-      .addColumn(FILL, 'number', [0, 0, 0, 1, 1, 2, 2, 2, 3, 3])
+      .addColumn('_value', 'double', 'number', valueData)
+      .addColumn(FILL, 'double', 'number', [0, 0, 0, 1, 1, 2, 2, 2, 3, 3])
 
     const actual = bin(table, '_value', extent(valueData), 5, 'stacked')
 
@@ -80,8 +80,8 @@ describe('bin', () => {
 
   test('with overlaid positioning', () => {
     const table = newTable(10)
-      .addColumn('_value', 'number', valueData)
-      .addColumn(FILL, 'number', [0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
+      .addColumn('_value', 'double', 'number', valueData)
+      .addColumn(FILL, 'double', 'number', [0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
 
     const actual = bin(table, '_value', extent(valueData), 5, 'overlaid')
 
@@ -118,8 +118,8 @@ describe('bin', () => {
 
   test('with a widened x domain', () => {
     const table = newTable(10)
-      .addColumn('_value', 'number', valueData)
-      .addColumn(FILL, 'number', [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+      .addColumn('_value', 'double', 'number', valueData)
+      .addColumn(FILL, 'double', 'number', [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
     const actual = bin(table, '_value', [-200, 200], 10, 'stacked')
 
@@ -151,8 +151,8 @@ describe('bin', () => {
 
   test('with a narrowed x domain', () => {
     const table = newTable(10)
-      .addColumn('_value', 'number', valueData)
-      .addColumn(FILL, 'number', [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+      .addColumn('_value', 'double', 'number', valueData)
+      .addColumn(FILL, 'double', 'number', [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
     const actual = bin(table, '_value', [50, 80], 3, 'stacked')
 
@@ -168,8 +168,8 @@ describe('histogramTransform', () => {
   test('does not crash when passed zero-width domain', () => {
     // x domain of this table has a zero-width domain
     const table = newTable(3)
-      .addColumn('x', 'number', [1, 1, 1])
-      .addColumn('y', 'number', [0, 1, 2])
+      .addColumn('x', 'double', 'number', [1, 1, 1])
+      .addColumn('y', 'double', 'number', [0, 1, 2])
 
     expect(() => {
       histogramTransform(

--- a/giraffe/src/transforms/histogram.ts
+++ b/giraffe/src/transforms/histogram.ts
@@ -27,7 +27,7 @@ export const histogramTransform = (
   )
 
   const table = bin(
-    inputTable.addColumn(FILL, 'number', fillColumn),
+    inputTable.addColumn(FILL, 'system', 'number', fillColumn),
     xColumnKey,
     resolvedXDomain,
     binCount,
@@ -92,6 +92,10 @@ export const bin = (
 ): Table => {
   const xColData = table.getColumn(xColKey, 'number')
   const xColType = table.getColumnType(xColKey) as 'number'
+  const xOriginalColType = table.getOriginalColumnType(xColKey) as
+    | 'double'
+    | 'long'
+    | 'unsignedLong'
   const groupColData = table.getColumn(FILL, 'number')
 
   if (!binCount) {
@@ -168,12 +172,12 @@ export const bin = (
   }
 
   const binTable = newTable(binCount * groupIDs.length)
-    .addColumn(X_MIN, xColType, xMinData)
-    .addColumn(X_MAX, xColType, xMaxData)
-    .addColumn(Y_MIN, 'number', yMinData)
-    .addColumn(Y_MAX, 'number', yMaxData)
-    .addColumn(COUNT, 'number', countData)
-    .addColumn(FILL, 'number', fillData)
+    .addColumn(X_MIN, xOriginalColType, xColType, xMinData)
+    .addColumn(X_MAX, xOriginalColType, xColType, xMaxData)
+    .addColumn(Y_MIN, 'system', 'number', yMinData)
+    .addColumn(Y_MAX, 'system', 'number', yMaxData)
+    .addColumn(COUNT, 'system', 'number', countData)
+    .addColumn(FILL, 'system', 'number', fillData)
 
   return binTable
 }

--- a/giraffe/src/transforms/line.ts
+++ b/giraffe/src/transforms/line.ts
@@ -65,7 +65,7 @@ export const lineTransform = (
     fillColKeys
   )
 
-  const table = inputTable.addColumn(FILL, 'number', fillColumn)
+  const table = inputTable.addColumn(FILL, 'system', 'number', fillColumn)
   const xCol = table.getColumn(xColumnKey, 'number')
   const yCol = table.getColumn(yColumnKey, 'number')
   const fillScale = getNominalColorScale(fillColumnMap, colors)

--- a/giraffe/src/transforms/mosaic.ts
+++ b/giraffe/src/transforms/mosaic.ts
@@ -96,10 +96,10 @@ export const mosaicTransform = (
         1554308748000  |   1554308758000 |       'mo'     | "b"  |  2
   */
   const table = newTable(tableLength)
-    .addColumn(X_MIN, 'number', xMinData) //startTimes
-    .addColumn(X_MAX, 'number', xMaxData) //endTimes
-    .addColumn(FILL, 'string', fillData) //values
-    .addColumn(SERIES, 'string', seriesData) //cpus (see storybook)
+    .addColumn(X_MIN, 'system', 'number', xMinData) //startTimes
+    .addColumn(X_MAX, 'system', 'number', xMaxData) //endTimes
+    .addColumn(FILL, 'string', 'string', fillData) //values
+    .addColumn(SERIES, 'string', 'string', seriesData) //cpus (see storybook)
 
   const resolvedXDomain = resolveDomain(xInputCol, xDomain)
   const resolvedYDomain = [0, valueStrings.length]

--- a/giraffe/src/transforms/scatter.ts
+++ b/giraffe/src/transforms/scatter.ts
@@ -23,8 +23,8 @@ export const scatterTransform = (
   )
 
   const table = inputTable
-    .addColumn(FILL, 'number', fillColumn)
-    .addColumn(SYMBOL, 'number', symbolColumn)
+    .addColumn(FILL, 'system', 'number', fillColumn)
+    .addColumn(SYMBOL, 'system', 'number', symbolColumn)
 
   const xCol = table.getColumn(xColumnKey, 'number')
   const yCol = table.getColumn(yColumnKey, 'number')

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -97,10 +97,12 @@ export interface Table {
   getColumn: GetColumn
   getColumnName: (columnKey: string) => string | null // null if the column is not available
   getColumnType: (columnKey: string) => ColumnType | null // null if the column is not available
+  getOriginalColumnType: (columnKey: string) => FluxDataType | null // null if the column is not available
   columnKeys: string[]
   length: number
   addColumn: (
     columnKey: string,
+    originalType: FluxDataType,
     type: ColumnType,
     data: ColumnData,
     name?: string
@@ -129,6 +131,15 @@ export type NumericColumnData =
 export type ColumnData = NumericColumnData | string[] | boolean[]
 
 export type ColumnType = 'number' | 'string' | 'time' | 'boolean'
+
+export type FluxDataType =
+  | 'boolean'
+  | 'unsignedLong'
+  | 'long'
+  | 'double'
+  | 'string'
+  | 'dateTime:RFC3339'
+  | 'system'
 
 export enum LayerTypes {
   RawFluxDataTable = 'flux data table',

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -102,7 +102,7 @@ export interface Table {
   length: number
   addColumn: (
     columnKey: string,
-    originalType: FluxDataType,
+    fluxDataType: FluxDataType,
     type: ColumnType,
     data: ColumnData,
     name?: string

--- a/giraffe/src/utils/PlotEnv.test.ts
+++ b/giraffe/src/utils/PlotEnv.test.ts
@@ -33,7 +33,7 @@ describe('PlotEnv', () => {
       const plotEnv = new PlotEnv()
 
       const aData = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
-      const table = newTable(10).addColumn('a', 'number', aData)
+      const table = newTable(10).addColumn('a', 'long', 'number', aData)
 
       const config: SizedConfig = {
         table,
@@ -66,7 +66,7 @@ describe('PlotEnv', () => {
       const plotEnv = new PlotEnv()
 
       const aData = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
-      const table = newTable(10).addColumn('a', 'number', aData)
+      const table = newTable(10).addColumn('a', 'long', 'number', aData)
 
       const config: SizedConfig = {
         table,
@@ -101,8 +101,8 @@ describe('PlotEnv', () => {
       const aData = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
       const bData = [10, 10, 10, 10, 10, 10, 10, 10, 10, 19]
       const table = newTable(10)
-        .addColumn('a', 'number', aData)
-        .addColumn('b', 'number', bData)
+        .addColumn('a', 'long', 'number', aData)
+        .addColumn('b', 'long', 'number', bData)
 
       const config: SizedConfig = {
         table,
@@ -135,7 +135,7 @@ describe('PlotEnv', () => {
       const plotEnv = new PlotEnv()
 
       const aData = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
-      const table = newTable(10).addColumn('a', 'number', aData)
+      const table = newTable(10).addColumn('a', 'long', 'number', aData)
 
       const config: SizedConfig = {
         table,
@@ -168,8 +168,8 @@ describe('PlotEnv', () => {
       const aData = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
       const bData = [10, 10, 10, 10, 10, 10, 10, 10, 10, 19]
       const table = newTable(10)
-        .addColumn('a', 'number', aData)
-        .addColumn('b', 'number', bData)
+        .addColumn('a', 'long', 'number', aData)
+        .addColumn('b', 'long', 'number', bData)
 
       const config: SizedConfig = {
         table,
@@ -199,8 +199,8 @@ describe('PlotEnv', () => {
       const aData = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
       const bData = [10, 10, 10, 10, 10, 10, 10, 10, 10, 19]
       const table = newTable(10)
-        .addColumn('a', 'number', aData)
-        .addColumn('b', 'number', bData)
+        .addColumn('a', 'long', 'number', aData)
+        .addColumn('b', 'long', 'number', bData)
 
       const config: SizedConfig = {
         table,
@@ -233,8 +233,8 @@ describe('PlotEnv', () => {
       const aData = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
       const bData = [10, 10, 10, 10, 10, 10, 10, 10, 10, 19]
       const table = newTable(10)
-        .addColumn('a', 'number', aData)
-        .addColumn('b', 'number', bData)
+        .addColumn('a', 'long', 'number', aData)
+        .addColumn('b', 'long', 'number', bData)
 
       const config: SizedConfig = {
         table,

--- a/giraffe/src/utils/fixtures/tooltip.ts
+++ b/giraffe/src/utils/fixtures/tooltip.ts
@@ -63,14 +63,14 @@ export const createSampleTable = (options: SampleTableOptions) => {
     }
   }
   const table = newTable(numberOfRecords)
-    .addColumn('_time', 'time', TIME_COL)
-    .addColumn('_value', 'number', VALUE_COL)
+    .addColumn('_time', 'dateTime:RFC3339', 'time', TIME_COL)
+    .addColumn('_value', 'system', 'number', VALUE_COL)
 
   if (plotType === LayerTypes.Scatter) {
     return table
-      .addColumn(POINT_KEY, 'string', DISK_COL)
-      .addColumn('__symbol', 'string', SYMBOL_COL)
-      .addColumn(HOST_KEY, 'string', HOST_COL)
+      .addColumn(POINT_KEY, 'string', 'string', DISK_COL)
+      .addColumn('__symbol', 'string', 'string', SYMBOL_COL)
+      .addColumn(HOST_KEY, 'string', 'string', HOST_COL)
   }
-  return table.addColumn(COLUMN_KEY, 'string', CPU_COL)
+  return table.addColumn(COLUMN_KEY, 'string', 'string', CPU_COL)
 }

--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -34,13 +34,13 @@ describe('fromFlux', () => {
         columns: {
           '_value (number)': {
             name: '_value',
-            originalType: 'long',
+            fluxDataType: 'long',
             type: 'number',
             data: [0, 161314315, undefined, 976, 0],
           },
           '_value (string)': {
             name: '_value',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: [
               undefined,
@@ -52,19 +52,19 @@ describe('fromFlux', () => {
           },
           result: {
             name: 'result',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: ['_result', '_result', '_result', '_result', '_result'],
           },
           table: {
             name: 'table',
-            originalType: 'long',
+            fluxDataType: 'long',
             type: 'number',
             data: [0, 1, 2, 3, 4],
           },
           _start: {
             name: '_start',
-            originalType: 'dateTime:RFC3339',
+            fluxDataType: 'dateTime:RFC3339',
             type: 'time',
             data: [
               1599255750122,
@@ -76,7 +76,7 @@ describe('fromFlux', () => {
           },
           _stop: {
             name: '_stop',
-            originalType: 'dateTime:RFC3339',
+            fluxDataType: 'dateTime:RFC3339',
             type: 'time',
             data: [
               1599601350122,
@@ -88,7 +88,7 @@ describe('fromFlux', () => {
           },
           _time: {
             name: '_time',
-            originalType: 'dateTime:RFC3339',
+            fluxDataType: 'dateTime:RFC3339',
             type: 'time',
             data: [
               1599599342000,
@@ -100,7 +100,7 @@ describe('fromFlux', () => {
           },
           _field: {
             name: '_field',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: [
               'rx_errors',
@@ -112,7 +112,7 @@ describe('fromFlux', () => {
           },
           _measurement: {
             name: '_measurement',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: [
               'docker_container_net',
@@ -124,7 +124,7 @@ describe('fromFlux', () => {
           },
           'com.docker.compose.config-hash': {
             name: 'com.docker.compose.config-hash',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: [
               '45fa1e93aad3798a2399d626ec9973dfcf5c15ed39a589ad8196f8e52fefd744',
@@ -136,25 +136,25 @@ describe('fromFlux', () => {
           },
           'com.docker.compose.container-number': {
             name: 'com.docker.compose.container-number',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: ['1', '1', '1', '1', '1'],
           },
           'com.docker.compose.oneoff': {
             name: 'com.docker.compose.oneoff',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: ['False', 'False', 'False', 'False', 'False'],
           },
           'com.docker.compose.project': {
             name: 'com.docker.compose.project',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: ['influx', 'influx', 'influx', 'influx', 'influx'],
           },
           'com.docker.compose.project.config_files': {
             name: 'com.docker.compose.project.config_files',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: [
               'compose/fig.cloud.yml,compose/fig.chronograf.yml,compose/fig.local.yml',
@@ -166,7 +166,7 @@ describe('fromFlux', () => {
           },
           'com.docker.compose.project.working_dir': {
             name: 'com.docker.compose.project.working_dir',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: [
               '/Users/asalem/go/src/github.com/monitor-ci/compose',
@@ -178,19 +178,19 @@ describe('fromFlux', () => {
           },
           'com.docker.compose.service': {
             name: 'com.docker.compose.service',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: ['telegraf', 'telegraf', 'telegraf', 'telegraf', 'telegraf'],
           },
           'com.docker.compose.version': {
             name: 'com.docker.compose.version',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: ['1.25.4', '1.25.4', '1.25.4', '1.25.4', '1.25.4'],
           },
           container_image: {
             name: 'container_image',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: [
               'influx_telegraf',
@@ -202,7 +202,7 @@ describe('fromFlux', () => {
           },
           container_name: {
             name: 'container_name',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: [
               'influx_telegraf_1',
@@ -214,19 +214,19 @@ describe('fromFlux', () => {
           },
           container_status: {
             name: 'container_status',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: ['running', 'running', 'running', 'running', 'running'],
           },
           container_version: {
             name: 'container_version',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: ['unknown', 'unknown', 'unknown', 'unknown', 'unknown'],
           },
           engine_host: {
             name: 'engine_host',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: [
               'docker-desktop',
@@ -238,7 +238,7 @@ describe('fromFlux', () => {
           },
           host: {
             name: 'host',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: [
               '5551e9bfb3bd',
@@ -250,19 +250,19 @@ describe('fromFlux', () => {
           },
           network: {
             name: 'network',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: ['eth0', undefined, undefined, 'eth0', 'eth0'],
           },
           server_version: {
             name: 'server_version',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: ['19.03.8', '19.03.8', '19.03.8', '19.03.8', '19.03.8'],
           },
           cpu: {
             name: 'cpu',
-            originalType: 'string',
+            fluxDataType: 'string',
             type: 'string',
             data: [undefined, 'cpu11', 'cpu11', undefined, undefined],
           },

--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -34,11 +34,13 @@ describe('fromFlux', () => {
         columns: {
           '_value (number)': {
             name: '_value',
+            originalType: 'long',
             type: 'number',
             data: [0, 161314315, undefined, 976, 0],
           },
           '_value (string)': {
             name: '_value',
+            originalType: 'string',
             type: 'string',
             data: [
               undefined,
@@ -50,12 +52,19 @@ describe('fromFlux', () => {
           },
           result: {
             name: 'result',
+            originalType: 'string',
             type: 'string',
             data: ['_result', '_result', '_result', '_result', '_result'],
           },
-          table: {name: 'table', type: 'number', data: [0, 1, 2, 3, 4]},
+          table: {
+            name: 'table',
+            originalType: 'long',
+            type: 'number',
+            data: [0, 1, 2, 3, 4],
+          },
           _start: {
             name: '_start',
+            originalType: 'dateTime:RFC3339',
             type: 'time',
             data: [
               1599255750122,
@@ -67,6 +76,7 @@ describe('fromFlux', () => {
           },
           _stop: {
             name: '_stop',
+            originalType: 'dateTime:RFC3339',
             type: 'time',
             data: [
               1599601350122,
@@ -78,6 +88,7 @@ describe('fromFlux', () => {
           },
           _time: {
             name: '_time',
+            originalType: 'dateTime:RFC3339',
             type: 'time',
             data: [
               1599599342000,
@@ -89,6 +100,7 @@ describe('fromFlux', () => {
           },
           _field: {
             name: '_field',
+            originalType: 'string',
             type: 'string',
             data: [
               'rx_errors',
@@ -100,6 +112,7 @@ describe('fromFlux', () => {
           },
           _measurement: {
             name: '_measurement',
+            originalType: 'string',
             type: 'string',
             data: [
               'docker_container_net',
@@ -111,6 +124,7 @@ describe('fromFlux', () => {
           },
           'com.docker.compose.config-hash': {
             name: 'com.docker.compose.config-hash',
+            originalType: 'string',
             type: 'string',
             data: [
               '45fa1e93aad3798a2399d626ec9973dfcf5c15ed39a589ad8196f8e52fefd744',
@@ -122,21 +136,25 @@ describe('fromFlux', () => {
           },
           'com.docker.compose.container-number': {
             name: 'com.docker.compose.container-number',
+            originalType: 'string',
             type: 'string',
             data: ['1', '1', '1', '1', '1'],
           },
           'com.docker.compose.oneoff': {
             name: 'com.docker.compose.oneoff',
+            originalType: 'string',
             type: 'string',
             data: ['False', 'False', 'False', 'False', 'False'],
           },
           'com.docker.compose.project': {
             name: 'com.docker.compose.project',
+            originalType: 'string',
             type: 'string',
             data: ['influx', 'influx', 'influx', 'influx', 'influx'],
           },
           'com.docker.compose.project.config_files': {
             name: 'com.docker.compose.project.config_files',
+            originalType: 'string',
             type: 'string',
             data: [
               'compose/fig.cloud.yml,compose/fig.chronograf.yml,compose/fig.local.yml',
@@ -148,6 +166,7 @@ describe('fromFlux', () => {
           },
           'com.docker.compose.project.working_dir': {
             name: 'com.docker.compose.project.working_dir',
+            originalType: 'string',
             type: 'string',
             data: [
               '/Users/asalem/go/src/github.com/monitor-ci/compose',
@@ -159,16 +178,19 @@ describe('fromFlux', () => {
           },
           'com.docker.compose.service': {
             name: 'com.docker.compose.service',
+            originalType: 'string',
             type: 'string',
             data: ['telegraf', 'telegraf', 'telegraf', 'telegraf', 'telegraf'],
           },
           'com.docker.compose.version': {
             name: 'com.docker.compose.version',
+            originalType: 'string',
             type: 'string',
             data: ['1.25.4', '1.25.4', '1.25.4', '1.25.4', '1.25.4'],
           },
           container_image: {
             name: 'container_image',
+            originalType: 'string',
             type: 'string',
             data: [
               'influx_telegraf',
@@ -180,6 +202,7 @@ describe('fromFlux', () => {
           },
           container_name: {
             name: 'container_name',
+            originalType: 'string',
             type: 'string',
             data: [
               'influx_telegraf_1',
@@ -191,16 +214,19 @@ describe('fromFlux', () => {
           },
           container_status: {
             name: 'container_status',
+            originalType: 'string',
             type: 'string',
             data: ['running', 'running', 'running', 'running', 'running'],
           },
           container_version: {
             name: 'container_version',
+            originalType: 'string',
             type: 'string',
             data: ['unknown', 'unknown', 'unknown', 'unknown', 'unknown'],
           },
           engine_host: {
             name: 'engine_host',
+            originalType: 'string',
             type: 'string',
             data: [
               'docker-desktop',
@@ -212,6 +238,7 @@ describe('fromFlux', () => {
           },
           host: {
             name: 'host',
+            originalType: 'string',
             type: 'string',
             data: [
               '5551e9bfb3bd',
@@ -223,16 +250,19 @@ describe('fromFlux', () => {
           },
           network: {
             name: 'network',
+            originalType: 'string',
             type: 'string',
             data: ['eth0', undefined, undefined, 'eth0', 'eth0'],
           },
           server_version: {
             name: 'server_version',
+            originalType: 'string',
             type: 'string',
             data: ['19.03.8', '19.03.8', '19.03.8', '19.03.8', '19.03.8'],
           },
           cpu: {
             name: 'cpu',
+            originalType: 'string',
             type: 'string',
             data: [undefined, 'cpu11', 'cpu11', undefined, undefined],
           },

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -19,12 +19,12 @@ type Column =
   | {
       name: string
       type: 'number'
-      originalType: FluxDataType
+      fluxDataType: FluxDataType
       data: Array<number | null>
     } //  parses empty numeric values as null
-  | {name: string; type: 'time'; originalType: FluxDataType; data: number[]}
-  | {name: string; type: 'boolean'; originalType: FluxDataType; data: boolean[]}
-  | {name: string; type: 'string'; originalType: FluxDataType; data: string[]}
+  | {name: string; type: 'time'; fluxDataType: FluxDataType; data: number[]}
+  | {name: string; type: 'boolean'; fluxDataType: FluxDataType; data: boolean[]}
+  | {name: string; type: 'string'; fluxDataType: FluxDataType; data: string[]}
 
 interface Columns {
   [columnKey: string]: Column
@@ -139,7 +139,7 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
         columns[columnKey] = {
           name: columnName,
           type: columnType,
-          originalType: annotationData.datatypeByColumnName[columnName],
+          fluxDataType: annotationData.datatypeByColumnName[columnName],
           data: [],
         } as Column
       }
@@ -165,9 +165,9 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
   resolveNames(columns, fluxGroupKeyUnion)
 
   const table = Object.entries(columns).reduce(
-    (table, [key, {name, originalType, type, data}]) => {
+    (table, [key, {name, fluxDataType, type, data}]) => {
       data.length = tableLength
-      return table.addColumn(key, originalType, type, data, name)
+      return table.addColumn(key, fluxDataType, type, data, name)
     },
     newTable(tableLength)
   )
@@ -207,7 +207,7 @@ export const fromFluxWithSchema = (fluxCSV: string): FromFluxResult => {
         columns[columnKey] = {
           name: columnName,
           type: columnType,
-          originalType: annotationData.datatypeByColumnName[columnName],
+          fluxDataType: annotationData.datatypeByColumnName[columnName],
           data: [],
         } as Column
       }
@@ -233,9 +233,9 @@ export const fromFluxWithSchema = (fluxCSV: string): FromFluxResult => {
   resolveNames(columns, fluxGroupKeyUnion)
 
   const table = Object.entries(columns).reduce(
-    (table, [key, {name, originalType, type, data}]) => {
+    (table, [key, {name, fluxDataType, type, data}]) => {
       data.length = tableLength
-      return table.addColumn(key, originalType, type, data, name)
+      return table.addColumn(key, fluxDataType, type, data, name)
     },
     newTable(tableLength)
   )

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -2,7 +2,7 @@ import {csvParse, csvParseRows} from 'd3-dsv'
 import Papa from 'papaparse'
 import {get, groupBy} from 'lodash'
 
-import {Schema, Table, ColumnType} from '../types'
+import {Schema, Table, ColumnType, FluxDataType} from '../types'
 import {assert} from './assert'
 import {newTable} from './newTable'
 
@@ -16,10 +16,15 @@ export interface FromFluxResult {
 }
 
 type Column =
-  | {name: string; type: 'number'; data: Array<number | null>} //  parses empty numeric values as null
-  | {name: string; type: 'time'; data: number[]}
-  | {name: string; type: 'boolean'; data: boolean[]}
-  | {name: string; type: 'string'; data: string[]}
+  | {
+      name: string
+      type: 'number'
+      originalType: FluxDataType
+      data: Array<number | null>
+    } //  parses empty numeric values as null
+  | {name: string; type: 'time'; originalType: FluxDataType; data: number[]}
+  | {name: string; type: 'boolean'; originalType: FluxDataType; data: boolean[]}
+  | {name: string; type: 'string'; originalType: FluxDataType; data: string[]}
 
 interface Columns {
   [columnKey: string]: Column
@@ -134,6 +139,7 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
         columns[columnKey] = {
           name: columnName,
           type: columnType,
+          originalType: annotationData.datatypeByColumnName[columnName],
           data: [],
         } as Column
       }
@@ -159,9 +165,9 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
   resolveNames(columns, fluxGroupKeyUnion)
 
   const table = Object.entries(columns).reduce(
-    (table, [key, {name, type, data}]) => {
+    (table, [key, {name, originalType, type, data}]) => {
       data.length = tableLength
-      return table.addColumn(key, type, data, name)
+      return table.addColumn(key, originalType, type, data, name)
     },
     newTable(tableLength)
   )
@@ -201,6 +207,7 @@ export const fromFluxWithSchema = (fluxCSV: string): FromFluxResult => {
         columns[columnKey] = {
           name: columnName,
           type: columnType,
+          originalType: annotationData.datatypeByColumnName[columnName],
           data: [],
         } as Column
       }
@@ -226,9 +233,9 @@ export const fromFluxWithSchema = (fluxCSV: string): FromFluxResult => {
   resolveNames(columns, fluxGroupKeyUnion)
 
   const table = Object.entries(columns).reduce(
-    (table, [key, {name, type, data}]) => {
+    (table, [key, {name, originalType, type, data}]) => {
       data.length = tableLength
-      return table.addColumn(key, type, data, name)
+      return table.addColumn(key, originalType, type, data, name)
     },
     newTable(tableLength)
   )

--- a/giraffe/src/utils/fromRows.ts
+++ b/giraffe/src/utils/fromRows.ts
@@ -45,7 +45,8 @@ export const fromRows = <T extends object>(
   }
 
   const table = Object.entries(columns).reduce(
-    (table, [key, values]) => table.addColumn(key, resolvedSchema[key], values),
+    (table, [key, values]) =>
+      table.addColumn(key, 'system', resolvedSchema[key], values),
     newTable(rows.length)
   )
 

--- a/giraffe/src/utils/getLatestValues.test.ts
+++ b/giraffe/src/utils/getLatestValues.test.ts
@@ -12,7 +12,7 @@ describe('getLatestValues', () => {
 
   test('finds the value when timestamp column is missing and only 1 row exists in the table', () => {
     const yColKey = '_value'
-    const table = newTable(1).addColumn(yColKey, 'number', [3.99])
+    const table = newTable(1).addColumn(yColKey, 'system', 'number', [3.99])
     const result = getLatestValues(table)
 
     expect(Array.isArray(result)).toEqual(true)
@@ -21,7 +21,7 @@ describe('getLatestValues', () => {
 
   test('gives an empty array when timestamp column is missing and there are multiple rows in the table', () => {
     const yColKey = '_value'
-    const table = newTable(4).addColumn(yColKey, 'number', [
+    const table = newTable(4).addColumn(yColKey, 'system', 'number', [
       0,
       1.67,
       2.32,
@@ -39,13 +39,13 @@ describe('getLatestValues', () => {
     const startTime = Date.now()
     const interval = 100
     const table = newTable(4)
-      .addColumn(xColKey, 'time', [
+      .addColumn(xColKey, 'dateTime:RFC3339', 'time', [
         startTime + interval * 4,
         startTime - interval,
         startTime + interval * 5,
         startTime + interval * 2,
       ])
-      .addColumn(yColKey, 'number', [0, 1.67, 2.32, 3.97])
+      .addColumn(yColKey, 'system', 'number', [0, 1.67, 2.32, 3.97])
     const result = getLatestValues(table)
 
     expect(Array.isArray(result)).toEqual(true)
@@ -58,12 +58,12 @@ describe('getLatestValues', () => {
     const startTime = Date.now()
     const interval = 100
     const table = newTable(3)
-      .addColumn(xColKey, 'time', [
+      .addColumn(xColKey, 'dateTime:RFC3339', 'time', [
         startTime,
         startTime + interval,
         startTime + interval * 2,
       ])
-      .addColumn(yColKey, 'number', [0, 4.67, 2.32])
+      .addColumn(yColKey, 'system', 'number', [0, 4.67, 2.32])
     const result = getLatestValues(table)
 
     expect(Array.isArray(result)).toEqual(true)
@@ -76,13 +76,13 @@ describe('getLatestValues', () => {
     const startTime = Date.now()
     const interval = 100
     const table = newTable(3)
-      .addColumn(xColKey, 'time', [
+      .addColumn(xColKey, 'dateTime:RFC3339', 'time', [
         startTime,
         startTime + interval,
         startTime + interval * 2,
       ])
-      .addColumn(yColKey, 'number', [2.32, 4.67, 0.01])
-      .addColumn('didItWork', 'boolean', [true, false, true])
+      .addColumn(yColKey, 'system', 'number', [2.32, 4.67, 0.01])
+      .addColumn('didItWork', 'boolean', 'boolean', [true, false, true])
     const result = getLatestValues(table)
 
     expect(Array.isArray(result)).toEqual(true)

--- a/giraffe/src/utils/newTable.ts
+++ b/giraffe/src/utils/newTable.ts
@@ -8,7 +8,7 @@ class SimpleTable implements Table {
   private columns: {
     [colKey: string]: {
       name: string
-      originalType: FluxDataType
+      fluxDataType: FluxDataType
       type: ColumnType
       data: ColumnData
     }
@@ -77,12 +77,12 @@ class SimpleTable implements Table {
       return null
     }
 
-    return column.originalType
+    return column.fluxDataType
   }
 
   addColumn(
     columnKey: string,
-    originalType: FluxDataType,
+    fluxDataType: FluxDataType,
     type: ColumnType,
     data: ColumnData,
     name?: string
@@ -103,7 +103,7 @@ class SimpleTable implements Table {
       ...this.columns,
       [columnKey]: {
         name: name || columnKey,
-        originalType,
+        fluxDataType,
         type,
         data,
       },

--- a/giraffe/src/utils/newTable.ts
+++ b/giraffe/src/utils/newTable.ts
@@ -82,7 +82,7 @@ class SimpleTable implements Table {
 
   addColumn(
     columnKey: string,
-    fluxDataType: FluxDataType = 'system',
+    fluxDataType: FluxDataType,
     type: ColumnType,
     data: ColumnData,
     name?: string

--- a/giraffe/src/utils/newTable.ts
+++ b/giraffe/src/utils/newTable.ts
@@ -82,7 +82,7 @@ class SimpleTable implements Table {
 
   addColumn(
     columnKey: string,
-    fluxDataType: FluxDataType,
+    fluxDataType: FluxDataType = 'system',
     type: ColumnType,
     data: ColumnData,
     name?: string

--- a/giraffe/src/utils/newTable.ts
+++ b/giraffe/src/utils/newTable.ts
@@ -1,4 +1,4 @@
-import {Table, ColumnType, ColumnData, Config} from '../types'
+import {Table, ColumnType, ColumnData, Config, FluxDataType} from '../types'
 import {fromFlux} from './fromFlux'
 
 // Don't export me!
@@ -8,6 +8,7 @@ class SimpleTable implements Table {
   private columns: {
     [colKey: string]: {
       name: string
+      originalType: FluxDataType
       type: ColumnType
       data: ColumnData
     }
@@ -69,8 +70,19 @@ class SimpleTable implements Table {
     return column.type
   }
 
+  getOriginalColumnType(columnKey: string): FluxDataType {
+    const column = this.columns[columnKey]
+
+    if (!column) {
+      return null
+    }
+
+    return column.originalType
+  }
+
   addColumn(
     columnKey: string,
+    originalType: FluxDataType,
     type: ColumnType,
     data: ColumnData,
     name?: string
@@ -91,6 +103,7 @@ class SimpleTable implements Table {
       ...this.columns,
       [columnKey]: {
         name: name || columnKey,
+        originalType,
         type,
         data,
       },

--- a/giraffe/src/utils/tooltip.test.ts
+++ b/giraffe/src/utils/tooltip.test.ts
@@ -54,7 +54,7 @@ describe('getPointsTooltipData', () => {
       plotType === 'line' ? COLUMN_KEY : HOST_KEY,
     ])
     fillScale = getNominalColorScale(fillColumnMap, NINETEEN_EIGHTY_FOUR)
-    sampleTable = sampleTable.addColumn(FILL, 'number', fillColumn)
+    sampleTable = sampleTable.addColumn(FILL, 'system', 'number', fillColumn)
 
     const fillColumnFromSampleTable = sampleTable.getColumn(FILL, 'number')
     fillColumn.forEach((item, index) =>

--- a/stories/src/data/bandLayer.ts
+++ b/stories/src/data/bandLayer.ts
@@ -26,8 +26,8 @@ for (let i = 0; i < numberOfRecords; i += 1) {
 }
 
 export const bandTable = newTable(numberOfRecords)
-  .addColumn('_field', 'string', FIELD_COL)
-  .addColumn('_measurement', 'string', MEASUREMENT_COL)
-  .addColumn('_time', 'time', TIME_COL)
-  .addColumn('_value', 'number', VALUE_COL)
-  .addColumn('cpu', 'string', CPU_COL)
+  .addColumn('_field', 'string', 'string', FIELD_COL)
+  .addColumn('_measurement', 'string', 'string', MEASUREMENT_COL)
+  .addColumn('_time', 'dateTime:RFC3339', 'time', TIME_COL)
+  .addColumn('_value', 'system', 'number', VALUE_COL)
+  .addColumn('cpu', 'string', 'string', CPU_COL)

--- a/stories/src/data/cpu.ts
+++ b/stories/src/data/cpu.ts
@@ -4013,7 +4013,7 @@ const CPU_HOST_COL = [
 ]
 
 export const CPU = newTable(1000)
-  .addColumn('_time', 'time', CPU_TIME_COL)
-  .addColumn('_value', 'number', CPU_VALUE_COL)
-  .addColumn('cpu', 'string', CPU_CPU_COL)
-  .addColumn('host', 'string', CPU_HOST_COL)
+  .addColumn('_time', 'dateTime:RFC3339', 'time', CPU_TIME_COL)
+  .addColumn('_value', 'system', 'number', CPU_VALUE_COL)
+  .addColumn('cpu', 'string', 'string', CPU_CPU_COL)
+  .addColumn('host', 'string', 'string', CPU_HOST_COL)

--- a/stories/src/data/cpuString.ts
+++ b/stories/src/data/cpuString.ts
@@ -4013,7 +4013,7 @@ const CPU_HOST_COL = [
 ]
 
 export const CPUString = newTable(1000)
-  .addColumn('_time', 'time', CPU_TIME_COL)
-  .addColumn('_value', 'string', CPU_VALUE_COL)
-  .addColumn('cpu', 'string', CPU_CPU_COL)
-  .addColumn('host', 'string', CPU_HOST_COL)
+  .addColumn('_time', 'dateTime:RFC3339', 'time', CPU_TIME_COL)
+  .addColumn('_value', 'string', 'string', CPU_VALUE_COL)
+  .addColumn('cpu', 'string', 'string', CPU_CPU_COL)
+  .addColumn('host', 'string', 'string', CPU_HOST_COL)

--- a/stories/src/data/gaugeLayer.ts
+++ b/stories/src/data/gaugeLayer.ts
@@ -24,7 +24,7 @@ export const gaugeTable = memoizeOne(
   (minValue: number, maxValue: number): Table => {
     createColumns(minValue, maxValue)
     return newTable(numberOfRecords)
-      .addColumn('_time', 'time', TIME_COL)
-      .addColumn('_value', 'number', VALUE_COL)
+      .addColumn('_time', 'dateTime:RFC3339', 'time', TIME_COL)
+      .addColumn('_value', 'system', 'number', VALUE_COL)
   }
 )

--- a/stories/src/data/mosaicDataSet.ts
+++ b/stories/src/data/mosaicDataSet.ts
@@ -61,7 +61,7 @@ const CPU_HOST_COL = [
 ]
 
 export const SERIES = newTable(12)
-  .addColumn('_time', 'time', CPU_TIME_COL)
-  .addColumn('_value', 'string', CPU_VALUE_COL)
-  .addColumn('cpu', 'string', CPU_COL)
-  .addColumn('host', 'string', CPU_HOST_COL)
+  .addColumn('_time', 'dateTime:RFC3339', 'time', CPU_TIME_COL)
+  .addColumn('_value', 'string', 'string', CPU_VALUE_COL)
+  .addColumn('cpu', 'string', 'string', CPU_COL)
+  .addColumn('host', 'string', 'string', CPU_HOST_COL)

--- a/stories/src/data/singleStatLayer.ts
+++ b/stories/src/data/singleStatLayer.ts
@@ -19,6 +19,6 @@ for (let i = 0; i < numberOfRecords; i += 1) {
 }
 
 export const singleStatTable = newTable(numberOfRecords)
-  .addColumn('_time', 'time', TIME_COL)
-  .addColumn('_value', 'number', VALUE_COL)
-  .addColumn('cpu', 'string', CPU_COL)
+  .addColumn('_time', 'dateTime:RFC3339', 'time', TIME_COL)
+  .addColumn('_value', 'system', 'number', VALUE_COL)
+  .addColumn('cpu', 'string', 'string', CPU_COL)

--- a/stories/src/data/stackedLineLayer.ts
+++ b/stories/src/data/stackedLineLayer.ts
@@ -74,10 +74,10 @@ for (let i = 0; i < numberOfRecords; i += 1) {
 }
 
 export const stackedLineTable = newTable(numberOfRecords)
-  .addColumn('_time', 'time', TIME_COL)
-  .addColumn('_value', 'number', VALUE_COL)
-  .addColumn('cpu', 'string', CPU_COL)
-  .addColumn('test_col_a', 'string', TEST_COL_A)
-  .addColumn('test_col_b', 'string', TEST_COL_B)
-  .addColumn('test_col_c', 'string', TEST_COL_C)
-  .addColumn('test_col_d', 'string', TEST_COL_D)
+  .addColumn('_time', 'dateTime:RFC3339', 'time', TIME_COL)
+  .addColumn('_value', 'system', 'number', VALUE_COL)
+  .addColumn('cpu', 'string', 'string', CPU_COL)
+  .addColumn('test_col_a', 'string', 'string', TEST_COL_A)
+  .addColumn('test_col_b', 'string', 'string', TEST_COL_B)
+  .addColumn('test_col_c', 'string', 'string', TEST_COL_C)
+  .addColumn('test_col_d', 'string', 'string', TEST_COL_D)

--- a/stories/src/sin.ts
+++ b/stories/src/sin.ts
@@ -24,6 +24,6 @@ for (let i = 0; i < tags.length; i++) {
 }
 
 export const SIN = newTable(size * tags.length)
-  .addColumn('x', 'number', xCol)
-  .addColumn('y', 'number', yCol)
-  .addColumn('tag', 'string', tagCol)
+  .addColumn('x', 'system', 'number', xCol)
+  .addColumn('y', 'system', 'number', yCol)
+  .addColumn('tag', 'string', 'string', tagCol)

--- a/stories/src/snapshotTests.stories.tsx
+++ b/stories/src/snapshotTests.stories.tsx
@@ -129,8 +129,8 @@ storiesOf('Snapshot Tests', module)
   })
   .add('binary prefix formatting', () => {
     const table = newTable(4)
-      .addColumn('time', 'number', [0, 1, 2, 3])
-      .addColumn('bytes', 'number', [
+      .addColumn('time', 'system', 'number', [0, 1, 2, 3])
+      .addColumn('bytes', 'system', 'number', [
         6799245312,
         6475784192,
         6419197952,


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/123

### Problem

SimpleTable converts the original data type for integers. By losing out on this context, the raw CSV view cannot properly map results based on the CSV string that's returned.

### Solution

Updated the SimpleTable class to include a reference to the originalType in each column. Added a method to the class in order to retrieve the relevant data when needed. After having some brief discussions with @drdelambre I added a default `system` type that is being set as the originalType whenever Giraffe sets a default `number` type since there is no concrete way of knowing whether the actual type is a `long`, `double`, or `unsignedLong`