### PR TITLE
fix: update the size of the sample text that determines axis padding

### DIFF
--- a/giraffe/src/utils/getTextMetrics.ts
+++ b/giraffe/src/utils/getTextMetrics.ts
@@ -3,6 +3,40 @@ export interface TextMetrics {
   height: number
 }
 
+const addPaddingToSampleText = (text: string): string => {
+  if (typeof text !== 'string') {
+    return text
+  }
+
+  let sample = text
+
+  /* The following are considered skinny characters:
+    -
+    1
+    |
+    i
+    l
+    I
+    !
+  */
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text.charAt(index)
+    if (
+      char === '-' ||
+      char === '1' ||
+      char === '|' ||
+      char === 'i' ||
+      char === 'l' ||
+      char === 'I' ||
+      char === '!'
+    ) {
+      sample += char
+    }
+  }
+  return sample
+}
+
 export const getTextMetrics = (font: string, text: string): TextMetrics => {
   const div = document.createElement('div')
   const span = document.createElement('span')
@@ -18,11 +52,10 @@ export const getTextMetrics = (font: string, text: string): TextMetrics => {
   document.body.appendChild(div)
 
   // Text with the same number of characters:
-  //   when it includes a dash (negative number), it tends to be skinnier than
-  //   a positive number because a dash is not as wide as a single digit (most of the time).
-  //   Add padding when text has a dash by making dashes twice as wide.
-  span.innerText =
-    typeof text === 'string' && text.includes('-') ? `-${text}` : text
+  //   when it includes a skinny character (defined above), it tends to be skinnier than
+  //   a positive number because the skinny character is not as wide as a single digit (most of the time).
+  //   Add padding when text has a skinny character by making them twice as wide.
+  span.innerText = addPaddingToSampleText(text)
 
   const metrics = {
     width: span.offsetWidth,

--- a/giraffe/src/utils/getTextMetrics.ts
+++ b/giraffe/src/utils/getTextMetrics.ts
@@ -8,29 +8,12 @@ const addPaddingToSampleText = (text: string): string => {
     return text
   }
 
+  const skinnyCharacters = ['-', '1', '|', 'i', 'l', 'I', 't']
   let sample = text
-
-  /* The following are considered skinny characters:
-    -
-    1
-    |
-    i
-    l
-    I
-    !
-  */
 
   for (let index = 0; index < text.length; index += 1) {
     const char = text.charAt(index)
-    if (
-      char === '-' ||
-      char === '1' ||
-      char === '|' ||
-      char === 'i' ||
-      char === 'l' ||
-      char === 'I' ||
-      char === '!'
-    ) {
+    if (skinnyCharacters.includes(char)) {
       sample += char
     }
   }


### PR DESCRIPTION
Closes #363 

Look for more skinny characters when updating the the sample text that determines axis padding. This will improve readability and prevent axis tick labels from being cut off on the y-axis.