### PR TITLE
fix: limit current hover point's nearest points to the first 200 data points

### DIFF
--- a/giraffe/README.md
+++ b/giraffe/README.md
@@ -464,11 +464,12 @@ Giraffe comes with utility functions.
 
   - **position**: _"overlaid" | "stacked". Optional._ Indicates whether the line graph's lines have no bearing on other lines (overlaid), or the lines are cumulatives of every line below it, ie [stacked](https://help.infragistics.com/Help/Doc/Silverlight/2011.1/CLR4.0/html/xamWebChart_Stacked_Line_Chart.html).
 
-  - **hoverDimension**: _"x" | "y" | "xy". Optional. Defaults to "x" when not included._ Indicates whether the legend (tooltip) should display all data points along an entire axis during mouse hover.
+  - **hoverDimension**: _"x" | "y" | "xy" | "auto". Optional. Defaults to "auto" when not included._ Indicates whether the legend (tooltip) should display all data points along an entire axis during mouse hover.
 
     - "x" means the legend will display all data points along the y-axis that have the same x-axis value
     - "y" means the legend will display all data points along the x-axis that have the same y-axis value
     - "xy" means the legend will display for a single data point nearest the mouse
+    - "auto" means "xy" if the legend has more than **maxTooltipRows** otherwise "auto" means "x"
 
   - **maxTooltipRows**: _number. Optional. Defaults to 24 when not included._ The maximum number of data rows to display in the legend (tooltip). Subject to screen size limitations and is not responsive or adaptive. Scrolling not implemented.
 
@@ -492,11 +493,12 @@ Giraffe comes with utility functions.
 
   - **fill**: _array[string, ...]. Optional._ An array of column key names of column filters that should be visualized. If this option is not included, the data in the graph will be interpreted as belonging to a single column.
 
-  - **hoverDimension**: _"x" | "y" | "xy". Optional. Defaults to "x" when not included._ Indicates whether the legend (tooltip) should display all data points along an entire axis during mouse hover.
+  - **hoverDimension**: _"x" | "y" | "xy" | "auto". Optional. Defaults to "xy" when not included._ Indicates whether the legend (tooltip) should display all data points along an entire axis during mouse hover.
 
     - "x" means the legend will display all data points along the y-axis that have the same x-axis value
     - "y" means the legend will display all data points along the x-axis that have the same y-axis value
     - "xy" means the legend will display for a single data point nearest the mouse
+    - "auto" means "xy" if the legend has more than **maxTooltipRows** otherwise "auto" means "x"
 
   - **maxTooltipRows**: _number. Optional. Defaults to 24 when not included._ The maximum number of data rows to display in the legend (tooltip). Subject to screen size limitations and is not responsive or adaptive. Scrolling not implemented.
 

--- a/giraffe/src/components/LineLayer.tsx
+++ b/giraffe/src/components/LineLayer.tsx
@@ -44,13 +44,11 @@ export const LineLayer: FunctionComponent<Props> = props => {
 
   let hoverDimension: 'x' | 'y' | 'xy'
 
-  if (
-    config.hoverDimension === 'auto' &&
-    Object.keys(spec.lineData).length > config.maxTooltipRows
-  ) {
-    hoverDimension = 'xy'
-  } else if (config.hoverDimension === 'auto') {
+  if (config.hoverDimension === 'auto') {
     hoverDimension = 'x'
+    if (Object.keys(spec.lineData).length > config.maxTooltipRows) {
+      hoverDimension = 'xy'
+    }
   } else {
     hoverDimension = config.hoverDimension
   }

--- a/giraffe/src/constants/index.ts
+++ b/giraffe/src/constants/index.ts
@@ -127,8 +127,8 @@ export const ALL_SYMBOL_TYPES: SymbolType[] = [
 export const BAND_COLOR_SCALE_CONSTANT = 3
 
 export const TOOLTIP_MINIMUM_OPACITY = 0
-
 export const TOOLTIP_MAXIMUM_OPACITY = 1.0
+export const HOVER_POINTS_COUNT_LIMIT = 200
 
 export const CLOCKFACE_Z_INDEX = 9599
 

--- a/giraffe/src/utils/useHoverPointIndices.ts
+++ b/giraffe/src/utils/useHoverPointIndices.ts
@@ -396,7 +396,10 @@ const lookupIndex1D = (
   if (!nearestRows.length) {
     return []
   }
-  const nearestDistance = nearestRows.reduce((acc, row) => Math.min(acc, row.distance), Infinity)
+  const nearestDistance = nearestRows.reduce(
+    (acc, row) => Math.min(acc, row.distance),
+    Infinity
+  )
 
   return nearestRows.filter(d => d.distance === nearestDistance).map(d => d.i)
 }

--- a/giraffe/src/utils/useHoverPointIndices.ts
+++ b/giraffe/src/utils/useHoverPointIndices.ts
@@ -396,12 +396,7 @@ const lookupIndex1D = (
   if (!nearestRows.length) {
     return []
   }
-  const nearestDistance = nearestRows.reduce((acc, row) => {
-    if (row.distance < acc) {
-      return row.distance
-    }
-    return acc
-  }, Infinity)
+  const nearestDistance = nearestRows.reduce((acc, row) => Math.min(acc, row.distance), Infinity)
 
   return nearestRows.filter(d => d.distance === nearestDistance).map(d => d.i)
 }


### PR DESCRIPTION
Closes idpe 9107

When there are many (thousands+) of data points with the same timestamp, hovering over them causes the browser to throw an error - "RangeError: maximum call stack size exceeded". What happens is, Giraffe collates the data of all of the nearest points to the mouse position. And then tries to render all of these points in the legend. When there are too many points, rendering all of these points on update causes this error.

To fix this, we limit the count of the nearest points to the first 200 points. This number was chosen because, visually, the legend won't fit 200 points in typically-used font sizes. Vertically, a laptop screen fits around 60 - 70 rows using a 12px font. So, 200 should be a sufficiently high limit. We can adjust this limit as necessary.

This is a temporary fix, as we should also notify the user, visually, that there are more data points than can be displayed on screen. See #375  