### PR TITLE
fix: make getDomainDataFromLines performant

### DIFF
--- a/giraffe/src/components/LineHoverLayer.tsx
+++ b/giraffe/src/components/LineHoverLayer.tsx
@@ -48,8 +48,7 @@ export const LineHoverLayer: FunctionComponent<Props> = ({
 
   const points = getLineHoverPoints(
     position,
-    spec.lineData,
-    spec.table,
+    spec,
     rowIndices,
     xColKey,
     yColKey,
@@ -111,7 +110,8 @@ export const LineHoverLayer: FunctionComponent<Props> = ({
     fillColKeys,
     fillScale,
     position,
-    spec.lineData
+    spec.lineData,
+    spec.stackedDomainValueColumn
   )
 
   return (

--- a/giraffe/src/components/LineLayer.tsx
+++ b/giraffe/src/components/LineLayer.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import {useMemo, useRef, FunctionComponent} from 'react'
 
-import {LayerProps, LineLayerSpec, LineLayerConfig, DomainLabel} from '../types'
+import {LayerProps, LineLayerSpec, LineLayerConfig} from '../types'
 import {LineHoverLayer} from './LineHoverLayer'
-import {simplifyLineData, getDomainDataFromLines} from '../utils/lineData'
+import {simplifyLineData} from '../utils/lineData'
 import {useCanvas} from '../utils/useCanvas'
 import {drawLines} from '../utils/drawLines'
 import {useHoverPointIndices} from '../utils/useHoverPointIndices'
@@ -57,7 +57,7 @@ export const LineLayer: FunctionComponent<Props> = props => {
 
   const hoverYColumnData =
     position === 'stacked'
-      ? getDomainDataFromLines(spec.lineData, DomainLabel.Y)
+      ? spec.stackedDomainValueColumn
       : spec.table.getColumn(config.y, 'number')
   const hoverRowIndices = useHoverPointIndices(
     hoverDimension,

--- a/giraffe/src/transforms/line.ts
+++ b/giraffe/src/transforms/line.ts
@@ -1,13 +1,15 @@
 import {
-  Table,
-  LineLayerSpec,
+  CumulativeValuesByTime,
+  DomainLabel,
   LineData,
+  LineLayerSpec,
   LinePosition,
   NumericColumnData,
-  CumulativeValuesByTime,
+  Table,
 } from '../types'
 import {FILL, VALUE} from '../constants/columnKeys'
 import {createGroupIDColumn, getNominalColorScale} from './'
+import {getDomainDataFromLines} from '../utils/lineData'
 
 export const mapCumulativeValuesToTimeRange = (
   timesCol: NumericColumnData,
@@ -129,6 +131,14 @@ export const lineTransform = (
     }
   }
 
+  let stackedDomainValueColumn: NumericColumnData
+  if (position === 'stacked') {
+    stackedDomainValueColumn = getDomainDataFromLines(
+      lineData,
+      yColumnKey === VALUE ? DomainLabel.Y : DomainLabel.X
+    )
+  }
+
   return {
     type: 'line',
     inputTable,
@@ -142,5 +152,6 @@ export const lineTransform = (
     yColumnType: table.getColumnType(yColumnKey),
     scales: {fill: fillScale},
     columnGroupMaps: {fill: fillColumnMap},
+    stackedDomainValueColumn,
   }
 }

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -516,6 +516,7 @@ export interface LineLayerSpec {
   columnGroupMaps: {
     fill: ColumnGroupMap
   }
+  stackedDomainValueColumn?: NumericColumnData
 }
 
 export interface BandLayerSpec {

--- a/giraffe/src/utils/fixtures/line.ts
+++ b/giraffe/src/utils/fixtures/line.ts
@@ -1,0 +1,47 @@
+import {newTable} from '../newTable'
+
+const now = Date.now()
+const numberOfLines = 1_000
+const dataPointsPerLine = 1_000
+const numberOfRecords = numberOfLines * dataPointsPerLine
+const maxValue = 100
+
+function getRandomNumber(max: number) {
+  return Math.random() * Math.floor(max)
+}
+
+function getRandomColor() {
+  return Math.floor(Math.random() * 255)
+}
+const lineData = {}
+const TIME_COL = []
+const VALUE_COL = []
+const CPU_COL = []
+
+for (let lineNumber = 0; lineNumber < numberOfLines; lineNumber += 1) {
+  lineData[lineNumber] = {
+    // prettier-ignore
+    fill: `rgb(${getRandomColor()}, ${getRandomColor()}, ${getRandomColor()})`,
+    xs: [],
+    ys: [],
+  }
+  for (let dataPoint = 0; dataPoint < dataPointsPerLine; dataPoint += 1) {
+    const time = now + (dataPoint % dataPointsPerLine) * 1000 * 60
+    const randomNumber = getRandomNumber(maxValue)
+    const index = lineNumber * numberOfLines + dataPointsPerLine
+
+    lineData[lineNumber].xs.push(time)
+    TIME_COL.push(time)
+
+    lineData[lineNumber].ys.push(randomNumber)
+    VALUE_COL.push(randomNumber)
+    CPU_COL.push(`cpu${Math.floor(index / dataPointsPerLine)}`)
+  }
+}
+
+const largeTable = newTable(numberOfRecords)
+  .addColumn('_time', 'dateTime:RFC3339', 'time', TIME_COL)
+  .addColumn('_value', 'system', 'number', VALUE_COL)
+  .addColumn('cpu', 'string', 'string', CPU_COL)
+
+export {largeTable, lineData}

--- a/giraffe/src/utils/fixtures/line.ts
+++ b/giraffe/src/utils/fixtures/line.ts
@@ -2,8 +2,8 @@ import {newTable} from '../newTable'
 
 const now = Date.now()
 const numberOfLines = 1_000
-const dataPointsPerLine = 1_000
-const numberOfRecords = numberOfLines * dataPointsPerLine
+const dataPointsPerLine = 5_000
+const dataSize = numberOfLines * dataPointsPerLine
 const maxValue = 100
 
 function getRandomNumber(max: number) {
@@ -39,9 +39,9 @@ for (let lineNumber = 0; lineNumber < numberOfLines; lineNumber += 1) {
   }
 }
 
-const largeTable = newTable(numberOfRecords)
+const largeTable = newTable(dataSize)
   .addColumn('_time', 'dateTime:RFC3339', 'time', TIME_COL)
   .addColumn('_value', 'system', 'number', VALUE_COL)
   .addColumn('cpu', 'string', 'string', CPU_COL)
 
-export {largeTable, lineData}
+export {dataSize, largeTable, lineData}

--- a/giraffe/src/utils/getLineHoverPoints.ts
+++ b/giraffe/src/utils/getLineHoverPoints.ts
@@ -1,13 +1,10 @@
-import {LinePosition, LineData, Table, Scale, DomainLabel} from '../types'
+import {LineLayerSpec, LinePosition, Scale} from '../types'
 
 import {FILL} from '../constants/columnKeys'
 
-import {getDomainDataFromLines} from './lineData'
-
 export const getLineHoverPoints = (
   position: LinePosition,
-  lineData: LineData,
-  table: Table,
+  spec: LineLayerSpec,
   hoverRowIndices: number[],
   xColKey: string,
   yColKey: string,
@@ -15,10 +12,11 @@ export const getLineHoverPoints = (
   yScale: Scale<number, number>,
   fillScale: Scale<number, string>
 ): Array<{x: number; y: number; fill: string}> => {
+  const {table} = spec
   const xColData = table.getColumn(xColKey, 'number')
   const yColData =
     position === 'stacked'
-      ? getDomainDataFromLines(lineData, DomainLabel.Y)
+      ? spec.stackedDomainValueColumn
       : table.getColumn(yColKey, 'number')
   const groupColData = table.getColumn(FILL, 'number')
 

--- a/giraffe/src/utils/lineData.perf.test.ts
+++ b/giraffe/src/utils/lineData.perf.test.ts
@@ -4,7 +4,22 @@ import {lineTransform} from '../transforms/line'
 
 import {largeTable, lineData} from './fixtures/line'
 
+// Baseline: one million data points within 3 seconds
+//   this seems arbitrary and will need adjusting
+const MAX_DURATION = 3000
+
 describe('line graph performance', () => {
+  let start, end
+
+  beforeEach(() => {
+    start = Date.now()
+  })
+
+  afterEach(() => {
+    end = Date.now()
+    expect(end - start).toBeLessThanOrEqual(MAX_DURATION)
+  })
+
   test('getDomainDataFromLines for 1,000,000 data points', () => {
     expect(() => {
       const result = getDomainDataFromLines(lineData, DomainLabel.Y)

--- a/giraffe/src/utils/lineData.perf.test.ts
+++ b/giraffe/src/utils/lineData.perf.test.ts
@@ -1,0 +1,30 @@
+import {DomainLabel} from '../types'
+import {getDomainDataFromLines} from './lineData'
+import {lineTransform} from '../transforms/line'
+
+import {largeTable, lineData} from './fixtures/line'
+
+describe('line graph performance', () => {
+  test('getDomainDataFromLines for 1,000,000 data points', () => {
+    expect(() => {
+      const result = getDomainDataFromLines(lineData, DomainLabel.Y)
+      expect(result.length).toEqual(1_000_000)
+    }).not.toThrow()
+  })
+
+  test('line transform a table with 1,000,000 data points', () => {
+    expect(() => {
+      const result = lineTransform(
+        largeTable,
+        '_time',
+        '_value',
+        ['cpu'],
+        ['#31C0F6', '#A500A5', '#FF7E27'],
+        'stacked'
+      )
+      expect(result.table.length).toEqual(1_000_000)
+      expect(Array.isArray(result.stackedDomainValueColumn)).toEqual(true)
+      expect(result.stackedDomainValueColumn.length).toEqual(1_000_000)
+    }).not.toThrow()
+  })
+})

--- a/giraffe/src/utils/lineData.perf.test.ts
+++ b/giraffe/src/utils/lineData.perf.test.ts
@@ -2,32 +2,26 @@ import {DomainLabel} from '../types'
 import {getDomainDataFromLines} from './lineData'
 import {lineTransform} from '../transforms/line'
 
-import {largeTable, lineData} from './fixtures/line'
+import {dataSize, largeTable, lineData} from './fixtures/line'
 
-// Baseline: one million data points within 3 seconds
-//   this seems arbitrary and will need adjusting
-const MAX_DURATION = 3000
+// A number representing the limit on the number of points
+//   in a data set that most, if not all users, could possibly want
+//   to see in a line graph
+const REASONABLE_LIMIT = 5_000_000
 
 describe('line graph performance', () => {
-  let start, end
-
-  beforeEach(() => {
-    start = Date.now()
+  test('fixture should be greater than or equal to REASONABLE_LIMIT', () => {
+    expect(dataSize).toBeGreaterThanOrEqual(REASONABLE_LIMIT)
   })
 
-  afterEach(() => {
-    end = Date.now()
-    expect(end - start).toBeLessThanOrEqual(MAX_DURATION)
-  })
-
-  test('getDomainDataFromLines for 1,000,000 data points', () => {
+  test(`getDomainDataFromLines on ${REASONABLE_LIMIT} data points`, () => {
     expect(() => {
       const result = getDomainDataFromLines(lineData, DomainLabel.Y)
-      expect(result.length).toEqual(1_000_000)
+      expect(result.length).toBeGreaterThanOrEqual(REASONABLE_LIMIT)
     }).not.toThrow()
   })
 
-  test('line transform a table with 1,000,000 data points', () => {
+  test(`line transform a table with ${REASONABLE_LIMIT} data points`, () => {
     expect(() => {
       const result = lineTransform(
         largeTable,
@@ -37,9 +31,11 @@ describe('line graph performance', () => {
         ['#31C0F6', '#A500A5', '#FF7E27'],
         'stacked'
       )
-      expect(result.table.length).toEqual(1_000_000)
+      expect(result.table.length).toBeGreaterThanOrEqual(REASONABLE_LIMIT)
       expect(Array.isArray(result.stackedDomainValueColumn)).toEqual(true)
-      expect(result.stackedDomainValueColumn.length).toEqual(1_000_000)
+      expect(result.stackedDomainValueColumn.length).toBeGreaterThanOrEqual(
+        REASONABLE_LIMIT
+      )
     }).not.toThrow()
   })
 })

--- a/giraffe/src/utils/lineData.ts
+++ b/giraffe/src/utils/lineData.ts
@@ -1,4 +1,4 @@
-import {Table, Scale, LineData, DomainLabel, NumericColumnData} from '../types'
+import {DomainLabel, LineData, Scale, Table} from '../types'
 import {simplify} from '../utils/simplify'
 import {FILL} from '../constants/columnKeys'
 
@@ -55,11 +55,16 @@ export const simplifyLineData = (
 export const getDomainDataFromLines = (
   lineData: LineData,
   domainLabel: DomainLabel
-): NumericColumnData => {
-  let result = []
+): number[] => {
+  const result = []
   const numberOfLines = Object.keys(lineData).length
-  for (let index = 0; index < numberOfLines; index += 1) {
-    result = result.concat(lineData[index][domainLabel])
+  for (let lineIndex = 0; lineIndex < numberOfLines; lineIndex += 1) {
+    const line = lineData[lineIndex] ? lineData[lineIndex][domainLabel] : []
+    if (Array.isArray(line)) {
+      for (let domainIndex = 0; domainIndex < line.length; domainIndex += 1) {
+        result.push(line[domainIndex])
+      }
+    }
   }
   return result
 }

--- a/giraffe/src/utils/tooltip.test.ts
+++ b/giraffe/src/utils/tooltip.test.ts
@@ -178,7 +178,8 @@ describe('getPointsTooltipData', () => {
         [COLUMN_KEY],
         fillScale,
         'stacked',
-        lineSpec.lineData
+        lineSpec.lineData,
+        lineSpec.stackedDomainValueColumn
       )
       const singleValueColumn = result.find(column => column.name === yColKey)
       expect(singleValueColumn).toBeTruthy()
@@ -212,7 +213,8 @@ describe('getPointsTooltipData', () => {
         [COLUMN_KEY],
         fillScale,
         'stacked',
-        lineSpec.lineData
+        lineSpec.lineData,
+        lineSpec.stackedDomainValueColumn
       )
       const singleValueColumn = result.find(column => column.name === yColKey)
 
@@ -247,7 +249,8 @@ describe('getPointsTooltipData', () => {
         [COLUMN_KEY],
         fillScale,
         'stacked',
-        lineSpec.lineData
+        lineSpec.lineData,
+        lineSpec.stackedDomainValueColumn
       )
       expect(result.find(column => column.name === yColKey)).toBeTruthy()
     })

--- a/giraffe/src/utils/tooltip.ts
+++ b/giraffe/src/utils/tooltip.ts
@@ -1,11 +1,12 @@
 import {
-  LinePosition,
+  DomainLabel,
   LineData,
-  TooltipData,
-  TooltipColumn,
+  LinePosition,
+  NumericColumnData,
   Scale,
   Table,
-  DomainLabel,
+  TooltipColumn,
+  TooltipData,
 } from '../types'
 import {
   FILL,
@@ -15,7 +16,6 @@ import {
   VALUE,
 } from '../constants/columnKeys'
 
-import {getDomainDataFromLines} from './lineData'
 import {BandHoverIndices} from './getBandHoverIndices'
 
 const isVoid = (x: any) => x === null || x === undefined
@@ -102,7 +102,8 @@ export const getPointsTooltipData = (
   fillColKeys: string[],
   fillScale: Scale<number, string>,
   position?: LinePosition,
-  lineData?: LineData
+  lineData?: LineData,
+  stackedDomainValueColumn?: NumericColumnData
 ): TooltipData => {
   const sortOrder = lineData
     ? getDataSortOrder(lineData, hoveredRowIndices, position)
@@ -140,6 +141,9 @@ export const getPointsTooltipData = (
 
   const tooltipAdditionalColumns = []
   if (position === 'stacked') {
+    const stackedDomainValues = stackedDomainValueColumn
+      ? stackedDomainValueColumn
+      : []
     tooltipAdditionalColumns.push({
       key: yColKey,
       name: STACKED_LINE_CUMULATIVE,
@@ -148,13 +152,7 @@ export const getPointsTooltipData = (
       values: orderDataByValue(
         hoveredRowIndices,
         sortOrder,
-        hoveredRowIndices.map(i => {
-          const cumulativeColData = getDomainDataFromLines(
-            lineData,
-            DomainLabel.Y
-          )
-          return yFormatter(cumulativeColData[i])
-        })
+        hoveredRowIndices.map(i => yFormatter(stackedDomainValues[i]))
       ),
     })
 


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/18179

- avoid using Array.prototype.concat to repeatedly re-create arrays in a loop
- call `getDomainDataFromLines` only once internally during transformation and save it on the `spec`
- test `getDomainDataFromLines` and `lineTransform` with 5,000,000 data points to ensure error will not be thrown