### PR TITLE
chore: use the 339x400 logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A React-based visualization library powering the data visualizations in the [Inf
 
 (_This library is currently in pre-beta._)
 
-<img src="https://influxdata.github.io/branding/img/mascots/chronograf.png" height="100" alt="giraffe"/>
+<img src="https://influxdata.github.io/branding/img/mascots/mascot-chronograf--white_png.png" height="100" alt="giraffe"/>
 
 ## Features
 

--- a/giraffe/README.md
+++ b/giraffe/README.md
@@ -4,7 +4,7 @@
 
 A React-based visualization library powering the data visualizations in [InfluxDB 2.0](https://github.com/influxdata/influxdb/) UI.
 
-<img src="https://influxdata.github.io/branding/img/mascots/chronograf.png" height="100" alt="giraffe"/>
+<img src="https://influxdata.github.io/branding/img/mascots/mascot-chronograf--white_png.png" height="100" alt="giraffe"/>
 
 ## Demos
 


### PR DESCRIPTION
Better scaling without the extra padding on the side.