### PR TITLE
feat(fromFlux-error-handling): optimized fromFlux, fromFluxWithSchema, and added error handling for both

### DIFF
--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -400,6 +400,17 @@ describe('fromFlux', () => {
     ])
   })
 
+  test('should error out gracefully when an error is thrown in the fromFlux parser', () => {
+    const CSV =
+      '#group,false,false,true,true,false,false,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true'
+
+    expect(() => {
+      fromFlux(CSV)
+    }).not.toThrow()
+    const actual = fromFlux(CSV)
+    expect(actual.error).toBeTruthy()
+  })
+
   test('uses the default annotation to fill in empty values', () => {
     const CSV = `#group,false,false,true,true,true,true
 #datatype,string,long,string,string,long,long
@@ -484,6 +495,17 @@ there",5
   it('fromFlux should return an empty object when an empty string is passed in', () => {
     const {schema} = fromFluxWithSchema('')
     expect(schema).toStrictEqual({})
+  })
+
+  it('should error out gracefully when an error is thrown in the fromFluxWithSchema parser', () => {
+    const CSV =
+      '#group,false,false,true,true,false,false,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true'
+
+    expect(() => {
+      fromFluxWithSchema(CSV)
+    }).not.toThrow()
+    const actual = fromFlux(CSV)
+    expect(actual.error).toBeTruthy()
   })
   it('should return an empty object if the response has no _measurement header', () => {
     const resp = `#group,false,false,false,false,false,false,true,true,true


### PR DESCRIPTION
Closes #314 

### Problem

At various points in the fromFlux parser, assertions were throwing unhandled errors, leading to the UI crashing in a number of different scenarios. Since fromFlux is the primary parser (at this point in time), it is important that it handles errors in a way that does not prevent users from reaching an unusable state

### Solution

Since most of the pain points were already being handled by the parser, wrapping the more nuanced logic in a try/catch and returning the error to the user allows the parser to degrade gracefully when an error is thrown.

With this change comes a change to the type definition to allow for the error to be handled by the UI in the event that an error is thrown.

Finally, some of the variable assignments were moved outside of the for loop in order to reduce memory consumption throughout the parsing process and make the parser more efficient.