### PR TITLE
fix: use color scaling consistently across all aspects of Band Plot

### DIFF
--- a/giraffe/src/components/BandHoverLayer.tsx
+++ b/giraffe/src/components/BandHoverLayer.tsx
@@ -11,6 +11,7 @@ import {drawLines} from '../utils/drawLines'
 import {drawLineHoverData} from '../utils/drawLineHoverData'
 import {useCanvas} from '../utils/useCanvas'
 import {BandHoverIndices} from '../utils/getBandHoverIndices'
+import {isNumber} from '../utils/isNumber'
 
 interface Props extends BandLayerProps {
   bandHoverIndices: BandHoverIndices
@@ -105,7 +106,10 @@ export const BandHoverLayer: FunctionComponent<Props> = ({
   const colors = []
   for (let i = 0; i < rowIndices.length; i += 1) {
     const lineIndex = groupColData[rowIndices[i]]
-    colors.push(spec.lineData[lineIndex].fill)
+    const lineData = spec.lineData || {}
+    if (isNumber(lineIndex) && lineData[lineIndex]) {
+      colors.push(lineData[lineIndex].fill)
+    }
   }
   const tooltipData = getBandTooltipData(
     bandHoverIndices,

--- a/giraffe/src/components/BandHoverLayer.tsx
+++ b/giraffe/src/components/BandHoverLayer.tsx
@@ -56,7 +56,7 @@ export const BandHoverLayer: FunctionComponent<Props> = ({
     yColKey,
     xScale,
     yScale,
-    spec.scales.fill
+    spec.lineData
   )
 
   const crosshairColor = plotConfig.legendCrosshairColor
@@ -103,10 +103,9 @@ export const BandHoverLayer: FunctionComponent<Props> = ({
   })
 
   const colors = []
-  if (Array.isArray(spec.bandIndexMap.rowIndices)) {
-    for (let i = 0; i < spec.bandIndexMap.rowIndices.length; i += 1) {
-      colors.push(spec.scales.fill(i))
-    }
+  for (let i = 0; i < rowIndices.length; i += 1) {
+    const lineIndex = groupColData[rowIndices[i]]
+    colors.push(spec.lineData[lineIndex].fill)
   }
   const tooltipData = getBandTooltipData(
     bandHoverIndices,

--- a/giraffe/src/components/BandLayer.tsx
+++ b/giraffe/src/components/BandLayer.tsx
@@ -48,7 +48,6 @@ export const BandLayer: FunctionComponent<Props> = props => {
 
   const drawBandsOptions = {
     fill: spec.columnGroupMaps.fill,
-    fillScale: spec.scales.fill,
     interpolation: config.interpolation,
     lineData: simplifiedLineData,
     lineWidth: config.lineWidth,

--- a/giraffe/src/transforms/band.test.ts
+++ b/giraffe/src/transforms/band.test.ts
@@ -250,11 +250,9 @@ describe('band transform utils', () => {
           ],
         },
       }
-      const cyan = 'rgb(49, 192, 246)'
-      const fillScale = () => cyan
-      const result = getBands(fill, lineData, fillScale, 'min', 'mean', 'max')
+      const result = getBands(fill, lineData, 'min', 'mean', 'max')
       expect(Array.isArray(result)).toEqual(true)
-      expect(result[0].fill).toEqual(cyan)
+      expect(result[0].fill).toEqual(lineData[2].fill)
       expect(result[0].lower).toBeDefined()
       expect(result[0].upper).toBeDefined()
     })
@@ -387,33 +385,18 @@ describe('band transform utils', () => {
           ],
         },
       }
-      const cyan = 'rgb(49, 192, 246)'
-      const babyBlue = 'rgb(78, 145, 226)'
-      const purple = 'rgb(106, 103, 205)'
-      const fillScale = index => {
-        switch (index) {
-          case 0:
-            return cyan
-          case 1:
-            return babyBlue
-          case 2:
-            return purple
-          default:
-            return 'none'
-        }
-      }
-      const result = getBands(fill, lineData, fillScale, 'min', 'mean', 'max')
+      const result = getBands(fill, lineData, 'min', 'mean', 'max')
       expect(Array.isArray(result)).toEqual(true)
 
-      expect(result[0].fill).toEqual(cyan)
+      expect(result[0].fill).toEqual(lineData[2].fill)
       expect(result[0].lower).toBeUndefined()
       expect(result[0].upper).toBeDefined()
 
-      expect(result[1].fill).toEqual(babyBlue)
+      expect(result[1].fill).toEqual(lineData[3].fill)
       expect(result[1].lower).toBeDefined()
       expect(result[1].upper).toBeUndefined()
 
-      expect(result[2].fill).toEqual(purple)
+      expect(result[2].fill).toEqual(lineData[4].fill)
       expect(result[2].lower).toBeUndefined()
       expect(result[2].upper).toBeUndefined()
     })

--- a/giraffe/src/transforms/band.ts
+++ b/giraffe/src/transforms/band.ts
@@ -451,8 +451,8 @@ export const bandTransform = (
     const y = yCol[i]
 
     if (!lineData[groupID]) {
-      lineData[groupID] = {xs: [], ys: [], fill: `${groupID}`}
-      // 'fill' is set temporarily to the groupID
+      lineData[groupID] = {xs: [], ys: [], fill: ''}
+      // 'fill' is set temporarily to no color
       //    it will be updated with another loop later,
       //    because it is faster to walk bandIndexMap once
       //    than to search for the indices of many lines

--- a/giraffe/src/utils/drawBands.ts
+++ b/giraffe/src/utils/drawBands.ts
@@ -11,7 +11,6 @@ import {getBands} from '../transforms/band'
 interface DrawBandsOptions {
   context: CanvasRenderingContext2D
   fill: ColumnGroupMap
-  fillScale: Function
   interpolation: LineInterpolation
   lineData: LineData
   lineWidth: number
@@ -25,7 +24,6 @@ interface DrawBandsOptions {
 export const drawBands = ({
   context,
   fill,
-  fillScale,
   interpolation,
   lineData,
   lineWidth,
@@ -38,7 +36,6 @@ export const drawBands = ({
   const bands = getBands(
     fill,
     lineData,
-    fillScale,
     lowerColumnName,
     rowColumnName,
     upperColumnName

--- a/giraffe/src/utils/getBandHoverPoints.ts
+++ b/giraffe/src/utils/getBandHoverPoints.ts
@@ -1,4 +1,6 @@
-import {Table, Scale} from '../types'
+import {LineData, Scale, Table} from '../types'
+import {FILL} from '../constants/columnKeys'
+import {isNumber} from '../utils/isNumber'
 
 export const getBandHoverPoints = (
   table: Table,
@@ -7,14 +9,23 @@ export const getBandHoverPoints = (
   yColKey: string,
   xScale: Scale<number, number>,
   yScale: Scale<number, number>,
-  fillScale: Function
+  lineData: LineData
 ): Array<{x: number; y: number; fill: string}> => {
   const xColData = table.getColumn(xColKey, 'number')
   const yColData = table.getColumn(yColKey, 'number')
+  const groupColData = table.getColumn(FILL, 'number')
+  const lines = lineData || {}
 
-  return hoverRowIndices.map((hoverIndex, index) => ({
-    x: xScale(xColData[hoverIndex]),
-    y: yScale(yColData[hoverIndex]),
-    fill: fillScale(index),
-  }))
+  return hoverRowIndices.map(hoverIndex => {
+    let color = ''
+    const lineIndex = groupColData[hoverIndex]
+    if (isNumber(lineIndex) && lines[lineIndex]) {
+      color = lines[lineIndex].fill
+    }
+    return {
+      x: xScale(xColData[hoverIndex]),
+      y: yScale(yColData[hoverIndex]),
+      fill: color,
+    }
+  })
 }


### PR DESCRIPTION
Closes #277 ...for real this time

Fixes Band Plot's color scaling on hover, closing the latest point in this issue.

<img width="1680" alt="Screen Shot 2020-10-06 at 5 14 18 PM" src="https://user-images.githubusercontent.com/10736577/95273276-7f5c3d00-07f7-11eb-9d32-870a63d81002.png">
<img width="1680" alt="Screen Shot 2020-10-06 at 5 14 12 PM" src="https://user-images.githubusercontent.com/10736577/95273281-83885a80-07f7-11eb-92b7-21c2fa2090ca.png">
<img width="1680" alt="Screen Shot 2020-10-06 at 5 14 15 PM" src="https://user-images.githubusercontent.com/10736577/95273288-897e3b80-07f7-11eb-8c38-ab7f3521d6e1.png">
