### PR TITLE
feat: use browser option in rollup config

### DIFF
--- a/giraffe/rollup.config.js
+++ b/giraffe/rollup.config.js
@@ -11,7 +11,7 @@ import tsc from 'typescript'
 const pkg = require('./package.json')
 
 let plugins = [
-  resolve(),
+  resolve({browser: true}),
   commonjs(),
   typescript({typescript: tsc}),
   sourceMaps(),


### PR DESCRIPTION
In reference to https://github.com/influxdata/giraffe/pull/282#issuecomment-706004339

Let's set this for anyone who might be using influxdb-client-js with giraffe. Keeping this outside of the scope of the PR it came from, since it might be helpful as a standalone change.