### PR TITLE
Improve Legibility of Tooltip

### DIFF
--- a/giraffe/src/components/Tooltip.tsx
+++ b/giraffe/src/components/Tooltip.tsx
@@ -116,6 +116,7 @@ export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
         color: colors && colors[i] ? colors[i] : fontBrightColor,
         display: 'table-cell',
         padding: '4px',
+        fontWeight: 600,
       }
     }
 
@@ -124,6 +125,7 @@ export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
+      fontWeight: 600,
       color: colors && colors[i] ? colors[i] : fontBrightColor,
     }
   }

--- a/giraffe/src/components/TooltipStyles.ts
+++ b/giraffe/src/components/TooltipStyles.ts
@@ -1,0 +1,233 @@
+import {CSSProperties} from 'react'
+import {TooltipData, ColumnType} from '../types'
+
+// Style Constants
+const tooltipColumnGap = '12px'
+const tooltipColumnMaxWidth = '200px'
+const tooltipTablePadding = '4px'
+
+const tooltipColumnOrder = (name: string): number | undefined => {
+  switch (name) {
+    case '_color':
+      return 1
+    case '_time':
+      return 2
+    case '_value':
+      return 3
+    default:
+      return 99
+  }
+}
+
+// Tooltip Styles
+export interface TooltipDotsStyles {
+  column: CSSProperties
+  header: CSSProperties
+  value: CSSProperties
+  dots: CSSProperties[]
+}
+
+export interface TooltipStyles {
+  table: CSSProperties
+  columns: CSSProperties[]
+  headers: CSSProperties
+  values: CSSProperties[][]
+  dots: TooltipDotsStyles
+}
+
+export const generateTooltipStyles = (
+  tooltipData: TooltipData,
+  switchToVertical: boolean,
+  colorizeRows: boolean,
+  fontColor: string,
+  fontBrightColor: string
+): TooltipStyles => {
+  // Regular Tooltip Styles
+  const columnCount = tooltipData.length - 1
+  const table = tooltipTableStyle(switchToVertical)
+  const columns = tooltipData.map((column, i) =>
+    tooltipColumnStyle(
+      column.name,
+      i,
+      column.type,
+      switchToVertical,
+      columnCount
+    )
+  )
+  const headers = tooltipColumnHeaderStyle(switchToVertical, fontColor)
+  const values = tooltipData.map(column => {
+    return column.values.map((_, i) =>
+      tooltipColumnValueStyle(
+        i,
+        column.colors,
+        colorizeRows,
+        fontBrightColor,
+        switchToVertical
+      )
+    )
+  })
+
+  // Special "Dots" Column Styles
+  const dots = tooltipDotsColumnStyles(switchToVertical, tooltipData)
+
+  return {
+    table,
+    columns,
+    headers,
+    values,
+    dots,
+  }
+}
+
+const tooltipTableStyle = (switchToVertical: boolean): CSSProperties => {
+  if (switchToVertical) {
+    return {
+      display: 'table',
+    }
+  }
+
+  return {
+    flexDirection: 'row',
+    display: 'flex',
+  }
+}
+
+const tooltipColumnStyle = (
+  name: string,
+  i: number,
+  type: ColumnType,
+  switchToVertical: boolean,
+  columnCount: number
+): CSSProperties => {
+  if (switchToVertical) {
+    return {
+      width: '100%',
+      display: 'table-row',
+    }
+  }
+
+  return {
+    display: 'flex',
+    order: tooltipColumnOrder(name),
+    flexDirection: 'column',
+    marginRight: i === columnCount ? 0 : tooltipColumnGap,
+    textAlign: type === 'number' ? 'right' : 'left',
+  }
+}
+
+const tooltipColumnHeaderStyle = (
+  switchToVertical: boolean,
+  fontColor: string
+): React.CSSProperties => {
+  if (switchToVertical) {
+    return {
+      color: fontColor,
+      display: 'table-cell',
+      margin: tooltipTablePadding,
+    }
+  }
+
+  return {
+    marginBottom: tooltipTablePadding,
+    color: fontColor,
+  }
+}
+
+const tooltipColumnValueStyle = (
+  i: number,
+  colors: string[],
+  colorizeRows: boolean,
+  fontBrightColor: string,
+  switchToVertical: boolean
+): React.CSSProperties => {
+  let color = fontBrightColor
+
+  if (colorizeRows && colors) {
+    color = colors[i]
+  }
+
+  if (switchToVertical) {
+    return {
+      maxWidth: tooltipColumnMaxWidth,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      color,
+      display: 'table-cell',
+      padding: tooltipTablePadding,
+      fontWeight: 600,
+      lineHeight: '1em',
+    }
+  }
+
+  return {
+    maxWidth: tooltipColumnMaxWidth,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    fontWeight: 600,
+    lineHeight: '1.125em',
+    height: '1.125em',
+    color,
+  }
+}
+
+const tooltipDotsColumnStyles = (
+  switchToVertical: boolean,
+  tooltipData: TooltipData
+): TooltipDotsStyles => {
+  let column: CSSProperties = {
+    display: 'flex',
+    order: tooltipColumnOrder('_color'),
+    flexDirection: 'column',
+    marginRight: '6px',
+    textAlign: 'left',
+  }
+
+  let header: CSSProperties = {
+    marginBottom: '5px',
+  }
+
+  let value: CSSProperties = {
+    width: 'auto',
+    lineHeight: '1.125em',
+    height: '1.125em',
+    display: 'flex',
+    alignItems: 'center',
+    alignContent: 'center',
+  }
+
+  if (switchToVertical) {
+    column = {
+      width: '100%',
+      display: 'table-row',
+    }
+
+    header = {
+      display: 'table-cell',
+      margin: tooltipTablePadding,
+    }
+
+    value = {
+      width: 'auto',
+      display: 'table-cell',
+      verticalAlign: 'middle',
+      padding: tooltipTablePadding,
+    }
+  }
+
+  const dots = tooltipData[0].colors.map(color => ({
+    width: '0.75em',
+    height: '0.75em',
+    borderRadius: '50%',
+    backgroundColor: color,
+    display: 'inline-block',
+  }))
+
+  return {
+    column,
+    header,
+    value,
+    dots,
+  }
+}

--- a/giraffe/src/constants/colorSchemes.ts
+++ b/giraffe/src/constants/colorSchemes.ts
@@ -180,7 +180,39 @@ export const DO_ANDROIDS_DREAM = ['#8F8AF4', '#A51414', '#F4CF31']
 export const DELOREAN = ['#FD7A5D', '#5F1CF2', '#4CE09A']
 export const CTHULHU = ['#FDC44F', '#007C76', '#8983FF']
 export const ECTOPLASM = ['#DA6FF1', '#00717A', '#ACFF76']
+export const PRIMARY = ['#00A3FF', '#67D74E', '#FFD255', '#DC4E58']
+export const PRIMARY_REVERSE = ['#DC4E58', '#FFD255', '#67D74E', '#00A3FF']
 export const T_MAX_400_FILM = ['#F6F6F8', '#A4A8B6', '#545667']
+export const RAINBOW_EIGHT = [
+  '#00f8ff',
+  '#33a8ff',
+  '#784dff',
+  '#da07ff',
+  '#FF0000',
+  '#FFC200',
+  '#85F700',
+  '#00b15d',
+]
+export const RAINBOW_SIXTEEN = [
+  '#4dfaff',
+  '#00adb2',
+  '#71c2ff',
+  '#2475b2',
+  '#a183ff',
+  '#5436b2',
+  '#e552ff',
+  '#9805b2',
+  '#ff4d4d',
+  '#b20000',
+  '#ffd44d',
+  '#b28700',
+  '#aaf94d',
+  '#5dac00',
+  '#4dc98e',
+  '#007c41',
+]
+
+// Solid Colors
 export const SOLID_RED = ['#DC4E58', '#DC4E58', '#DC4E58']
 export const SOLID_YELLOW = ['#FFD255', '#FFD255', '#FFD255']
 export const SOLID_GREEN = ['#67D74E', '#67D74E', '#67D74E']

--- a/giraffe/src/constants/colorSchemes.ts
+++ b/giraffe/src/constants/colorSchemes.ts
@@ -174,8 +174,8 @@ export const BU_GN = [
 ]
 
 // Chronograf Colors
-export const NINETEEN_EIGHTY_FOUR = ['#31C0F6', '#A500A5', '#FF7E27']
-export const ATLANTIS = ['#74D495', '#3F3FBA', '#FF4D9E']
+export const NINETEEN_EIGHTY_FOUR = ['#31C0F6', '#BC00B8', '#FF7E27']
+export const ATLANTIS = ['#74D495', '#4949EA', '#FF4D9E']
 export const DO_ANDROIDS_DREAM = ['#8F8AF4', '#A51414', '#F4CF31']
 export const DELOREAN = ['#FD7A5D', '#5F1CF2', '#4CE09A']
 export const CTHULHU = ['#FDC44F', '#007C76', '#8983FF']

--- a/giraffe/src/constants/index.ts
+++ b/giraffe/src/constants/index.ts
@@ -47,10 +47,10 @@ export const CONFIG_DEFAULTS: Partial<Config> = {
   tickFont: '10px sans-serif',
   tickFontColor: '#8e91a1',
   legendFont: '10px monospace',
-  legendFontColor: '#8e91a1',
-  legendFontBrightColor: '#c6cad3',
-  legendBackgroundColor: '#1c1c21',
-  legendBorder: '1px solid #202028',
+  legendFontColor: '#bec2cc',
+  legendFontBrightColor: '#f6f6f8',
+  legendBackgroundColor: '#0f0e15',
+  legendBorder: '2px solid #202028',
   legendCrosshairColor: '#31313d',
 }
 

--- a/giraffe/src/constants/index.ts
+++ b/giraffe/src/constants/index.ts
@@ -52,6 +52,7 @@ export const CONFIG_DEFAULTS: Partial<Config> = {
   legendBackgroundColor: '#0f0e15',
   legendBorder: '2px solid #202028',
   legendCrosshairColor: '#31313d',
+  legendColorizeRows: true,
 }
 
 export const LAYER_DEFAULTS: {[layerType: string]: Partial<LayerConfig>} = {

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -65,6 +65,7 @@ export interface Config {
   legendMessage?: string
   legendOpacity?: number
   legendOrientationThreshold?: number
+  legendColorizeRows?: boolean
 
   // The type of the y-axis column
   yColumnType?: ColumnType

--- a/stories/src/band.stories.tsx
+++ b/stories/src/band.stories.tsx
@@ -28,6 +28,7 @@ import {
   interpolationKnob,
   timeZoneKnob,
   tooltipOrientationThresholdKnob,
+  tooltipColorizeRowsKnob,
 } from './helpers'
 
 storiesOf('Band Chart', module)
@@ -94,6 +95,7 @@ storiesOf('Band Chart', module)
       step: 0.05,
     })
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
+    const legendColorizeRows = tooltipColorizeRowsKnob()
 
     const config: Config = {
       fluxResponse: staticData,
@@ -113,6 +115,7 @@ storiesOf('Band Chart', module)
       showAxes,
       legendOpacity,
       legendOrientationThreshold,
+      legendColorizeRows,
       layers: [
         {
           type: 'band',
@@ -185,6 +188,7 @@ storiesOf('Band Chart', module)
       step: 0.05,
     })
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
+    const legendColorizeRows = tooltipColorizeRowsKnob()
 
     const config: Config = {
       fluxResponse: customCSV,
@@ -204,6 +208,7 @@ storiesOf('Band Chart', module)
       showAxes,
       legendOpacity,
       legendOrientationThreshold,
+      legendColorizeRows,
       layers: [
         {
           type: 'band',

--- a/stories/src/helpers.tsx
+++ b/stories/src/helpers.tsx
@@ -163,3 +163,6 @@ export const timeZoneKnob = (initial?: string) =>
 
 export const tooltipOrientationThresholdKnob = () =>
   number('tooltipOrientationThreshold', 5)
+
+export const tooltipColorizeRowsKnob = () =>
+  boolean('tooltipColorizeRows', true)

--- a/stories/src/helpers.tsx
+++ b/stories/src/helpers.tsx
@@ -55,7 +55,11 @@ export const colorSchemeKnob = (initial?: string[]) =>
       Delorean: giraffe.DELOREAN,
       Cthulhu: giraffe.CTHULHU,
       Ectoplasm: giraffe.ECTOPLASM,
+      Primary: giraffe.PRIMARY,
+      'Primary (Reverse)': giraffe.PRIMARY_REVERSE,
       'T Max 400 Film': giraffe.T_MAX_400_FILM,
+      'Rainbow (8)': giraffe.RAINBOW_EIGHT,
+      'Rainbow (16)': giraffe.RAINBOW_SIXTEEN,
       Viridis: giraffe.VIRIDIS,
       Magma: giraffe.MAGMA,
       Inferno: giraffe.INFERNO,
@@ -63,6 +67,11 @@ export const colorSchemeKnob = (initial?: string[]) =>
       ylOrRd: giraffe.YL_OR_RD,
       ylGnBu: giraffe.YL_GN_BU,
       buGn: giraffe.BU_GN,
+      'Solid Blue': giraffe.SOLID_BLUE,
+      'Solid Green': giraffe.SOLID_GREEN,
+      'Solid Red': giraffe.SOLID_RED,
+      'Solid Yellow': giraffe.SOLID_YELLOW,
+      'Solid Purple': giraffe.SOLID_PURPLE,
     },
     initial || giraffe.NINETEEN_EIGHTY_FOUR
   )

--- a/stories/src/index.stories.tsx
+++ b/stories/src/index.stories.tsx
@@ -29,6 +29,7 @@ import {
   interpolationKnob,
   timeZoneKnob,
   tooltipOrientationThresholdKnob,
+  tooltipColorizeRowsKnob,
 } from './helpers'
 
 storiesOf('XY Plot', module)
@@ -84,6 +85,7 @@ storiesOf('XY Plot', module)
       step: 0.05,
     })
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
+    const legendColorizeRows = tooltipColorizeRowsKnob()
 
     const config: Config = {
       table,
@@ -101,6 +103,7 @@ storiesOf('XY Plot', module)
       showAxes,
       legendOpacity,
       legendOrientationThreshold,
+      legendColorizeRows,
       layers: [
         {
           type: 'line',
@@ -169,6 +172,7 @@ storiesOf('XY Plot', module)
       step: 0.05,
     })
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
+    const legendColorizeRows = tooltipColorizeRowsKnob()
 
     const config: Config = {
       table,
@@ -179,6 +183,7 @@ storiesOf('XY Plot', module)
       legendFont,
       legendOpacity,
       legendOrientationThreshold,
+      legendColorizeRows,
       tickFont,
       showAxes,
       xScale,
@@ -278,6 +283,7 @@ storiesOf('XY Plot', module)
       'auto'
     )
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
+    const legendColorizeRows = tooltipColorizeRowsKnob()
 
     const layers = [
       {
@@ -326,6 +332,7 @@ storiesOf('XY Plot', module)
       yScale,
       legendFont,
       legendOrientationThreshold,
+      legendColorizeRows,
       tickFont,
       showAxes,
       layers,
@@ -348,11 +355,13 @@ storiesOf('XY Plot', module)
     const yScale = yScaleKnob()
     const showAxes = showAxesKnob()
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
+    const legendColorizeRows = tooltipColorizeRowsKnob()
 
     const config: Config = {
       table,
       legendFont,
       legendOrientationThreshold,
+      legendColorizeRows,
       xScale,
       yScale,
       tickFont,
@@ -378,11 +387,13 @@ storiesOf('XY Plot', module)
     const showAxes = showAxesKnob()
     const binCount = number('Bin Count', 10)
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
+    const legendColorizeRows = tooltipColorizeRowsKnob()
 
     const config: Config = {
       table,
       legendFont,
       legendOrientationThreshold,
+      legendColorizeRows,
       tickFont,
       showAxes,
       xScale,
@@ -406,10 +417,12 @@ storiesOf('XY Plot', module)
     const showAxes = showAxesKnob()
     const hoverDimension = select('Hover Dimension', {x: 'x', xy: 'xy'}, 'xy')
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
+    const legendColorizeRows = tooltipColorizeRowsKnob()
 
     const config: Config = {
       table: CPUString,
       legendOrientationThreshold,
+      legendColorizeRows,
       showAxes,
       layers: [
         {

--- a/stories/src/linegraph.stories.tsx
+++ b/stories/src/linegraph.stories.tsx
@@ -18,6 +18,7 @@ import {
   yKnob,
   yScaleKnob,
   tooltipOrientationThresholdKnob,
+  tooltipColorizeRowsKnob,
 } from './helpers'
 
 import {tooltipFalsyValues} from './data/fluxCSV'
@@ -70,6 +71,8 @@ storiesOf('Line Graph', module)
     )
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
 
+    const legendColorizeRows = tooltipColorizeRowsKnob()
+
     const config: Config = {
       fluxResponse: staticData,
       valueFormatters: {
@@ -82,6 +85,7 @@ storiesOf('Line Graph', module)
       xScale,
       yScale,
       legendOrientationThreshold,
+      legendColorizeRows,
       layers: [
         {
           type: 'line',
@@ -146,6 +150,8 @@ storiesOf('Line Graph', module)
     )
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
 
+    const legendColorizeRows = tooltipColorizeRowsKnob()
+
     const config: Config = {
       fluxResponse: csv,
       valueFormatters: {
@@ -158,6 +164,7 @@ storiesOf('Line Graph', module)
       xScale,
       yScale,
       legendOrientationThreshold,
+      legendColorizeRows,
       layers: [
         {
           type: 'line',

--- a/stories/src/scatterplot.stories.tsx
+++ b/stories/src/scatterplot.stories.tsx
@@ -17,6 +17,7 @@ import {
   findStringColumns,
   timeZoneKnob,
   tooltipOrientationThresholdKnob,
+  tooltipColorizeRowsKnob,
   tableKnob,
   fillKnob,
   symbolKnob,
@@ -36,6 +37,7 @@ storiesOf('Scatter Plot', module)
     const fill = fillKnob(table, ['cpu'])
     const symbol = symbolKnob(table, ['host'])
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
+    const legendColorizeRows = tooltipColorizeRowsKnob()
     const showAxes = showAxesKnob()
 
     const config: Config = {
@@ -43,6 +45,7 @@ storiesOf('Scatter Plot', module)
       valueFormatters: {_value: val => `${Math.round(val)}%`},
       legendFont,
       legendOrientationThreshold,
+      legendColorizeRows,
       tickFont,
       showAxes,
       xScale,
@@ -98,6 +101,7 @@ storiesOf('Scatter Plot', module)
     )
     const showAxes = showAxesKnob()
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
+    const legendColorizeRows = tooltipColorizeRowsKnob()
 
     const config: Config = {
       table,
@@ -107,6 +111,7 @@ storiesOf('Scatter Plot', module)
       },
       legendFont,
       legendOrientationThreshold,
+      legendColorizeRows,
       tickFont,
       showAxes,
       xScale,


### PR DESCRIPTION
### Screenshots

![Screen Shot 2020-10-14 at 5 23 45 PM](https://user-images.githubusercontent.com/2433762/96177303-844d7a80-0ee2-11eb-845f-0d3f46ff3b8d.png)
![Screen Shot 2020-10-14 at 4 07 24 PM](https://user-images.githubusercontent.com/2433762/96177317-8b748880-0ee2-11eb-863a-6d0298b9b17d.png)
![Screen Shot 2020-10-14 at 2 20 53 PM](https://user-images.githubusercontent.com/2433762/96177319-8f080f80-0ee2-11eb-8dcc-8fe5a507ac77.png)


### Changes

- Make background of tooltip darker
- Make font weight of text in tooltip slightly bolder
- Add a handful of color schemes optimized for less series
- Add `legendColorizeRows` option with default `true`
  - If `false` colors are displayed as dots in each row instead of applied to text

### CSS in JS Pattern

- Since we are generating CSS dynamically and the style functions make the component a bit hard to read I moved them to a separate file named `TooltipStyles.ts`
- the `___Styles.ts` naming scheme is probably something we could re-use for other components
- The styles file exports only 1 function which returns an object containing styles for every element organized by element name