### PR TITLE
chore: update webpack external config for react-dom

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/webpack.config.js
+++ b/giraffe/webpack.config.js
@@ -20,7 +20,12 @@ module.exports = {
       commonjs2: 'react',
       root: 'React',
     },
-    'react-dom': 'react-dom',
+    'react-dom': {
+      amd: 'react-dom',
+      commonjs: 'react-dom',
+      commonjs2: 'react-dom',
+      root: 'ReactDOM',
+    },
     // lodash: 'lodash' TODO: should we externalize lodash?,
   },
   devtool: 'source-map',


### PR DESCRIPTION
this should fix `<script>` consumption of Giraffe.

`v0.43.0` changed the only usage of `react-dom` in the Giraffe library, and the default config caused pages that imported Giraffe via `script` tags to break.