### PR TITLE
feat: gauge default config

### DIFF
--- a/giraffe/src/components/GaugeLayer.tsx
+++ b/giraffe/src/components/GaugeLayer.tsx
@@ -17,11 +17,11 @@ interface Props {
 export const GaugeLayer: FunctionComponent<Props> = (props: Props) => {
   const {value, config} = props
   const {
-    prefix,
-    suffix,
-    tickPrefix,
-    tickSuffix,
-    decimalPlaces,
+    prefix = '',
+    suffix = '',
+    tickPrefix = '',
+    tickSuffix = '',
+    decimalPlaces = {},
     gaugeColors,
     gaugeSize = Math.PI,
     gaugeTheme = {},

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -198,14 +198,14 @@ export interface RawFluxDataTableLayerConfig {
 
 export interface GaugeLayerConfig {
   type: 'gauge' // do not refactor or restrict to LayerTypes.Gauge
-  prefix: string
-  suffix: string
-  tickPrefix: string
-  tickSuffix: string
-  decimalPlaces: DecimalPlaces
+  prefix?: string
+  suffix?: string
+  tickPrefix?: string
+  tickSuffix?: string
+  decimalPlaces?: DecimalPlaces
   gaugeColors: Color[]
   gaugeSize?: number
-  gaugeTheme?: GaugeTheme
+  gaugeTheme?: Partial<GaugeTheme>
 }
 
 export interface GaugeTheme {


### PR DESCRIPTION
## Proposed Changes

Gauge config parameters has default argument (are now optional):

` prefix, suffix, tickPrefix, tickSuffix ` has now default value `''`
`decimalPlaces` has now default value `{}`

When using `gaugeTheme` all parameters are optional. Missing parameters is filled in with default theme (already was implemented; only missing in interface - definition changed to be more user-friendly)

## Checklist

- [X] Rebased/mergeable
- [x] Tested
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
