### PR TITLE
chore: rename test to it and add collectCoverage option to test scripts

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -4,8 +4,8 @@
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
-    "test": "jest --maxWorkers=2",
-    "test:watch": "jest --watch --verbose false",
+    "test": "jest --collectCoverage --maxWorkers=2",
+    "test:watch": "jest --collectCoverage --watch --verbose false",
     "build": "rm -rf dist && NODE_ENV=production rollup -c",
     "start": "rollup -cw",
     "lint": "eslint '{src,../stories/src}/**/*.{ts,tsx}'",

--- a/giraffe/src/transforms/heatmap.test.ts
+++ b/giraffe/src/transforms/heatmap.test.ts
@@ -2,7 +2,7 @@ import {heatmapTransform, bin2d} from './heatmap'
 import {newTable} from '../utils/newTable'
 
 describe('heatmapTransform', () => {
-  test('does not crash when passed zero-width domain', () => {
+  it('does not crash when passed zero-width domain', () => {
     // x domain of this table has a zero-width domain
     const table = newTable(3)
       .addColumn('x', 'long', 'number', [1, 1, 1])
@@ -16,7 +16,7 @@ describe('heatmapTransform', () => {
     }).not.toThrow()
   })
 
-  test('does not crash when bin size is the largest among bin size, width, and height', () => {
+  it('does not crash when bin size is the largest among bin size, width, and height', () => {
     const xColKey = '_time'
     const yColKey = '_value'
     const startTime = Date.now()
@@ -48,7 +48,7 @@ describe('heatmapTransform', () => {
     }).not.toThrow()
   })
 
-  test('does not crash when bin size is negative 0, positive 0, negative, NaN, negative Infinity, or positive Infinity', () => {
+  it('does not crash when bin size is negative 0, positive 0, negative, NaN, negative Infinity, or positive Infinity', () => {
     const xColKey = '_time'
     const yColKey = '_value'
     const startTime = Date.now()

--- a/giraffe/src/transforms/histogram.test.ts
+++ b/giraffe/src/transforms/histogram.test.ts
@@ -7,7 +7,7 @@ import {X_MIN, X_MAX, Y_MIN, Y_MAX, COUNT, FILL} from '../constants/columnKeys'
 const valueData = [70, 56, 60, 100, 76, 0, 63, 48, 79, 67]
 
 describe('bin', () => {
-  test('with a single group', () => {
+  it('with a single group', () => {
     const table = newTable(10)
       .addColumn('_value', 'double', 'number', valueData)
       .addColumn(FILL, 'double', 'number', [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
@@ -22,7 +22,7 @@ describe('bin', () => {
     expect(actual.getColumn(COUNT, 'number')).toEqual([1, 0, 2, 6, 1])
   })
 
-  test('with four groups', () => {
+  it('with four groups', () => {
     const table = newTable(10)
       .addColumn('_value', 'double', 'number', valueData)
       .addColumn(FILL, 'double', 'number', [0, 0, 0, 1, 1, 2, 2, 2, 3, 3])
@@ -78,7 +78,7 @@ describe('bin', () => {
     ])
   })
 
-  test('with overlaid positioning', () => {
+  it('with overlaid positioning', () => {
     const table = newTable(10)
       .addColumn('_value', 'double', 'number', valueData)
       .addColumn(FILL, 'double', 'number', [0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
@@ -116,7 +116,7 @@ describe('bin', () => {
     ])
   })
 
-  test('with a widened x domain', () => {
+  it('with a widened x domain', () => {
     const table = newTable(10)
       .addColumn('_value', 'double', 'number', valueData)
       .addColumn(FILL, 'double', 'number', [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
@@ -149,7 +149,7 @@ describe('bin', () => {
     ])
   })
 
-  test('with a narrowed x domain', () => {
+  it('with a narrowed x domain', () => {
     const table = newTable(10)
       .addColumn('_value', 'double', 'number', valueData)
       .addColumn(FILL, 'double', 'number', [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
@@ -165,7 +165,7 @@ describe('bin', () => {
 })
 
 describe('histogramTransform', () => {
-  test('does not crash when passed zero-width domain', () => {
+  it('does not crash when passed zero-width domain', () => {
     // x domain of this table has a zero-width domain
     const table = newTable(3)
       .addColumn('x', 'double', 'number', [1, 1, 1])

--- a/giraffe/src/transforms/index.test.ts
+++ b/giraffe/src/transforms/index.test.ts
@@ -4,7 +4,7 @@ import {NINETEEN_EIGHTY_FOUR} from '../constants/colorSchemes'
 describe('getBandColorScale', () => {
   const COLOR_TEST_LIMIT = 1000
 
-  test('uses the same color when bandIndexMap has no rowIndices', () => {
+  it('uses the same color when bandIndexMap has no rowIndices', () => {
     const scale = getBandColorScale(
       {rowIndices: [], lowerIndices: [], upperIndices: []},
       NINETEEN_EIGHTY_FOUR
@@ -23,7 +23,7 @@ describe('getBandColorScale', () => {
     expect(scale(0)).toEqual(scale(100))
   })
 
-  test('uses more than 1 color when bandIndexMap.rowIndices has length greater than 0', () => {
+  it('uses more than 1 color when bandIndexMap.rowIndices has length greater than 0', () => {
     let scale = getBandColorScale(
       {rowIndices: [0], lowerIndices: [], upperIndices: []},
       NINETEEN_EIGHTY_FOUR
@@ -64,7 +64,7 @@ describe('getBandColorScale', () => {
     expect(Object.keys(colorsTracker).length).toBeGreaterThan(1)
   })
 
-  test('upper and lower indicies have no effect on the colors when rowIndices are empty', () => {
+  it('upper and lower indicies have no effect on the colors when rowIndices are empty', () => {
     let scale = getBandColorScale(
       {rowIndices: [], lowerIndices: [0, 1], upperIndices: []},
       NINETEEN_EIGHTY_FOUR
@@ -111,7 +111,7 @@ describe('getBandColorScale', () => {
     ).toEqual(true)
   })
 
-  test('upper and lower indicies have no effect on the colors when rowIndices are not empty', () => {
+  it('upper and lower indicies have no effect on the colors when rowIndices are not empty', () => {
     let scale = getBandColorScale(
       {rowIndices: [4, 5], lowerIndices: [0, 1], upperIndices: []},
       NINETEEN_EIGHTY_FOUR

--- a/giraffe/src/utils/PlotEnv.test.ts
+++ b/giraffe/src/utils/PlotEnv.test.ts
@@ -29,7 +29,7 @@ describe('PlotEnv', () => {
       lineTransformSpy.mockRestore()
     })
 
-    test('updates xScale when xDomain is updated', () => {
+    it('updates xScale when xDomain is updated', () => {
       const plotEnv = new PlotEnv()
 
       const aData = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
@@ -62,7 +62,7 @@ describe('PlotEnv', () => {
       )
     })
 
-    test('runs bin stat when x domain changes', () => {
+    it('runs bin stat when x domain changes', () => {
       const plotEnv = new PlotEnv()
 
       const aData = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
@@ -95,7 +95,7 @@ describe('PlotEnv', () => {
       expect(histogramTransformSpy).toHaveBeenCalledTimes(2)
     })
 
-    test('runs bin stat when histogram layer x mapping changes', () => {
+    it('runs bin stat when histogram layer x mapping changes', () => {
       const plotEnv = new PlotEnv()
 
       const aData = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
@@ -131,7 +131,7 @@ describe('PlotEnv', () => {
       expect(histogramTransformSpy).toHaveBeenCalledTimes(2)
     })
 
-    test('does not run bin stat when histogram fillOpacity change', () => {
+    it('does not run bin stat when histogram fillOpacity change', () => {
       const plotEnv = new PlotEnv()
 
       const aData = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
@@ -162,7 +162,7 @@ describe('PlotEnv', () => {
       expect(histogramTransformSpy).toHaveBeenCalledTimes(1)
     })
 
-    test('updating line interpolation should not reset the x domain', () => {
+    it('updating line interpolation should not reset the x domain', () => {
       const plotEnv = new PlotEnv()
 
       const aData = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
@@ -193,7 +193,7 @@ describe('PlotEnv', () => {
       expect(plotEnv.xDomain).toEqual([12, 15])
     })
 
-    test('does not run line stat when x domain changes', () => {
+    it('does not run line stat when x domain changes', () => {
       const plotEnv = new PlotEnv()
 
       const aData = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
@@ -227,7 +227,7 @@ describe('PlotEnv', () => {
       expect(lineTransformSpy).toHaveBeenCalledTimes(1)
     })
 
-    test('resets uncontrolled domain state when x mapping changes', () => {
+    it('resets uncontrolled domain state when x mapping changes', () => {
       const plotEnv = new PlotEnv()
 
       const aData = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]

--- a/giraffe/src/utils/fluxParsing.test.ts
+++ b/giraffe/src/utils/fluxParsing.test.ts
@@ -57,13 +57,13 @@ const TRUNCATED_RESPONSE = `
 `
 
 describe('parseResponse', () => {
-  test('parseResponse into the right number of tables', () => {
+  it('parseResponse into the right number of tables', () => {
     const result = parseResponse(MULTI_SCHEMA_RESPONSE)
     expect(result).toHaveLength(4)
   })
 
   describe('result name', () => {
-    test('uses the result name from the result column if present', () => {
+    it('uses the result name from the result column if present', () => {
       const resp = `#group,false,false,false,false,false,false,true,true,true
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
 #default,,,,,,,,,
@@ -79,7 +79,7 @@ describe('parseResponse', () => {
       expect(actual[0].result).toBe('max')
     })
 
-    test('uses the result name from the default annotation if result columns are empty', () => {
+    it('uses the result name from the default annotation if result columns are empty', () => {
       const resp = `#group,false,false,false,false,false,false,true,true,true
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
 #default,max,,,,,,,,
@@ -107,20 +107,20 @@ describe('parseResponse', () => {
   })
 
   describe('headers', () => {
-    test('throws when no metadata is present', () => {
+    it('throws when no metadata is present', () => {
       expect(() => {
         parseResponse(RESPONSE_NO_METADATA)
       }).toThrow()
     })
 
-    test('can parse headers when metadata is present', () => {
+    it('can parse headers when metadata is present', () => {
       const actual = parseResponse(RESPONSE_METADATA)[0].data[0]
       expect(actual).toEqual(EXPECTED_COLUMNS)
     })
   })
 
   describe('group key', () => {
-    test('parses the group key properly', () => {
+    it('parses the group key properly', () => {
       const actual = parseResponse(MULTI_SCHEMA_RESPONSE)[0].groupKey
       const expected = {
         _field: 'usage_guest',
@@ -133,7 +133,7 @@ describe('parseResponse', () => {
   })
 
   describe('partial responses', () => {
-    test('should discard tables without any non-annotation rows', () => {
+    it('should discard tables without any non-annotation rows', () => {
       const actual = parseResponse(TRUNCATED_RESPONSE)
 
       expect(actual).toHaveLength(2)

--- a/giraffe/src/utils/formatStatValue.test.ts
+++ b/giraffe/src/utils/formatStatValue.test.ts
@@ -6,7 +6,7 @@ describe('formatStatValue', () => {
   let suffix: string
 
   describe('handles bad input gracefully', () => {
-    test('does not throw an error when decimal places is greater than 100', () => {
+    it('does not throw an error when decimal places is greater than 100', () => {
       expect(() =>
         formatStatValue('2.00', {
           decimalPlaces: {isEnforced: true, digits: 101},
@@ -14,7 +14,7 @@ describe('formatStatValue', () => {
       ).not.toThrow()
     })
 
-    test('handles undefined', () => {
+    it('handles undefined', () => {
       prefix = 'LOL'
       value = undefined
       suffix = ' is funny'
@@ -28,7 +28,7 @@ describe('formatStatValue', () => {
       expect(errorResult).not.toEqual(`${prefix}${value}${suffix}`)
     })
 
-    test('handles null', () => {
+    it('handles null', () => {
       prefix = ':-('
       value = null
       suffix = ' is not funny'
@@ -43,7 +43,7 @@ describe('formatStatValue', () => {
     })
   })
 
-  test('formats NaN', () => {
+  it('formats NaN', () => {
     prefix = 'My nanny is '
     value = NaN
     suffix = ''
@@ -56,7 +56,7 @@ describe('formatStatValue', () => {
     ).toEqual(`${prefix}${value}${suffix}`)
   })
 
-  test('formats Infinity', () => {
+  it('formats Infinity', () => {
     prefix = 'To '
     value = Infinity
     suffix = ' and beyond'
@@ -71,7 +71,7 @@ describe('formatStatValue', () => {
     ).toEqual(`${prefix}${INFINITY_SYMBOL}${suffix}`)
   })
 
-  test('formats negative Infinity', () => {
+  it('formats negative Infinity', () => {
     prefix = 'To '
     value = -Infinity
     suffix = ' and beyond'
@@ -86,7 +86,7 @@ describe('formatStatValue', () => {
     ).toEqual(`${prefix}-${INFINITY_SYMBOL}${suffix}`)
   })
 
-  test('formats 0 with trailing decimal 0s', () => {
+  it('formats 0 with trailing decimal 0s', () => {
     prefix = ''
     value = 0
     let trailingDecimals = 2
@@ -110,7 +110,7 @@ describe('formatStatValue', () => {
     ).toEqual(`${prefix}0.0000000000${suffix}`)
   })
 
-  test('formats an integer value', () => {
+  it('formats an integer value', () => {
     prefix = 'we have '
     value = 123
     suffix = ' abc'
@@ -141,7 +141,7 @@ describe('formatStatValue', () => {
     ).toEqual(`${prefix}123,456,789${suffix}`)
   })
 
-  test('formats a float value', () => {
+  it('formats a float value', () => {
     prefix = 'abc '
     value = 123.456789
     suffix = ' yoyoyo'
@@ -163,7 +163,7 @@ describe('formatStatValue', () => {
     ).toEqual(`${prefix}-9.0123456789${suffix}`)
   })
 
-  test('formats an empty string value', () => {
+  it('formats an empty string value', () => {
     prefix = ''
     value = ''
     suffix = ''
@@ -176,7 +176,7 @@ describe('formatStatValue', () => {
     ).toEqual(`${prefix}${value}${suffix}`)
   })
 
-  test('formats a non-empty string value', () => {
+  it('formats a non-empty string value', () => {
     prefix = 'Negative '
     value = '-666.666'
     suffix = ' is Evil'
@@ -189,7 +189,7 @@ describe('formatStatValue', () => {
     ).toEqual(`${prefix}${value}${suffix}`)
   })
 
-  test('keeps trailing zeroes for the required number of decimal places only when not a string', () => {
+  it('keeps trailing zeroes for the required number of decimal places only when not a string', () => {
     value = '2.000'
     expect(
       formatStatValue(value, {decimalPlaces: {isEnforced: true, digits: 3}})
@@ -224,7 +224,7 @@ describe('formatStatValue', () => {
     ).toEqual('2.000')
   })
 
-  test('has commas as separator for large numbers', () => {
+  it('has commas as separator for large numbers', () => {
     value = 1234567
     expect(formatStatValue(value)).toEqual('1,234,567')
     expect(

--- a/giraffe/src/utils/formatters.test.ts
+++ b/giraffe/src/utils/formatters.test.ts
@@ -5,7 +5,7 @@ import {
 } from './formatters'
 
 describe('timeFormatter', () => {
-  test('defaults to 12 hour time unless timezone is UTC', () => {
+  it('defaults to 12 hour time unless timezone is UTC', () => {
     const utcFormatter = timeFormatter({timeZone: 'UTC'})
     const nonUTCFormatter = timeFormatter({timeZone: 'America/Los_Angeles'})
 
@@ -18,7 +18,7 @@ describe('timeFormatter', () => {
     expect(nonUTCFormatter(d)).toEqual('2018-12-31  4:00:00 PM PST')
   })
 
-  test('handles ante meridiem and post meridiem', () => {
+  it('handles ante meridiem and post meridiem', () => {
     let d = new Date('2019-01-01T00:00Z')
 
     let meridiemFormatter = timeFormatter({
@@ -74,7 +74,7 @@ describe('timeFormatter', () => {
     expect(meridiemFormatter(d)).toEqual('4:00 PM')
   })
 
-  test('uses AM/PM when given "a" in the format regardless of time zone or time format', () => {
+  it('uses AM/PM when given "a" in the format regardless of time zone or time format', () => {
     const utcFormatterWithFormat = timeFormatter({
       timeZone: 'UTC',
       format: 'YYYY-MM-DD HH:mm:ss a ZZ',
@@ -104,7 +104,7 @@ describe('timeFormatter', () => {
     )
   })
 
-  test('24 hour format and UTC format without "a" should not show "24" for midnight', () => {
+  it('24 hour format and UTC format without "a" should not show "24" for midnight', () => {
     const utcFormatterWithFormat = timeFormatter({
       timeZone: 'UTC',
       format: 'YYYY-MM-DD HH:mm:ss ZZ',
@@ -127,7 +127,7 @@ describe('timeFormatter', () => {
     )
   })
 
-  test('24 hour format and UTC format without "a" should display correctly', () => {
+  it('24 hour format and UTC format without "a" should display correctly', () => {
     const utcFormatterWithFormat = timeFormatter({
       timeZone: 'UTC',
       format: 'YYYY-MM-DD HH:mm:ss ZZ',
@@ -147,7 +147,7 @@ describe('timeFormatter', () => {
     expect(nonUTCFormatterWithFormat(date)).toEqual('2019-01-01 08:00:00 GMT+1')
   })
 
-  test('can format times with format strings', () => {
+  it('can format times with format strings', () => {
     const tests = [
       ['YYYY-MM-DD HH:mm:ss', '2019-01-01 00:00:00'],
       ['YYYY-MM-DD HH:mm:ss ZZ', '2019-01-01 00:00:00 UTC'],
@@ -171,7 +171,7 @@ describe('timeFormatter', () => {
     }
   })
 
-  test('it can format times with a variable level of detail', () => {
+  it('it can format times with a variable level of detail', () => {
     const formatter = timeFormatter({timeZone: 'UTC'})
 
     // Defaults to quite detailed if no domainWidth passed
@@ -188,7 +188,7 @@ describe('timeFormatter', () => {
 })
 
 describe('siPrefixFormatter', () => {
-  test('can format numbers with SI unit prefixes', () => {
+  it('can format numbers with SI unit prefixes', () => {
     const f = siPrefixFormatter({significantDigits: 6})
 
     expect(f(123456)).toEqual('123.456k')
@@ -196,19 +196,19 @@ describe('siPrefixFormatter', () => {
     expect(f(12345678912345.123456789)).toEqual('12.3457T')
   })
 
-  test('can format numbers with a unit suffix', () => {
+  it('can format numbers with a unit suffix', () => {
     const f = siPrefixFormatter({suffix: 'm'})
 
     expect(f(1000)).toEqual('1km')
   })
 
-  test('can format numbers with a prefix', () => {
+  it('can format numbers with a prefix', () => {
     const f = siPrefixFormatter({prefix: 'howdy'})
 
     expect(f(1000)).toEqual('howdy1k')
   })
 
-  test('can specify zeros are always included', () => {
+  it('can specify zeros are always included', () => {
     const f = siPrefixFormatter({trimZeros: false, significantDigits: 4})
 
     expect(f(37)).toEqual('37.00')
@@ -217,7 +217,7 @@ describe('siPrefixFormatter', () => {
 })
 
 describe('binaryPrefixFormatter', () => {
-  test('can format numbers with binary unit prefixes', () => {
+  it('can format numbers with binary unit prefixes', () => {
     const f = binaryPrefixFormatter()
 
     expect(f(2 ** 10)).toEqual('1 K')
@@ -225,32 +225,32 @@ describe('binaryPrefixFormatter', () => {
     expect(f(2 ** 30)).toEqual('1 G')
   })
 
-  test('can format negative numbers with a binary unit prefix', () => {
+  it('can format negative numbers with a binary unit prefix', () => {
     const f = binaryPrefixFormatter()
 
     expect(f(0 - 2 ** 30)).toEqual('-1 G')
   })
 
-  test('formats small numbers without unit prefixes', () => {
+  it('formats small numbers without unit prefixes', () => {
     const f = binaryPrefixFormatter()
 
     expect(f(0.551249)).toEqual('0.551249')
     expect(f(0.551249)).toEqual('0.551249')
   })
 
-  test('can add a prefix to formatted numbers', () => {
+  it('can add a prefix to formatted numbers', () => {
     const f = binaryPrefixFormatter({prefix: 'my favorite number '})
 
     expect(f(1)).toEqual('my favorite number 1')
   })
 
-  test('can add a suffix to formatted numbers', () => {
+  it('can add a suffix to formatted numbers', () => {
     const f = binaryPrefixFormatter({suffix: ' snorp'})
 
     expect(f(1)).toEqual('1 snorp')
   })
 
-  test('can configure the significant digits for formatted number', () => {
+  it('can configure the significant digits for formatted number', () => {
     const f = binaryPrefixFormatter({significantDigits: 1})
     const g = binaryPrefixFormatter({significantDigits: 8})
     const h = binaryPrefixFormatter({significantDigits: 0})

--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -295,7 +295,7 @@ describe('fromFlux', () => {
     const fFlux = fromFlux(resp)
     expect(fFlux).toEqual(expected)
   })
-  test('can parse a Flux CSV with mismatched schemas', () => {
+  it('can parse a Flux CSV with mismatched schemas', () => {
     const CSV = `#group,false,false,true,true,false,true,true,true,true,true
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
 #default,_result,,,,,,,,,
@@ -400,7 +400,7 @@ describe('fromFlux', () => {
     ])
   })
 
-  test('should error out gracefully when an error is thrown in the fromFlux parser', () => {
+  it('should error out gracefully when an error is thrown in the fromFlux parser', () => {
     const CSV =
       '#group,false,false,true,true,false,false,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true'
 
@@ -411,7 +411,7 @@ describe('fromFlux', () => {
     expect(actual.error).toBeTruthy()
   })
 
-  test('uses the default annotation to fill in empty values', () => {
+  it('uses the default annotation to fill in empty values', () => {
     const CSV = `#group,false,false,true,true,true,true
 #datatype,string,long,string,string,long,long
 #default,_result,,,cpu,,6
@@ -428,7 +428,7 @@ describe('fromFlux', () => {
     expect(actual.getColumn('d')).toEqual([6, 6])
   })
 
-  test('returns a group key union', () => {
+  it('returns a group key union', () => {
     const CSV = `#group,true,false,false,true
 #datatype,string,string,string,string
 #default,,,,
@@ -444,7 +444,7 @@ describe('fromFlux', () => {
     expect(fluxGroupKeyUnion).toEqual(['a', 'c', 'd'])
   })
 
-  test('parses empty numeric values as null', () => {
+  it('parses empty numeric values as null', () => {
     const CSV = `#group,false,false,true,true,false,true,true,true,true,true
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
 #default,_result,,,,,,,,,
@@ -457,7 +457,7 @@ describe('fromFlux', () => {
     expect(table.getColumn('_value')).toEqual([10, null])
   })
 
-  test('handles newlines inside string values', () => {
+  it('handles newlines inside string values', () => {
     const CSV = `#group,false,false,false,false
 #datatype,string,long,string,long
 #default,_result,,,

--- a/giraffe/src/utils/fromRows.test.ts
+++ b/giraffe/src/utils/fromRows.test.ts
@@ -2,7 +2,7 @@ import {fromRows} from './fromRows'
 import {ColumnType} from '../types'
 
 describe('fromRows', () => {
-  test('it can infer column types', () => {
+  it('it can infer column types', () => {
     const rows = [
       {foo: 1, bar: new Date(0), baz: false, a: 'A'},
       {foo: 3, bar: new Date(1), baz: true, a: 'B'},
@@ -26,7 +26,7 @@ describe('fromRows', () => {
     expect(table.getColumnType('a')).toEqual('string')
   })
 
-  test('it can accept an explicit schema definition', () => {
+  it('it can accept an explicit schema definition', () => {
     const rows = [
       {foo: 1, bar: 0, baz: 0, a: 'A', b: '1'},
       {foo: 3, bar: 1, baz: 1, a: 'B', b: '2'},
@@ -59,7 +59,7 @@ describe('fromRows', () => {
     expect(table.getColumn('b')).toBeNull()
   })
 
-  test('with sparse data', () => {
+  it('with sparse data', () => {
     const rows = [
       {foo: 1, baz: 3},
       {foo: 3, bar: 1, baz: 7},
@@ -81,7 +81,7 @@ describe('fromRows', () => {
     ])
   })
 
-  test('throws an error when encountering a mismatched schema', () => {
+  it('throws an error when encountering a mismatched schema', () => {
     const rows = [{foo: 'bar'}, {foo: 1}]
 
     expect(() => fromRows(rows)).toThrowError(
@@ -89,7 +89,7 @@ describe('fromRows', () => {
     )
   })
 
-  test('throws an error when encountering a value of unknown ColumnType', () => {
+  it('throws an error when encountering a value of unknown ColumnType', () => {
     const rows = [{foo: {some: 'object'}}]
 
     expect(() => fromRows(rows)).toThrowError(

--- a/giraffe/src/utils/getJavaScriptTag.test.ts
+++ b/giraffe/src/utils/getJavaScriptTag.test.ts
@@ -1,39 +1,39 @@
 import {getJavaScriptTag} from './getJavaScriptTag'
 
 describe('getJavaScriptTag', () => {
-  test('get tag for Undefined', () => {
+  it('get tag for Undefined', () => {
     expect(getJavaScriptTag(undefined)).toEqual('[object Undefined]')
   })
 
-  test('get tag for Null', () => {
+  it('get tag for Null', () => {
     expect(getJavaScriptTag(null)).toEqual('[object Null]')
   })
 
-  test('get tag for Object', () => {
+  it('get tag for Object', () => {
     expect(getJavaScriptTag({})).toEqual('[object Object]')
   })
 
-  test('get tag for Array', () => {
+  it('get tag for Array', () => {
     expect(getJavaScriptTag([])).toEqual('[object Array]')
   })
 
-  test('get tag for Function', () => {
+  it('get tag for Function', () => {
     expect(getJavaScriptTag(() => {})).toEqual('[object Function]')
   })
 
-  test('get tag for String', () => {
+  it('get tag for String', () => {
     expect(getJavaScriptTag('')).toEqual('[object String]')
   })
 
-  test('get tag for Number', () => {
+  it('get tag for Number', () => {
     expect(getJavaScriptTag(1)).toEqual('[object Number]')
   })
 
-  test('get tag for Boolean', () => {
+  it('get tag for Boolean', () => {
     expect(getJavaScriptTag(true)).toEqual('[object Boolean]')
   })
 
-  test('get tag for Symbol', () => {
+  it('get tag for Symbol', () => {
     expect(getJavaScriptTag(Symbol())).toEqual('[object Symbol]')
   })
 })

--- a/giraffe/src/utils/getLatestValues.test.ts
+++ b/giraffe/src/utils/getLatestValues.test.ts
@@ -2,7 +2,7 @@ import {getLatestValues} from './getLatestValues'
 import {newTable} from '../utils/newTable'
 
 describe('getLatestValues', () => {
-  test('gives an empty array when table is empty', () => {
+  it('gives an empty array when table is empty', () => {
     const table = newTable(0)
     const result = getLatestValues(table)
 
@@ -10,7 +10,7 @@ describe('getLatestValues', () => {
     expect(result.length).toEqual(0)
   })
 
-  test('finds the value when timestamp column is missing and only 1 row exists in the table', () => {
+  it('finds the value when timestamp column is missing and only 1 row exists in the table', () => {
     const yColKey = '_value'
     const table = newTable(1).addColumn(yColKey, 'system', 'number', [3.99])
     const result = getLatestValues(table)
@@ -19,7 +19,7 @@ describe('getLatestValues', () => {
     expect(result[0]).toEqual(3.99)
   })
 
-  test('gives an empty array when timestamp column is missing and there are multiple rows in the table', () => {
+  it('gives an empty array when timestamp column is missing and there are multiple rows in the table', () => {
     const yColKey = '_value'
     const table = newTable(4).addColumn(yColKey, 'system', 'number', [
       0,
@@ -33,7 +33,7 @@ describe('getLatestValues', () => {
     expect(result.length).toEqual(0)
   })
 
-  test('finds the correct value even when timestamp column is not ordered', () => {
+  it('finds the correct value even when timestamp column is not ordered', () => {
     const xColKey = '_time'
     const yColKey = '_value'
     const startTime = Date.now()
@@ -52,7 +52,7 @@ describe('getLatestValues', () => {
     expect(result[0]).toEqual(2.32)
   })
 
-  test('finds the value associated with the most recent timestamp', () => {
+  it('finds the value associated with the most recent timestamp', () => {
     const xColKey = '_time'
     const yColKey = '_value'
     const startTime = Date.now()
@@ -70,7 +70,7 @@ describe('getLatestValues', () => {
     expect(result[0]).toEqual(2.32)
   })
 
-  test('ignores columns with invalid types', () => {
+  it('ignores columns with invalid types', () => {
     const xColKey = '_time'
     const yColKey = '_value'
     const startTime = Date.now()

--- a/giraffe/src/utils/identityMerge.test.ts
+++ b/giraffe/src/utils/identityMerge.test.ts
@@ -7,7 +7,7 @@ import {
 } from './identityMerge'
 
 describe('identityMerge', () => {
-  test('can merge two objects', () => {
+  it('can merge two objects', () => {
     const source = {
       key1: 'PRIMATIVE_VALUE',
       key2: 10,
@@ -48,7 +48,7 @@ describe('identityMerge', () => {
     expect(result.key4.key7.key9).toBe(source.key4.key7.key9)
   })
 
-  test('returns source when source and target are logically equal', () => {
+  it('returns source when source and target are logically equal', () => {
     const source = {foo: 'a', bar: 'b', baz: ['a', 'b', 'c']}
     const target = {foo: 'a', bar: 'b', baz: ['a', 'b', 'c']}
 
@@ -57,7 +57,7 @@ describe('identityMerge', () => {
     expect(result).toBe(source)
   })
 
-  test('can maintain reference equality of a function with a property', () => {
+  it('can maintain reference equality of a function with a property', () => {
     const f = () => 2
 
     f.someProperty = 'foo'
@@ -72,7 +72,7 @@ describe('identityMerge', () => {
 })
 
 describe('enumeratePaths', () => {
-  test('enumerates the paths in a tree according to preorder traversal', () => {
+  it('enumerates the paths in a tree according to preorder traversal', () => {
     const target = {
       root: {
         a: [4, 5, 6],
@@ -99,13 +99,13 @@ describe('enumeratePaths', () => {
 })
 
 describe('getByPath', () => {
-  test('can access existant and nonexistant properties', () => {
+  it('can access existant and nonexistant properties', () => {
     expect(getByPath({a: {b: {c: 2}}}, ['a', 'b', 'c'])).toEqual(2)
     expect(getByPath({a: false}, ['a'])).toEqual(false)
     expect(getByPath({a: false}, ['b'])).toBeUndefined()
   })
 
-  test('can safely attempt property access on null, undefined values, and primative values', () => {
+  it('can safely attempt property access on null, undefined values, and primative values', () => {
     expect(getByPath(null, ['a', 'b'])).toBeUndefined()
     expect(getByPath(undefined, ['a', 'b'])).toBeUndefined()
     expect(getByPath(1, ['a', 'b'])).toBeUndefined()
@@ -115,7 +115,7 @@ describe('getByPath', () => {
 })
 
 describe('setByPath', () => {
-  test('can set deep non-existant paths in an object', () => {
+  it('can set deep non-existant paths in an object', () => {
     const target = {a: '1'}
 
     setByPath(target, ['b', 'c'], 2)
@@ -123,7 +123,7 @@ describe('setByPath', () => {
     expect(target).toEqual({a: '1', b: {c: 2}})
   })
 
-  test('can set deep existant paths in an object', () => {
+  it('can set deep existant paths in an object', () => {
     const target = {a: '1', b: {c: 2}}
 
     setByPath(target, ['b', 'c'], 3)
@@ -131,17 +131,17 @@ describe('setByPath', () => {
     expect(target).toEqual({a: '1', b: {c: 3}})
   })
 
-  test('throws an error when attempting to set on null', () => {
+  it('throws an error when attempting to set on null', () => {
     expect(() => setByPath(null, ['a', 'b'], 2)).toThrow()
   })
 
-  test('throws an error when attempting to set an empty path', () => {
+  it('throws an error when attempting to set an empty path', () => {
     expect(() => setByPath({a: 'b'}, [], 2)).toThrow()
   })
 })
 
 describe('isEqual', () => {
-  test('checks if objects are equal according to their logical identity', () => {
+  it('checks if objects are equal according to their logical identity', () => {
     expect(isEqual('4', '4')).toBeTruthy()
     expect(isEqual('4', '5')).toBeFalsy()
     expect(isEqual('4', 4)).toBeFalsy()

--- a/giraffe/src/utils/isNumber.test.ts
+++ b/giraffe/src/utils/isNumber.test.ts
@@ -1,37 +1,37 @@
 import {isNumber} from './isNumber'
 
 describe('isNumber', () => {
-  test('the value created from the Number constructor is a number', () => {
+  it('the value created from the Number constructor is a number', () => {
     const value = new Number()
 
     expect(typeof value === 'object').toEqual(true)
     expect(isNumber(value)).toEqual(true)
   })
 
-  test('the value created from the Number function is a number', () => {
+  it('the value created from the Number function is a number', () => {
     const value = Number()
 
     expect(typeof value !== 'object').toEqual(true)
     expect(isNumber(value)).toEqual(true)
   })
 
-  test('a literal number is a number', () => {
+  it('a literal number is a number', () => {
     expect(isNumber(1)).toEqual(true)
     expect(isNumber(123456789)).toEqual(true)
     expect(isNumber(0)).toEqual(true)
     expect(isNumber(-4567.89)).toEqual(true)
   })
 
-  test('Infinity and negative Infinity are numbers', () => {
+  it('Infinity and negative Infinity are numbers', () => {
     expect(isNumber(Infinity)).toEqual(true)
     expect(isNumber(-Infinity)).toEqual(true)
   })
 
-  test('the value NaN is a number', () => {
+  it('the value NaN is a number', () => {
     expect(isNumber(NaN)).toEqual(true)
   })
 
-  test('anything else is not a number', () => {
+  it('anything else is not a number', () => {
     expect(isNumber(undefined)).toEqual(false)
     expect(isNumber(null)).toEqual(false)
     expect(isNumber({})).toEqual(false)

--- a/giraffe/src/utils/isString.test.ts
+++ b/giraffe/src/utils/isString.test.ts
@@ -1,21 +1,21 @@
 import {isString} from './isString'
 
 describe('isString', () => {
-  test('the value created from the String constructor is a string', () => {
+  it('the value created from the String constructor is a string', () => {
     const value = new String()
 
     expect(typeof value === 'object').toEqual(true)
     expect(isString(value)).toEqual(true)
   })
 
-  test('the value created from the String function is a string', () => {
+  it('the value created from the String function is a string', () => {
     const value = String()
 
     expect(typeof value !== 'object').toEqual(true)
     expect(isString(value)).toEqual(true)
   })
 
-  test('a literal string is a string', () => {
+  it('a literal string is a string', () => {
     expect(
       isString('@#$^@#$@ ; \n\nerer /.,.. abc one two three!!!!! #_+[]')
     ).toEqual(true)
@@ -24,7 +24,7 @@ describe('isString', () => {
     expect(isString('-4567.89')).toEqual(true)
   })
 
-  test('anything else is not a string', () => {
+  it('anything else is not a string', () => {
     expect(isString(undefined)).toEqual(false)
     expect(isString(null)).toEqual(false)
     expect(isString({})).toEqual(false)

--- a/giraffe/src/utils/isSymbol.test.ts
+++ b/giraffe/src/utils/isSymbol.test.ts
@@ -1,7 +1,7 @@
 import {isSymbol} from './isSymbol'
 
 describe('isSymbol', () => {
-  test('a value created from the Symbol function is a Symbol', () => {
+  it('a value created from the Symbol function is a Symbol', () => {
     expect(isSymbol(Symbol())).toEqual(true)
     expect(isSymbol(Symbol(''))).toEqual(true)
     expect(isSymbol(Symbol('yoyoyo'))).toEqual(true)
@@ -10,13 +10,13 @@ describe('isSymbol', () => {
     expect(isSymbol(Symbol(-3.14))).toEqual(true)
   })
 
-  test('an object wrapping a value created from the Symbol function is a Symbol', () => {
+  it('an object wrapping a value created from the Symbol function is a Symbol', () => {
     const symbol = Symbol('a real symbol')
     const wrapper = Object(symbol)
     expect(isSymbol(wrapper)).toEqual(true)
   })
 
-  test('anything else is not a Symbol', () => {
+  it('anything else is not a Symbol', () => {
     expect(isSymbol('is this a symbol?')).toEqual(false)
     expect(isSymbol(undefined)).toEqual(false)
     expect(isSymbol(null)).toEqual(false)

--- a/giraffe/src/utils/lineData.perf.test.ts
+++ b/giraffe/src/utils/lineData.perf.test.ts
@@ -10,7 +10,7 @@ import {dataSize, largeTable, lineData} from './fixtures/line'
 const REASONABLE_LIMIT = 5_000_000
 
 describe('line graph performance', () => {
-  test('fixture should be greater than or equal to REASONABLE_LIMIT', () => {
+  it('fixture should be greater than or equal to REASONABLE_LIMIT', () => {
     expect(dataSize).toBeGreaterThanOrEqual(REASONABLE_LIMIT)
   })
 

--- a/giraffe/src/utils/range.test.ts
+++ b/giraffe/src/utils/range.test.ts
@@ -5,77 +5,77 @@ describe('range creates an array from start to end using an increment or decreme
   const MAX_INTEGER = 1.7976931348623157e308
 
   describe('uses increment when end is greater than start', () => {
-    test('uses an increment of 1 when not specified or explicitly undefined', () => {
+    it('uses an increment of 1 when not specified or explicitly undefined', () => {
       expect(range(0, 5)).toEqual([0, 1, 2, 3, 4])
       expect(range(0, 5, undefined)).toEqual([0, 1, 2, 3, 4])
     })
 
-    test('uses an increment of 0 when increment is NaN or null', () => {
+    it('uses an increment of 0 when increment is NaN or null', () => {
       expect(range(0, 5, NaN)).toEqual([0, 0, 0, 0, 0])
       expect(range(0, 5, null)).toEqual([0, 0, 0, 0, 0])
     })
 
-    test('uses a max integer for increment when increment is Infinity', () => {
+    it('uses a max integer for increment when increment is Infinity', () => {
       expect(range(0, MAX_INTEGER, Infinity)).toEqual([0])
     })
 
-    test('throws an error when start is negative Infinity, end is Infinity, or both', () => {
+    it('throws an error when start is negative Infinity, end is Infinity, or both', () => {
       expect(() => range(0, Infinity)).toThrow()
       expect(() => range(-Infinity, 0)).toThrow()
       expect(() => range(-Infinity, Infinity)).toThrow()
     })
 
-    test('uses the increment when specified', () => {
+    it('uses the increment when specified', () => {
       expect(range(0, 10, 2)).toEqual([0, 2, 4, 6, 8])
     })
   })
 
   describe('uses decrement when start is greater than end', () => {
-    test('returns empty range when decrement is not specified, explicitly undefined, null, or NaN', () => {
+    it('returns empty range when decrement is not specified, explicitly undefined, null, or NaN', () => {
       expect(range(5, 0)).toEqual(emptyRange)
       expect(range(5, 0, undefined)).toEqual(emptyRange)
       expect(range(5, 0, NaN)).toEqual(emptyRange)
       expect(range(5, 0, null)).toEqual(emptyRange)
     })
 
-    test('uses a max integer for decrement when decrement is -Infinity', () => {
+    it('uses a max integer for decrement when decrement is -Infinity', () => {
       expect(range(0, -MAX_INTEGER, -Infinity)).toEqual([0])
     })
 
-    test('throws an error when start is Infinity, end is negative Infinity, or both', () => {
+    it('throws an error when start is Infinity, end is negative Infinity, or both', () => {
       expect(() => range(Infinity, 0, -1)).toThrow()
       expect(() => range(0, -Infinity, -1)).toThrow()
       expect(() => range(Infinity, -Infinity, -1)).toThrow()
     })
 
-    test('uses the decrement when specified', () => {
+    it('uses the decrement when specified', () => {
       expect(range(5, 0, -1)).toEqual([5, 4, 3, 2, 1])
     })
   })
 
-  test('gives a range that includes start and excludes end', () => {
+  it('gives a range that includes start and excludes end', () => {
     expect(range(0, 1)).toEqual([0])
     expect(range(-1, -2, -1)).toEqual([-1])
   })
 
-  test('gives an empty range when start and end are equal', () => {
+  it('gives an empty range when start and end are equal', () => {
     expect(range(0, 0)).toEqual(emptyRange)
     expect(range(20, 20)).toEqual(emptyRange)
     expect(range(-1, -1)).toEqual(emptyRange)
     expect(range(-5, -5, -1)).toEqual(emptyRange)
   })
 
-  test('interprets start as 0 when start is NaN', () => {
+  it('interprets start as 0 when start is NaN', () => {
     expect(range(NaN, 5)).toEqual([0, 1, 2, 3, 4])
     expect(range(NaN, -5, -1)).toEqual([0, -1, -2, -3, -4])
   })
 
-  test('interprets end as 0 when end is NaN', () => {
+  it('interprets end as 0 when end is NaN', () => {
     expect(range(-5, NaN)).toEqual([-5, -4, -3, -2, -1])
     expect(range(5, NaN, -1)).toEqual([5, 4, 3, 2, 1])
   })
 
-  test('interprets start and end as 0 when both are NaN', () => {
+  it('interprets start and end as 0 when both are NaN', () => {
     expect(range(NaN, NaN)).toEqual(emptyRange)
     expect(range(NaN, NaN, -1)).toEqual(emptyRange)
   })

--- a/giraffe/src/utils/rawFluxDataTable.test.ts
+++ b/giraffe/src/utils/rawFluxDataTable.test.ts
@@ -1,7 +1,7 @@
 import {parseFiles, parseFilesWithObjects} from './rawFluxDataTable'
 
 describe('parseFiles', () => {
-  test('can parse multi-csv response', () => {
+  it('can parse multi-csv response', () => {
     const CSV = `
 #group,false,false,false,false
 #datatype,string,long,string,long
@@ -46,7 +46,7 @@ describe('parseFiles', () => {
     expect(parseFiles([CSV])).toEqual(expected)
   })
 
-  test('can parse multi-csv response with values containing newlines', () => {
+  it('can parse multi-csv response with values containing newlines', () => {
     const CSV = `
 #group,false,false,false,false
 #datatype,string,long,string,long
@@ -97,7 +97,7 @@ there",5
 })
 
 describe('parseFilesWithObjects', () => {
-  test('can parse objects in CSV', () => {
+  it('can parse objects in CSV', () => {
     const CSV = `#group,false,false,true,true,false,false,true,true,true,true,true,true,true,true,true,true,true
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string,string,string,string,string,string,string,string
 #default,_result,,,,,,,,,,,,,,,,
@@ -220,7 +220,7 @@ describe('parseFilesWithObjects', () => {
     }).not.toThrow()
   })
 
-  test('can parse nested objects in CSV', () => {
+  it('can parse nested objects in CSV', () => {
     const CSV = `#group,false,false,true,true,false,false,true,true,true,true,true,true,true,true,true,true,true
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string,string,string,string,string,string,string,string
 #default,_result,,,,,,,,,,,,,,,,
@@ -343,7 +343,7 @@ describe('parseFilesWithObjects', () => {
     }).not.toThrow()
   })
 
-  test('can parse objects in multi-csv response', () => {
+  it('can parse objects in multi-csv response', () => {
     const CSV = `#group,false,false,true,true,false,false,true,true,true,true,true,true,true,true,true,true,true
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string,string,string,string,string,string,string,string
 #default,_result,,,,,,,,,,,,,,,,


### PR DESCRIPTION
- `test` becomes `it`
- collect coverage stats in test scripts to view them locally