### PR TITLE
fix: bundle react correctly as an external dependency

### DIFF
--- a/giraffe/webpack.config.js
+++ b/giraffe/webpack.config.js
@@ -14,7 +14,12 @@ module.exports = {
     sourceMapFilename: '[file].map[query]',
   },
   externals: {
-    react: 'React',
+    react: {
+      amd: 'react',
+      commonjs: 'react',
+      commonjs2: 'react',
+      root: 'React',
+    },
     'react-dom': 'react-dom',
     // lodash: 'lodash' TODO: should we externalize lodash?,
   },


### PR DESCRIPTION
The previous fix worked for `<script>` imports, but left common imports high and dry. Looks like we'll need a bit more config.