### PR TITLE
test: add coverage to test artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run: cd stories && yarn run lint
       - run: cd stories && yarn run typecheck
       - store_artifacts:
-          path: coverage
+          path: giraffe/coverage
       # See: https://github.com/influxdata/giraffe/issues/129
       # - run:
       #     name: chromatic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,12 @@ jobs:
           key: v1-dependencies-{{ checksum "yarn.lock" }}
       - run: cd giraffe && yarn run lint
       - run: cd giraffe && yarn run typecheck
-      - run: cd giraffe && yarn run test
+      - run: cd giraffe && yarn run test --collectCoverage
       - run: cd giraffe && yarn run build
       - run: cd stories && yarn run lint
       - run: cd stories && yarn run typecheck
+      - store_artifacts:
+          path: coverage
       # See: https://github.com/influxdata/giraffe/issues/129
       # - run:
       #     name: chromatic

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 .out
 .env
 .vscode
+coverage

--- a/giraffe/jest.config.js
+++ b/giraffe/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
       diagnostics: false,
     },
   },
+  coverageReporters: ['json', 'html'],
 }


### PR DESCRIPTION
Closes #139 

### What

Uploads a `coverage/index.html` to our CircleCI test artifacts tab.  It looks a little something like this:

![Screen Shot 2020-10-08 at 2 24 30 PM](https://user-images.githubusercontent.com/7582765/95515148-00d7da80-0972-11eb-81b3-043b9c293a5d.png)
