### PR TITLE
chore: update randomTable to allow subsequent calls

### DIFF
--- a/stories/src/data/randomTable.ts
+++ b/stories/src/data/randomTable.ts
@@ -2,28 +2,32 @@ import {newTable} from '../../../giraffe/src/utils/newTable'
 import memoizeOne from 'memoize-one'
 
 const now = Date.now()
-const numberOfRecords = 80
-const recordsPerLine = 20
-
-const TIME_COL = []
-const VALUE_COL = []
-const CPU_COL = []
+const defaultNumberOfRecords = 80
+const defaultRecordsPerLine = 20
 
 function getRandomNumber(max) {
   return Math.random() * Math.floor(max) - max / 2
 }
 
-export const getRandomTable = memoizeOne((maxValue: number) => {
-  for (let i = 0; i < numberOfRecords; i += 1) {
-    VALUE_COL.push(getRandomNumber(maxValue))
-    CPU_COL.push(`cpu${Math.floor(i / recordsPerLine)}`)
-    TIME_COL.push(now + (i % recordsPerLine) * 1000 * 60)
+export const getRandomTable = memoizeOne(
+  (
+    maxValue: number,
+    numberOfRecords: number = defaultNumberOfRecords,
+    recordsPerLine: number = defaultRecordsPerLine
+  ) => {
+    const timeColumn = []
+    const valueColumn = []
+    const cpuColumn = []
+
+    for (let i = 0; i < numberOfRecords; i += 1) {
+      valueColumn.push(getRandomNumber(maxValue))
+      cpuColumn.push(`cpu${Math.floor(i / recordsPerLine)}`)
+      timeColumn.push(now + (i % recordsPerLine) * 1000 * 60)
+    }
+
+    return newTable(numberOfRecords)
+      .addColumn('_time', 'dateTime:RFC3339', 'time', timeColumn)
+      .addColumn('_value', 'system', 'number', valueColumn)
+      .addColumn('cpu', 'string', 'string', cpuColumn)
   }
-
-  const randomTable = newTable(numberOfRecords)
-    .addColumn('_time', 'dateTime:RFC3339', 'time', TIME_COL)
-    .addColumn('_value', 'system', 'number', VALUE_COL)
-    .addColumn('cpu', 'string', 'string', CPU_COL)
-
-  return randomTable
-})
+)


### PR DESCRIPTION
#### Should have no effect on current stories. These changes emerged after working on adding multiple layers to Giraffe

* moves arrays that were defined in a closure to inside the function now.
  * what was happening was the closure was keeping the same set of arrays around and overwriting them, making it impossible to call `randomTable` subsequently to get unique tables.

* adds ability to override the number of records and the records per row