### PR TITLE
fix: limit tick generation to 1000 ticks

### DIFF
--- a/giraffe/src/constants/index.ts
+++ b/giraffe/src/constants/index.ts
@@ -131,3 +131,5 @@ export const TOOLTIP_MINIMUM_OPACITY = 0
 export const TOOLTIP_MAXIMUM_OPACITY = 1.0
 
 export const CLOCKFACE_Z_INDEX = 9599
+
+export const TICK_COUNT_LIMIT = 1000

--- a/giraffe/src/utils/getTicks.ts
+++ b/giraffe/src/utils/getTicks.ts
@@ -8,6 +8,7 @@ import {AxisTicks, Formatter, FormatterType} from '../types'
 
 // Constants
 import {TIME, VALUE} from '../constants/columnKeys'
+import {TICK_COUNT_LIMIT} from '../constants'
 
 // Utils
 import {getTextMetrics} from './getTextMetrics'
@@ -136,7 +137,9 @@ export const generateTicks = (
     step = (end - stepStart) / (isFiniteNumber(tickStart) ? parts : parts + 1)
   }
 
-  const tickCountLimit = isFiniteNumber(totalTicks) ? totalTicks : Infinity
+  const tickCountLimit = isFiniteNumber(totalTicks)
+    ? Math.min(totalTicks, TICK_COUNT_LIMIT)
+    : TICK_COUNT_LIMIT
 
   let counter = isFiniteNumber(tickStart) ? 0 : 1
   let generatedTick = stepStart + step * counter


### PR DESCRIPTION
Closes #362 

1000 seems like a reasonable limit. This might seem a little bit high but I wanted to leave some wiggle room for any users who might display their graphs on very large screens (a stadium-sized projector) with a small font. Not sure if there would ever be such a use case.

Performance is great with 1000 as the limit. Tested with the existing storybook story on user defined ticks.

 I am open to feedback on this number and willing to adjust accordingly.