### PR TITLE
fix: use correct dimensions and hoverable points for Band Plot and untangle unnecessary code

### DIFF
--- a/giraffe/src/components/BandLayer.tsx
+++ b/giraffe/src/components/BandLayer.tsx
@@ -9,11 +9,7 @@ import {drawBands} from '../utils/drawBands'
 import {useHoverPointIndices} from '../utils/useHoverPointIndices'
 import {isDefined} from '../utils/isDefined'
 import {FILL} from '../constants/columnKeys'
-import {
-  getBandHoverIndices,
-  getLineLengths,
-  getBandBoundaries,
-} from '../utils/getBandHoverIndices'
+import {getBandHoverIndices, getLineLengths} from '../utils/getBandHoverIndices'
 import {
   groupLineIndicesIntoBands,
   alignMinMaxWithBand,
@@ -47,15 +43,12 @@ export const BandLayer: FunctionComponent<Props> = props => {
   )
 
   const drawBandsOptions = {
-    fill: spec.columnGroupMaps.fill,
+    bandIndexMap: spec.bandIndexMap,
     interpolation: config.interpolation,
     lineData: simplifiedLineData,
     lineWidth: config.lineWidth,
     lineOpacity: config.lineOpacity,
-    lowerColumnName,
-    rowColumnName,
     shadeOpacity: config.shadeOpacity,
-    upperColumnName,
   }
 
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -79,8 +72,10 @@ export const BandLayer: FunctionComponent<Props> = props => {
     hoverDimension = config.hoverDimension
   }
 
+  // Band Plot allows hovering on the nearest band or bands,
+  // and any hoverable point should be associate with a band
   const groupColData = spec.table.getColumn(FILL, 'number')
-  const hoverXYColumnData = {
+  const hoverableColumnData = {
     xs: [],
     ys: [],
     groupColData: [],
@@ -89,51 +84,25 @@ export const BandLayer: FunctionComponent<Props> = props => {
 
   rowIndices.forEach(rowIndex => {
     if (isDefined(rowIndex)) {
-      hoverXYColumnData.xs = hoverXYColumnData.xs.concat(
+      hoverableColumnData.xs = hoverableColumnData.xs.concat(
         spec.lineData[rowIndex].xs
       )
-      hoverXYColumnData.ys = hoverXYColumnData.ys.concat(
+      hoverableColumnData.ys = hoverableColumnData.ys.concat(
         spec.lineData[rowIndex].ys
       )
-      hoverXYColumnData.groupColData = hoverXYColumnData.groupColData.concat(
-        ...groupColData.filter(index => index === rowIndex)
-      )
+      groupColData
+        .filter(index => index === rowIndex)
+        .forEach(value => hoverableColumnData.groupColData.push(value))
     }
   })
-
-  // Get the min and max indices of the corresponding hovered line(s)
-  //   by using an 'x' dimension hover
-  const hoverAsXIndices = useHoverPointIndices(
-    'x',
-    hoverX,
-    hoverY,
-    spec.table.getColumn(config.x, 'number'),
-    spec.table.getColumn(config.y, 'number'),
-    spec.table.getColumn(FILL, 'number'),
-    xScale,
-    yScale,
-    width,
-    height
-  )
-
-  const bandBoundaries = getBandBoundaries(
-    hoverAsXIndices,
-    groupColData,
-    groupLineIndicesIntoBands(
-      spec.columnGroupMaps.fill,
-      lowerColumnName,
-      rowColumnName,
-      upperColumnName
-    )
-  )
 
   const hoverRowIndices = useHoverPointIndices(
     hoverDimension,
     hoverX,
     hoverY,
-    hoverXYColumnData.xs,
-    hoverXYColumnData.ys,
-    hoverXYColumnData.groupColData,
+    hoverableColumnData.xs,
+    hoverableColumnData.ys,
+    hoverableColumnData.groupColData,
     xScale,
     yScale,
     width,
@@ -145,8 +114,13 @@ export const BandLayer: FunctionComponent<Props> = props => {
   const bandHoverIndices = getBandHoverIndices(
     lineLengths,
     hoverRowIndices,
-    hoverXYColumnData.groupColData,
-    bandBoundaries
+    hoverableColumnData.groupColData,
+    groupLineIndicesIntoBands(
+      spec.columnGroupMaps.fill,
+      lowerColumnName,
+      rowColumnName,
+      upperColumnName
+    )
   )
 
   const hasHoverData = hoverRowIndices && hoverRowIndices.length > 0

--- a/giraffe/src/components/BandLayer.tsx
+++ b/giraffe/src/components/BandLayer.tsx
@@ -7,7 +7,7 @@ import {simplifyLineData} from '../utils/lineData'
 import {useCanvas} from '../utils/useCanvas'
 import {drawBands} from '../utils/drawBands'
 import {useHoverPointIndices} from '../utils/useHoverPointIndices'
-import {isDefined} from '../utils/isDefined'
+import {useBandHoverColumns} from '../utils/useBandHoverColumns'
 import {FILL} from '../constants/columnKeys'
 import {getBandHoverIndices, getLineLengths} from '../utils/getBandHoverIndices'
 import {
@@ -74,27 +74,15 @@ export const BandLayer: FunctionComponent<Props> = props => {
 
   // Band Plot allows hovering on the nearest band or bands,
   // and any hoverable point should be associate with a band
-  const groupColData = spec.table.getColumn(FILL, 'number')
-  const hoverableColumnData = {
-    xs: [],
-    ys: [],
-    groupColData: [],
-  }
-  const {rowIndices} = spec.bandIndexMap
-
-  rowIndices.forEach(rowIndex => {
-    if (isDefined(rowIndex)) {
-      hoverableColumnData.xs = hoverableColumnData.xs.concat(
-        spec.lineData[rowIndex].xs
-      )
-      hoverableColumnData.ys = hoverableColumnData.ys.concat(
-        spec.lineData[rowIndex].ys
-      )
-      groupColData
-        .filter(index => index === rowIndex)
-        .forEach(value => hoverableColumnData.groupColData.push(value))
-    }
-  })
+  const hoverableColumnData = useBandHoverColumns(
+    hoverX,
+    hoverY,
+    spec.lineData,
+    spec.table.getColumn(FILL, 'number'),
+    spec.bandIndexMap,
+    width,
+    height
+  )
 
   const hoverRowIndices = useHoverPointIndices(
     hoverDimension,

--- a/giraffe/src/transforms/band.test.ts
+++ b/giraffe/src/transforms/band.test.ts
@@ -164,39 +164,6 @@ describe('band transform utils', () => {
 
   describe('creates the bands to be rendered', () => {
     it('creates a line with lower and upper when they are available in the lineData', () => {
-      const fill = {
-        columnKeys: ['result', '_field', '_measurement', 'cpu', 'host'],
-        mappings: [
-          {
-            cpu: 'cpu0',
-            host: 'localhost',
-            result: 'min',
-            _field: 'usage_system',
-            _measurement: 'cpu',
-          },
-          {
-            cpu: 'cpu0',
-            host: 'localhost',
-            result: 'max',
-            _field: 'usage_system',
-            _measurement: 'cpu',
-          },
-          {
-            cpu: 'cpu0',
-            host: 'localhost',
-            result: 'mean',
-            _field: 'usage_system',
-            _measurement: 'cpu',
-          },
-          {
-            cpu: 'cpu1',
-            host: 'localhost',
-            result: 'max',
-            _field: 'usage_system',
-            _measurement: 'cpu',
-          },
-        ],
-      }
       const lineData = {
         0: {
           fill: 'rgb(106, 103, 205)',
@@ -250,54 +217,20 @@ describe('band transform utils', () => {
           ],
         },
       }
-      const result = getBands(fill, lineData, 'min', 'mean', 'max')
+      const bandIndexMap = {
+        upperIndices: [2],
+        rowIndices: [0],
+        lowerIndices: [1],
+      }
+
+      const result = getBands(lineData, bandIndexMap)
       expect(Array.isArray(result)).toEqual(true)
-      expect(result[0].fill).toEqual(lineData[2].fill)
+      expect(result[0].fill).toEqual(lineData[0].fill)
       expect(result[0].lower).toBeDefined()
       expect(result[0].upper).toBeDefined()
     })
 
     it('creates a line without the lower or upper when corresponding lower or upper is missing from lineData', () => {
-      const fill = {
-        columnKeys: ['result', '_field', '_measurement', 'cpu', 'host'],
-        mappings: [
-          {
-            cpu: 'cpu1',
-            host: 'localhost',
-            result: 'min',
-            _field: 'usage_system',
-            _measurement: 'cpu',
-          },
-          {
-            cpu: 'cpu0',
-            host: 'localhost',
-            result: 'max',
-            _field: 'usage_system',
-            _measurement: 'cpu',
-          },
-          {
-            cpu: 'cpu0',
-            host: 'localhost',
-            result: 'mean',
-            _field: 'usage_system',
-            _measurement: 'cpu',
-          },
-          {
-            cpu: 'cpu1',
-            host: 'localhost',
-            result: 'mean',
-            _field: 'usage_system',
-            _measurement: 'cpu',
-          },
-          {
-            cpu: 'cpu2',
-            host: 'localhost',
-            result: 'mean',
-            _field: 'usage_system',
-            _measurement: 'cpu',
-          },
-        ],
-      }
       const lineData = {
         0: {
           fill: 'rgb(106, 103, 205)',
@@ -385,18 +318,24 @@ describe('band transform utils', () => {
           ],
         },
       }
-      const result = getBands(fill, lineData, 'min', 'mean', 'max')
+      const bandIndexMap = {
+        upperIndices: [3, null, null],
+        rowIndices: [0, 1, 2],
+        lowerIndices: [null, 4, null],
+      }
+
+      const result = getBands(lineData, bandIndexMap)
       expect(Array.isArray(result)).toEqual(true)
 
-      expect(result[0].fill).toEqual(lineData[2].fill)
+      expect(result[0].fill).toEqual(lineData[0].fill)
       expect(result[0].lower).toBeUndefined()
       expect(result[0].upper).toBeDefined()
 
-      expect(result[1].fill).toEqual(lineData[3].fill)
+      expect(result[1].fill).toEqual(lineData[1].fill)
       expect(result[1].lower).toBeDefined()
       expect(result[1].upper).toBeUndefined()
 
-      expect(result[2].fill).toEqual(lineData[4].fill)
+      expect(result[2].fill).toEqual(lineData[2].fill)
       expect(result[2].lower).toBeUndefined()
       expect(result[2].upper).toBeUndefined()
     })

--- a/giraffe/src/transforms/band.ts
+++ b/giraffe/src/transforms/band.ts
@@ -23,28 +23,29 @@ export const getBands = (
 ): Band[] => {
   const {upperIndices = [], rowIndices = [], lowerIndices = []} = bandIndexMap
   const bands: Band[] = []
-  rowIndices.forEach((rowIndex, position) => {
-    const upperIndex = upperIndices[position]
+  rowIndices.forEach((rowIndex, i) => {
+    if (!isFiniteNumber(rowIndex)) {
+      return
+    }
+    const upperIndex = upperIndices[i]
     const upperIsFinite = isFiniteNumber(upperIndex)
     const upper = upperIsFinite ? lineData[upperIndex] : {fill: ''}
 
-    const lowerIndex = lowerIndices[position]
+    const lowerIndex = lowerIndices[i]
     const lowerIsFinite = isFiniteNumber(lowerIndex)
     const lower = lowerIsFinite ? lineData[lowerIndex] : {fill: ''}
 
-    if (isFiniteNumber(rowIndex)) {
-      const row = lineData[rowIndex]
-      upper.fill = row.fill
-      lower.fill = row.fill
-      const result: Band = {...row}
-      if (upperIsFinite) {
-        result.upper = upper as BandBorder
-      }
-      if (lowerIsFinite) {
-        result.lower = lower as BandBorder
-      }
-      bands.push(result)
+    const row = lineData[rowIndex]
+    upper.fill = row.fill
+    lower.fill = row.fill
+    const result: Band = {...row}
+    if (upperIsFinite) {
+      result.upper = upper as BandBorder
     }
+    if (lowerIsFinite) {
+      result.lower = lower as BandBorder
+    }
+    bands.push(result)
   })
 
   return bands

--- a/giraffe/src/transforms/band.ts
+++ b/giraffe/src/transforms/band.ts
@@ -24,6 +24,9 @@ export const getBands = (
   const {upperIndices = [], rowIndices = [], lowerIndices = []} = bandIndexMap
   const bands: Band[] = []
   rowIndices.forEach((rowIndex, i) => {
+    // Each band must have a "main column" which creates a row index
+    // Any non-main column not associated with a "main" is not a band
+    // Only bands get rendered
     if (!isFiniteNumber(rowIndex)) {
       return
     }

--- a/giraffe/src/transforms/band.ts
+++ b/giraffe/src/transforms/band.ts
@@ -1,76 +1,65 @@
 import {
   BandLayerSpec,
   Band,
+  BandBorder,
   ColumnGroupMap,
   LineData,
   Table,
   BandIndexMap,
 } from '../types'
-import {FILL, LOWER, RESULT, UPPER} from '../constants/columnKeys'
-import {isDefined} from '../utils/isDefined'
+
 import {createGroupIDColumn, getBandColorScale} from './'
 
+import {FILL, LOWER, RESULT, UPPER} from '../constants/columnKeys'
 import {BAND_COLOR_SCALE_CONSTANT} from '../constants'
+
+import {isDefined} from '../utils/isDefined'
+import {isFiniteNumber} from '../utils/isFiniteNumber'
 import {isNumber} from '../utils/isNumber'
 
 export const getBands = (
-  fill: ColumnGroupMap,
   lineData: LineData,
-  lowerColumnName: string,
-  rowColumnName: string,
-  upperColumnName: string
+  bandIndexMap: BandIndexMap
 ): Band[] => {
-  const lowerUpperMap = {}
-  const {columnKeys, mappings} = fill
-  const columnKeysWithoutResult = Array.isArray(columnKeys)
-    ? columnKeys.filter(key => key !== RESULT)
-    : []
+  const {upperIndices = [], rowIndices = [], lowerIndices = []} = bandIndexMap
+  const bands: Band[] = []
+  rowIndices.forEach((rowIndex, position) => {
+    const upperIndex = upperIndices[position]
+    const upperIsFinite = isFiniteNumber(upperIndex)
+    const upper = upperIsFinite ? lineData[upperIndex] : {fill: ''}
 
-  if (!Array.isArray(mappings)) {
-    return []
-  }
+    const lowerIndex = lowerIndices[position]
+    const lowerIsFinite = isFiniteNumber(lowerIndex)
+    const lower = lowerIsFinite ? lineData[lowerIndex] : {fill: ''}
 
-  const bands = mappings.reduce((bandLines, map, index) => {
-    const lineName = columnKeysWithoutResult.reduce((accum, current) => {
-      return `${accum}${mappings[index][current]}`
-    }, '')
-    if (!lowerUpperMap[lineName]) {
-      lowerUpperMap[lineName] = {}
-    }
-    if (map[RESULT] === upperColumnName) {
-      if (!lowerUpperMap[lineName][upperColumnName]) {
-        lowerUpperMap[lineName][upperColumnName] = lineData[index]
+    if (isFiniteNumber(rowIndex)) {
+      const row = lineData[rowIndex]
+      upper.fill = row.fill
+      lower.fill = row.fill
+      const result: Band = {...row}
+      if (upperIsFinite) {
+        result.upper = upper as BandBorder
       }
-    } else if (map[RESULT] === lowerColumnName) {
-      if (!lowerUpperMap[lineName][lowerColumnName]) {
-        lowerUpperMap[lineName][lowerColumnName] = lineData[index]
+      if (lowerIsFinite) {
+        result.lower = lower as BandBorder
       }
-    } else if (map[RESULT] === rowColumnName) {
-      bandLines.push({
-        ...lineData[index],
-        lineName,
-      })
-    }
-    return bandLines
-  }, [])
-
-  bands.forEach(band => {
-    if (band.lineName) {
-      if (lowerUpperMap[band.lineName][lowerColumnName]) {
-        band[LOWER] = {
-          ...lowerUpperMap[band.lineName][lowerColumnName],
-          fill: band.fill,
-        }
+      bands.push(result)
+    } else if (upperIsFinite && lowerIsFinite) {
+      if (lowerIndex < upperIndex) {
+        bands.push({...(lower as Band)})
+        bands.push({...(upper as Band)})
+      } else {
+        bands.push({...(upper as Band)})
+        bands.push({...(lower as Band)})
       }
-      if (lowerUpperMap[band.lineName][upperColumnName]) {
-        band[UPPER] = {
-          ...lowerUpperMap[band.lineName][upperColumnName],
-          fill: band.fill,
-        }
-      }
+    } else if (upperIsFinite) {
+      bands.push({...(upper as Band)})
+    } else if (lowerIsFinite) {
+      bands.push({...(lower as Band)})
     }
   })
-  return bands as Band[]
+
+  return bands
 }
 
 export const getBandIndexMap = (
@@ -150,14 +139,14 @@ export const alignMinMaxWithBand = (
 
   const alignedData = {}
 
-  let bandXs = []
-  let bandYs = []
-  let upperXs = []
-  let upperYs = []
-  let lowerXs = []
-  let lowerYs = []
-
   for (let i = 0; i < rowIndices.length; i += 1) {
+    let bandXs = []
+    let bandYs = []
+    let upperXs = []
+    let upperYs = []
+    let lowerXs = []
+    let lowerYs = []
+
     const bandId = rowIndices[i]
     const upperId = upperIndices[i]
     const lowerId = lowerIndices[i]
@@ -190,218 +179,218 @@ export const alignMinMaxWithBand = (
       }
       bandXs = lineData[bandId].xs
       bandYs = lineData[bandId].ys
+    }
 
-      let bandIterator = 0
-      let upperIterator = 0
-      let lowerIterator = 0
+    let bandIterator = 0
+    let upperIterator = 0
+    let lowerIterator = 0
 
-      while (
-        bandIterator < bandXs.length ||
-        upperIterator < upperXs.length ||
-        lowerIterator < lowerXs.length
-      ) {
-        const bandTime = bandXs[bandIterator]
-        const bandValue = bandYs[bandIterator]
-        const upperTime = upperXs[upperIterator]
-        const upperValue = upperYs[upperIterator]
-        const lowerTime = lowerXs[lowerIterator]
-        const lowerValue = lowerYs[lowerIterator]
+    while (
+      bandIterator < bandXs.length ||
+      upperIterator < upperXs.length ||
+      lowerIterator < lowerXs.length
+    ) {
+      const bandTime = bandXs[bandIterator]
+      const bandValue = bandYs[bandIterator]
+      const upperTime = upperXs[upperIterator]
+      const upperValue = upperYs[upperIterator]
+      const lowerTime = lowerXs[lowerIterator]
+      const lowerValue = lowerYs[lowerIterator]
 
-        // 1. All three are equal
-        if (bandTime === upperTime && bandTime === lowerTime) {
-          if (isDefined(bandTime)) {
-            alignedData[bandId].xs.push(bandTime)
-            alignedData[bandId].ys.push(bandValue)
-            bandIterator += 1
-          }
-          if (isDefined(upperTime)) {
-            alignedData[upperId].xs.push(upperTime)
-            alignedData[upperId].ys.push(upperValue)
-            upperIterator += 1
-          }
-          if (isDefined(lowerTime)) {
-            alignedData[lowerId].xs.push(lowerTime)
-            alignedData[lowerId].ys.push(lowerValue)
-            lowerIterator += 1
-          }
+      // 1. All three are equal
+      if (bandTime === upperTime && bandTime === lowerTime) {
+        if (isDefined(bandTime)) {
+          alignedData[bandId].xs.push(bandTime)
+          alignedData[bandId].ys.push(bandValue)
+          bandIterator += 1
         }
-        // 2. Min is not equal to the other two
-        else if (bandTime === upperTime) {
-          if (bandTime > lowerTime || !isDefined(bandTime)) {
+        if (isDefined(upperTime)) {
+          alignedData[upperId].xs.push(upperTime)
+          alignedData[upperId].ys.push(upperValue)
+          upperIterator += 1
+        }
+        if (isDefined(lowerTime)) {
+          alignedData[lowerId].xs.push(lowerTime)
+          alignedData[lowerId].ys.push(lowerValue)
+          lowerIterator += 1
+        }
+      }
+      // 2. Lower is not equal to the other two
+      else if (bandTime === upperTime) {
+        if (bandTime > lowerTime || !isDefined(bandTime)) {
+          if (isDefined(bandId)) {
+            alignedData[bandId].xs.push(lowerTime)
+            alignedData[bandId].ys.push(lowerValue)
+          }
+          if (isDefined(upperId)) {
+            alignedData[upperId].xs.push(lowerTime)
+            alignedData[upperId].ys.push(lowerValue)
+          }
+          alignedData[lowerId].xs.push(lowerTime)
+          alignedData[lowerId].ys.push(lowerValue)
+          lowerIterator += 1
+        } else if (bandTime < lowerTime || !isDefined(lowerTime)) {
+          alignedData[bandId].xs.push(bandTime)
+          alignedData[bandId].ys.push(bandValue)
+          alignedData[upperId].xs.push(upperTime)
+          alignedData[upperId].ys.push(upperValue)
+          if (isDefined(lowerId)) {
+            alignedData[lowerId].xs.push(bandTime)
+            alignedData[lowerId].ys.push(bandValue)
+          }
+          bandIterator += 1
+          upperIterator += 1
+        }
+      }
+      // 3. Upper is not equal to the other two
+      else if (bandTime === lowerTime) {
+        if (bandTime > upperTime || !isDefined(bandTime)) {
+          if (isDefined(bandId)) {
+            alignedData[bandId].xs.push(upperTime)
+            alignedData[bandId].ys.push(upperValue)
+          }
+          if (isDefined(lowerId)) {
+            alignedData[lowerId].xs.push(upperTime)
+            alignedData[lowerId].ys.push(upperValue)
+          }
+          alignedData[upperId].xs.push(upperTime)
+          alignedData[upperId].ys.push(upperValue)
+          upperIterator += 1
+        } else if (bandTime < upperTime || !isDefined(upperTime)) {
+          alignedData[bandId].xs.push(bandTime)
+          alignedData[bandId].ys.push(bandValue)
+          if (isDefined(upperId)) {
+            alignedData[upperId].xs.push(bandTime)
+            alignedData[upperId].ys.push(bandValue)
+          }
+          alignedData[lowerId].xs.push(lowerTime)
+          alignedData[lowerId].ys.push(lowerValue)
+          bandIterator += 1
+          lowerIterator += 1
+        }
+      }
+      // 4. Band is not equal to the other two
+      else if (upperTime === lowerTime) {
+        if (upperTime > bandTime || !isDefined(upperTime)) {
+          alignedData[bandId].xs.push(bandTime)
+          alignedData[bandId].ys.push(bandValue)
+          if (isDefined(upperId)) {
+            alignedData[upperId].xs.push(bandTime)
+            alignedData[upperId].ys.push(bandValue)
+          }
+          if (isDefined(lowerId)) {
+            alignedData[lowerId].xs.push(bandTime)
+            alignedData[lowerId].ys.push(bandValue)
+          }
+          bandIterator += 1
+        } else if (upperTime < bandTime || !isDefined(bandTime)) {
+          if (isDefined(bandId)) {
+            alignedData[bandId].xs.push(upperTime)
+            alignedData[bandId].ys.push(upperValue)
+          }
+          alignedData[upperId].xs.push(upperTime)
+          alignedData[upperId].ys.push(upperValue)
+          alignedData[lowerId].xs.push(lowerTime)
+          alignedData[lowerId].ys.push(lowerValue)
+          upperIterator += 1
+          lowerIterator += 1
+        }
+      }
+      // 5. They are all different
+      else {
+        if (!isDefined(bandTime)) {
+          if (upperTime > lowerTime) {
             if (isDefined(bandId)) {
               alignedData[bandId].xs.push(lowerTime)
               alignedData[bandId].ys.push(lowerValue)
             }
-            if (isDefined(upperId)) {
-              alignedData[upperId].xs.push(lowerTime)
-              alignedData[upperId].ys.push(lowerValue)
-            }
+            alignedData[upperId].xs.push(lowerTime)
+            alignedData[upperId].ys.push(lowerValue)
             alignedData[lowerId].xs.push(lowerTime)
             alignedData[lowerId].ys.push(lowerValue)
             lowerIterator += 1
-          } else if (bandTime < lowerTime || !isDefined(lowerTime)) {
-            alignedData[bandId].xs.push(bandTime)
-            alignedData[bandId].ys.push(bandValue)
-            alignedData[upperId].xs.push(upperTime)
-            alignedData[upperId].ys.push(upperValue)
-            if (isDefined(lowerId)) {
-              alignedData[lowerId].xs.push(bandTime)
-              alignedData[lowerId].ys.push(bandValue)
-            }
-            bandIterator += 1
-            upperIterator += 1
-          }
-        }
-        // 3. Max is not equal to the other two
-        else if (bandTime === lowerTime) {
-          if (bandTime > upperTime || !isDefined(bandTime)) {
-            if (isDefined(bandId)) {
-              alignedData[bandId].xs.push(upperTime)
-              alignedData[bandId].ys.push(upperValue)
-            }
-            if (isDefined(lowerId)) {
-              alignedData[lowerId].xs.push(upperTime)
-              alignedData[lowerId].ys.push(upperValue)
-            }
-            alignedData[upperId].xs.push(upperTime)
-            alignedData[upperId].ys.push(upperValue)
-            upperIterator += 1
-          } else if (bandTime < upperTime || !isDefined(upperTime)) {
-            alignedData[bandId].xs.push(bandTime)
-            alignedData[bandId].ys.push(bandValue)
-            if (isDefined(upperId)) {
-              alignedData[upperId].xs.push(bandTime)
-              alignedData[upperId].ys.push(bandValue)
-            }
-            alignedData[lowerId].xs.push(lowerTime)
-            alignedData[lowerId].ys.push(lowerValue)
-            bandIterator += 1
-            lowerIterator += 1
-          }
-        }
-        // 4. Band is not equal to the other two
-        else if (upperTime === lowerTime) {
-          if (upperTime > bandTime || !isDefined(upperTime)) {
-            alignedData[bandId].xs.push(bandTime)
-            alignedData[bandId].ys.push(bandValue)
-            if (isDefined(upperId)) {
-              alignedData[upperId].xs.push(bandTime)
-              alignedData[upperId].ys.push(bandValue)
-            }
-            if (isDefined(lowerId)) {
-              alignedData[lowerId].xs.push(bandTime)
-              alignedData[lowerId].ys.push(bandValue)
-            }
-            bandIterator += 1
-          } else if (upperTime < bandTime || !isDefined(bandTime)) {
-            if (isDefined(bandId)) {
-              alignedData[bandId].xs.push(upperTime)
-              alignedData[bandId].ys.push(upperValue)
-            }
-            alignedData[upperId].xs.push(upperTime)
-            alignedData[upperId].ys.push(upperValue)
-            alignedData[lowerId].xs.push(lowerTime)
-            alignedData[lowerId].ys.push(lowerValue)
-            upperIterator += 1
-            lowerIterator += 1
-          }
-        }
-        // 5. They are all different
-        else {
-          if (!isDefined(bandTime)) {
-            if (upperTime > lowerTime) {
-              if (isDefined(bandId)) {
-                alignedData[bandId].xs.push(lowerTime)
-                alignedData[bandId].ys.push(lowerValue)
-              }
-              alignedData[upperId].xs.push(lowerTime)
-              alignedData[upperId].ys.push(lowerValue)
-              alignedData[lowerId].xs.push(lowerTime)
-              alignedData[lowerId].ys.push(lowerValue)
-              lowerIterator += 1
-            } else {
-              if (isDefined(bandId)) {
-                alignedData[bandId].xs.push(upperTime)
-                alignedData[bandId].ys.push(upperValue)
-              }
-              alignedData[upperId].xs.push(upperTime)
-              alignedData[upperId].ys.push(upperValue)
-              alignedData[lowerId].xs.push(upperTime)
-              alignedData[lowerId].ys.push(upperValue)
-              upperIterator += 1
-            }
-          } else if (!isDefined(upperTime)) {
-            if (bandTime > lowerTime) {
-              alignedData[bandId].xs.push(lowerTime)
-              alignedData[bandId].ys.push(lowerValue)
-              if (isDefined(upperId)) {
-                alignedData[upperId].xs.push(lowerTime)
-                alignedData[upperId].ys.push(lowerValue)
-              }
-              alignedData[lowerId].xs.push(lowerTime)
-              alignedData[lowerId].ys.push(lowerValue)
-              lowerIterator += 1
-            } else {
-              alignedData[bandId].xs.push(bandTime)
-              alignedData[bandId].ys.push(bandValue)
-              if (isDefined(upperId)) {
-                alignedData[upperId].xs.push(bandTime)
-                alignedData[upperId].ys.push(bandValue)
-              }
-              alignedData[lowerId].xs.push(bandTime)
-              alignedData[lowerId].ys.push(bandValue)
-              bandIterator += 1
-            }
-          } else if (!isDefined(lowerTime)) {
-            if (bandTime > upperTime) {
-              alignedData[bandId].xs.push(upperTime)
-              alignedData[bandId].ys.push(upperValue)
-              alignedData[upperId].xs.push(upperTime)
-              alignedData[upperId].ys.push(upperValue)
-              if (isDefined(lowerId)) {
-                alignedData[lowerId].xs.push(upperTime)
-                alignedData[lowerId].ys.push(upperValue)
-              }
-              upperIterator += 1
-            } else {
-              alignedData[bandId].xs.push(bandTime)
-              alignedData[bandId].ys.push(bandValue)
-              alignedData[upperId].xs.push(bandTime)
-              alignedData[upperId].ys.push(bandValue)
-              if (isDefined(lowerId)) {
-                alignedData[lowerId].xs.push(bandTime)
-                alignedData[lowerId].ys.push(bandValue)
-              }
-              bandIterator += 1
-            }
           } else {
-            const lowest = Math.min(bandTime, upperTime, lowerTime)
-
-            if (lowest === lowerTime) {
-              alignedData[bandId].xs.push(lowerTime)
-              alignedData[bandId].ys.push(lowerValue)
-              alignedData[upperId].xs.push(lowerTime)
-              alignedData[upperId].ys.push(lowerValue)
-              alignedData[lowerId].xs.push(lowerTime)
-              alignedData[lowerId].ys.push(lowerValue)
-              lowerIterator += 1
-            } else if (lowest === upperTime) {
+            if (isDefined(bandId)) {
               alignedData[bandId].xs.push(upperTime)
               alignedData[bandId].ys.push(upperValue)
-              alignedData[upperId].xs.push(upperTime)
-              alignedData[upperId].ys.push(upperValue)
-              alignedData[lowerId].xs.push(upperTime)
-              alignedData[lowerId].ys.push(upperValue)
-              upperIterator += 1
-            } else {
-              alignedData[bandId].xs.push(bandTime)
-              alignedData[bandId].ys.push(bandValue)
+            }
+            alignedData[upperId].xs.push(upperTime)
+            alignedData[upperId].ys.push(upperValue)
+            alignedData[lowerId].xs.push(upperTime)
+            alignedData[lowerId].ys.push(upperValue)
+            upperIterator += 1
+          }
+        } else if (!isDefined(upperTime)) {
+          if (bandTime > lowerTime) {
+            alignedData[bandId].xs.push(lowerTime)
+            alignedData[bandId].ys.push(lowerValue)
+            if (isDefined(upperId)) {
+              alignedData[upperId].xs.push(lowerTime)
+              alignedData[upperId].ys.push(lowerValue)
+            }
+            alignedData[lowerId].xs.push(lowerTime)
+            alignedData[lowerId].ys.push(lowerValue)
+            lowerIterator += 1
+          } else {
+            alignedData[bandId].xs.push(bandTime)
+            alignedData[bandId].ys.push(bandValue)
+            if (isDefined(upperId)) {
               alignedData[upperId].xs.push(bandTime)
               alignedData[upperId].ys.push(bandValue)
+            }
+            alignedData[lowerId].xs.push(bandTime)
+            alignedData[lowerId].ys.push(bandValue)
+            bandIterator += 1
+          }
+        } else if (!isDefined(lowerTime)) {
+          if (bandTime > upperTime) {
+            alignedData[bandId].xs.push(upperTime)
+            alignedData[bandId].ys.push(upperValue)
+            alignedData[upperId].xs.push(upperTime)
+            alignedData[upperId].ys.push(upperValue)
+            if (isDefined(lowerId)) {
+              alignedData[lowerId].xs.push(upperTime)
+              alignedData[lowerId].ys.push(upperValue)
+            }
+            upperIterator += 1
+          } else {
+            alignedData[bandId].xs.push(bandTime)
+            alignedData[bandId].ys.push(bandValue)
+            alignedData[upperId].xs.push(bandTime)
+            alignedData[upperId].ys.push(bandValue)
+            if (isDefined(lowerId)) {
               alignedData[lowerId].xs.push(bandTime)
               alignedData[lowerId].ys.push(bandValue)
-              bandIterator += 1
             }
+            bandIterator += 1
+          }
+        } else {
+          const lowest = Math.min(bandTime, upperTime, lowerTime)
+
+          if (lowest === lowerTime) {
+            alignedData[bandId].xs.push(lowerTime)
+            alignedData[bandId].ys.push(lowerValue)
+            alignedData[upperId].xs.push(lowerTime)
+            alignedData[upperId].ys.push(lowerValue)
+            alignedData[lowerId].xs.push(lowerTime)
+            alignedData[lowerId].ys.push(lowerValue)
+            lowerIterator += 1
+          } else if (lowest === upperTime) {
+            alignedData[bandId].xs.push(upperTime)
+            alignedData[bandId].ys.push(upperValue)
+            alignedData[upperId].xs.push(upperTime)
+            alignedData[upperId].ys.push(upperValue)
+            alignedData[lowerId].xs.push(upperTime)
+            alignedData[lowerId].ys.push(upperValue)
+            upperIterator += 1
+          } else {
+            alignedData[bandId].xs.push(bandTime)
+            alignedData[bandId].ys.push(bandValue)
+            alignedData[upperId].xs.push(bandTime)
+            alignedData[upperId].ys.push(bandValue)
+            alignedData[lowerId].xs.push(bandTime)
+            alignedData[lowerId].ys.push(bandValue)
+            bandIterator += 1
           }
         }
       }

--- a/giraffe/src/transforms/band.ts
+++ b/giraffe/src/transforms/band.ts
@@ -44,18 +44,6 @@ export const getBands = (
         result.lower = lower as BandBorder
       }
       bands.push(result)
-    } else if (upperIsFinite && lowerIsFinite) {
-      if (lowerIndex < upperIndex) {
-        bands.push({...(lower as Band)})
-        bands.push({...(upper as Band)})
-      } else {
-        bands.push({...(upper as Band)})
-        bands.push({...(lower as Band)})
-      }
-    } else if (upperIsFinite) {
-      bands.push({...(upper as Band)})
-    } else if (lowerIsFinite) {
-      bands.push({...(lower as Band)})
     }
   })
 

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -725,9 +725,8 @@ export interface BandBorder {
   fill: string
 }
 export interface Band {
-  lineName: string
-  lower: BandBorder
-  upper: BandBorder
+  lower?: BandBorder
+  upper?: BandBorder
   xs: Array<number>
   ys: Array<number>
   fill: string

--- a/giraffe/src/utils/drawBands.ts
+++ b/giraffe/src/utils/drawBands.ts
@@ -1,7 +1,7 @@
 import {line, curveLinear, area} from 'd3-shape'
 import {range} from 'd3-array'
 
-import {ColumnGroupMap, LineData, LineInterpolation} from '../types'
+import {BandIndexMap, LineData, LineInterpolation} from '../types'
 import {CURVES} from '../constants'
 import {LOWER, UPPER} from '../constants/columnKeys'
 import {isDefined} from '../utils/isDefined'
@@ -9,37 +9,25 @@ import {isDefined} from '../utils/isDefined'
 import {getBands} from '../transforms/band'
 
 interface DrawBandsOptions {
+  bandIndexMap: BandIndexMap
   context: CanvasRenderingContext2D
-  fill: ColumnGroupMap
   interpolation: LineInterpolation
   lineData: LineData
   lineWidth: number
   lineOpacity: number
-  lowerColumnName: string
-  rowColumnName: string
   shadeOpacity: number
-  upperColumnName: string
 }
 
 export const drawBands = ({
+  bandIndexMap,
   context,
-  fill,
   interpolation,
   lineData,
   lineWidth,
   lineOpacity,
-  lowerColumnName,
-  rowColumnName,
   shadeOpacity,
-  upperColumnName,
 }: DrawBandsOptions): void => {
-  const bands = getBands(
-    fill,
-    lineData,
-    lowerColumnName,
-    rowColumnName,
-    upperColumnName
-  )
+  const bands = getBands(lineData, bandIndexMap)
 
   // draw shading
   for (const band of bands) {

--- a/giraffe/src/utils/getBandHoverIndices.test.ts
+++ b/giraffe/src/utils/getBandHoverIndices.test.ts
@@ -1,118 +1,6 @@
-import {
-  getLineLengths,
-  getBandBoundaries,
-  getBandHoverIndices,
-} from './getBandHoverIndices'
+import {getLineLengths, getBandHoverIndices} from './getBandHoverIndices'
 
 describe('getBandHoverIndices utils', () => {
-  describe('getBandBoundaries', () => {
-    it('handles empty data', () => {
-      expect(getBandBoundaries(null, [], {})).toEqual({})
-      expect(getBandBoundaries(null, null, {})).toEqual({})
-      expect(getBandBoundaries(null, null, null)).toEqual({})
-      expect(getBandBoundaries([], [], {})).toEqual({})
-    })
-
-    const hoverGroupData = [
-      0,
-      0,
-      0,
-      1,
-      1,
-      1,
-      2,
-      2,
-      2,
-      3,
-      3,
-      3,
-      4,
-      4,
-      4,
-      5,
-      5,
-      5,
-      6,
-      6,
-      6,
-      7,
-      7,
-      7,
-      8,
-      8,
-      8,
-    ]
-    const bandLineIndexMap = {
-      usage_systemcpucpu0localhost: {
-        lower: 5,
-        upper: 2,
-        row: 6,
-      },
-      usage_systemcpucpu1localhost: {
-        lower: 4,
-        upper: 1,
-        row: 7,
-      },
-      usage_systemcpucpu2localhost: {
-        lower: 3,
-        upper: 0,
-        row: 8,
-      },
-    }
-
-    it('creates a map with band boundaries when the hover indices are null and other data is available', () => {
-      const hoverRowIndices = null
-      expect(
-        getBandBoundaries(hoverRowIndices, hoverGroupData, bandLineIndexMap)
-      ).toEqual({
-        6: {
-          upperCol: 2,
-          lowerCol: 5,
-          upperIndex: null,
-          lowerIndex: null,
-        },
-        7: {
-          upperCol: 1,
-          lowerCol: 4,
-          upperIndex: null,
-          lowerIndex: null,
-        },
-        8: {
-          upperCol: 0,
-          lowerCol: 3,
-          upperIndex: null,
-          lowerIndex: null,
-        },
-      })
-    })
-
-    it('creates a mpa with band boundaries when the hover indicies and other data are available', () => {
-      const hoverRowIndices = [0, 3, 6, 9, 12, 15, 18, 21, 24]
-      expect(
-        getBandBoundaries(hoverRowIndices, hoverGroupData, bandLineIndexMap)
-      ).toEqual({
-        6: {
-          upperCol: 2,
-          lowerCol: 5,
-          upperIndex: 6,
-          lowerIndex: 15,
-        },
-        7: {
-          upperCol: 1,
-          lowerCol: 4,
-          upperIndex: 3,
-          lowerIndex: 12,
-        },
-        8: {
-          upperCol: 0,
-          lowerCol: 3,
-          upperIndex: 0,
-          lowerIndex: 9,
-        },
-      })
-    })
-  })
-
   describe('getLineLengths', () => {
     it('handles empty data', () => {
       expect(getLineLengths({})).toEqual({})
@@ -210,17 +98,17 @@ describe('getBandHoverIndices utils', () => {
       }
       const hoverRowIndices = [6, 3, 0]
       const hoverGroupData = [8, 8, 8, 7, 7, 7, 6, 6, 6]
-      const bandBoundaries = {
-        6: {upperCol: 2, lowerCol: 5, upperIndex: 6, lowerIndex: 15},
-        7: {upperCol: 1, lowerCol: 4, upperIndex: 3, lowerIndex: 12},
-        8: {upperCol: 0, lowerCol: 3, upperIndex: 0, lowerIndex: 9},
+      const bandLineIndexMap = {
+        band1: {upper: 2, lower: 5, row: 6},
+        band2: {upper: 1, lower: 4, row: 7},
+        band3: {upper: 0, lower: 3, row: 8},
       }
       expect(
         getBandHoverIndices(
           lineLengths,
           hoverRowIndices,
           hoverGroupData,
-          bandBoundaries
+          bandLineIndexMap
         )
       ).toEqual({
         rowIndices: [18, 21, 24],

--- a/giraffe/src/utils/getBandHoverIndices.ts
+++ b/giraffe/src/utils/getBandHoverIndices.ts
@@ -1,4 +1,5 @@
 import {NumericColumnData, BandIndexMap, LineData} from '../types'
+import {isDefined} from './isDefined'
 
 interface LineLengths {
   [index: string]: {
@@ -76,15 +77,21 @@ export const getBandHoverIndices = (
 
       if (hoverGroupBoundaries[hoveredBandId]) {
         const rowBase = lineLengths[hoveredBandId].startIndex
-        const upperBase =
-          lineLengths[hoverGroupBoundaries[hoveredBandId].upper].startIndex
-        const lowerBase =
-          lineLengths[hoverGroupBoundaries[hoveredBandId].lower].startIndex
         const offset = index - hoverGroupBoundaries[hoveredBandId].startIndex
 
         bandHoverIndices.rowIndices.push(rowBase + offset)
-        bandHoverIndices.upperIndices.push(upperBase + offset)
-        bandHoverIndices.lowerIndices.push(lowerBase + offset)
+
+        if (isDefined(hoverGroupBoundaries[hoveredBandId].upper)) {
+          const upperBase =
+            lineLengths[hoverGroupBoundaries[hoveredBandId].upper].startIndex
+          bandHoverIndices.upperIndices.push(upperBase + offset)
+        }
+
+        if (isDefined(hoverGroupBoundaries[hoveredBandId].lower)) {
+          const lowerBase =
+            lineLengths[hoverGroupBoundaries[hoveredBandId].lower].startIndex
+          bandHoverIndices.lowerIndices.push(lowerBase + offset)
+        }
       }
     })
   }

--- a/giraffe/src/utils/getBandHoverIndices.ts
+++ b/giraffe/src/utils/getBandHoverIndices.ts
@@ -1,15 +1,4 @@
 import {NumericColumnData, BandIndexMap, LineData} from '../types'
-import {LOWER, UPPER} from '../constants/columnKeys'
-import {isDefined} from './isDefined'
-
-interface BandBoundaries {
-  [index: string]: {
-    upperCol: number
-    lowerCol: number
-    upperIndex: number
-    lowerIndex: number
-  }
-}
 
 interface LineLengths {
   [index: string]: {
@@ -22,47 +11,6 @@ export interface BandHoverIndices {
   rowIndices: number[]
   lowerIndices: number[]
   upperIndices: number[]
-}
-
-export const getBandBoundaries = (
-  hoverRowIndices: number[],
-  hoverGroupData: NumericColumnData,
-  bandLineIndexMap: object
-): BandBoundaries => {
-  const bandBoundaries = {}
-
-  const hoverColumnToIndexMap = {}
-
-  if (Array.isArray(hoverRowIndices)) {
-    hoverRowIndices.forEach(index => {
-      hoverColumnToIndexMap[hoverGroupData[index]] = index
-    })
-  }
-
-  const bands = bandLineIndexMap ? Object.values(bandLineIndexMap) : []
-
-  bands.forEach(band => {
-    bandBoundaries[band.row] = {
-      upperCol: null,
-      lowerCol: null,
-      upperIndex: null,
-      lowerIndex: null,
-    }
-    if (isDefined(band[UPPER])) {
-      bandBoundaries[band.row].upperCol = band[UPPER]
-      if (isDefined(hoverColumnToIndexMap[band[UPPER]])) {
-        bandBoundaries[band.row].upperIndex = hoverColumnToIndexMap[band[UPPER]]
-      }
-    }
-    if (isDefined(band[LOWER])) {
-      bandBoundaries[band.row].lowerCol = band[LOWER]
-      if (isDefined(hoverColumnToIndexMap[band[LOWER]])) {
-        bandBoundaries[band.row].lowerIndex = hoverColumnToIndexMap[band[LOWER]]
-      }
-    }
-  })
-
-  return bandBoundaries
 }
 
 export const getLineLengths = (lineData: LineData): LineLengths => {
@@ -91,32 +39,52 @@ export const getBandHoverIndices = (
   lineLengths: LineLengths,
   hoverRowIndices: number[],
   hoverGroupData: NumericColumnData,
-  bandBoundaries: BandBoundaries
+  bandLineIndexMap: object
 ): BandIndexMap => {
   const bandHoverIndices = {
     rowIndices: [],
     lowerIndices: [],
     upperIndices: [],
   }
+  const hoverGroupBoundaries = {}
+
+  if (Array.isArray(hoverGroupData)) {
+    hoverGroupData.forEach((lineIndex, position) => {
+      if (!hoverGroupBoundaries[lineIndex]) {
+        hoverGroupBoundaries[lineIndex] = {
+          length: lineLengths[lineIndex].length,
+          startIndex: position,
+        }
+      }
+    })
+  }
+
+  const bands = bandLineIndexMap ? Object.values(bandLineIndexMap) : []
+  bands.forEach(band => {
+    if (hoverGroupBoundaries[band.row]) {
+      hoverGroupBoundaries[band.row].upper = band.upper
+      hoverGroupBoundaries[band.row].lower = band.lower
+    }
+  })
 
   if (Array.isArray(hoverRowIndices)) {
     hoverRowIndices.forEach(index => {
       const columnId = hoverGroupData[index]
-      const hoveredBandId = Object.keys(bandBoundaries).find(
+      const hoveredBandId = Object.keys(hoverGroupBoundaries).find(
         bandId => Number(bandId) === Number(columnId)
       )
 
-      if (bandBoundaries[hoveredBandId]) {
-        const offset = index % lineLengths[hoveredBandId].length
+      if (hoverGroupBoundaries[hoveredBandId]) {
         const rowBase = lineLengths[hoveredBandId].startIndex
+        const upperBase =
+          lineLengths[hoverGroupBoundaries[hoveredBandId].upper].startIndex
+        const lowerBase =
+          lineLengths[hoverGroupBoundaries[hoveredBandId].lower].startIndex
+        const offset = index - hoverGroupBoundaries[hoveredBandId].startIndex
 
         bandHoverIndices.rowIndices.push(rowBase + offset)
-        bandHoverIndices.upperIndices.push(
-          bandBoundaries[hoveredBandId].upperIndex
-        )
-        bandHoverIndices.lowerIndices.push(
-          bandBoundaries[hoveredBandId].lowerIndex
-        )
+        bandHoverIndices.upperIndices.push(upperBase + offset)
+        bandHoverIndices.lowerIndices.push(lowerBase + offset)
       }
     })
   }

--- a/giraffe/src/utils/useBandHoverColumns.ts
+++ b/giraffe/src/utils/useBandHoverColumns.ts
@@ -24,9 +24,10 @@ const buildColumnData = (
         ...hoverableColumnData.ys,
         ...lineData[rowIndex].ys,
       ]
-      groupColData
-        .filter(index => index === rowIndex)
-        .forEach(value => hoverableColumnData.groupColData.push(value))
+      hoverableColumnData.groupColData = [
+        ...hoverableColumnData.groupColData,
+        ...groupColData.filter(index => index === rowIndex),
+      ]
     }
   })
   return hoverableColumnData

--- a/giraffe/src/utils/useBandHoverColumns.ts
+++ b/giraffe/src/utils/useBandHoverColumns.ts
@@ -1,0 +1,65 @@
+import {BandIndexMap, LineData, NumericColumnData} from '../types'
+import {useLazyMemo} from './useLazyMemo'
+import {isDefined} from './isDefined'
+
+const buildColumnData = (
+  lineData: LineData,
+  groupColData: NumericColumnData,
+  bandIndexMap: BandIndexMap
+) => {
+  const hoverableColumnData = {
+    xs: [],
+    ys: [],
+    groupColData: [],
+  }
+  const {rowIndices} = bandIndexMap
+
+  rowIndices.forEach(rowIndex => {
+    if (isDefined(rowIndex)) {
+      hoverableColumnData.xs = hoverableColumnData.xs.concat(
+        lineData[rowIndex].xs
+      )
+      hoverableColumnData.ys = hoverableColumnData.ys.concat(
+        lineData[rowIndex].ys
+      )
+      groupColData
+        .filter(index => index === rowIndex)
+        .forEach(value => hoverableColumnData.groupColData.push(value))
+    }
+  })
+  return hoverableColumnData
+}
+
+export const useBandHoverColumns = (
+  mouseX: number,
+  mouseY: number,
+  lineData: LineData,
+  groupColData: NumericColumnData,
+  bandIndexMap: BandIndexMap,
+  width: number,
+  height: number
+) => {
+  const isActive =
+    mouseX !== undefined &&
+    mouseX !== null &&
+    mouseX >= 0 &&
+    mouseX < width &&
+    mouseY !== undefined &&
+    mouseY !== null &&
+    mouseY >= 0 &&
+    mouseY < height
+
+  const result = useLazyMemo(
+    () => buildColumnData(lineData, groupColData, bandIndexMap),
+    [lineData, groupColData, bandIndexMap, width, height],
+    isActive
+  )
+
+  return !result
+    ? {
+        xs: [],
+        ys: [],
+        groupColData: [],
+      }
+    : result
+}

--- a/giraffe/src/utils/useBandHoverColumns.ts
+++ b/giraffe/src/utils/useBandHoverColumns.ts
@@ -16,12 +16,14 @@ const buildColumnData = (
 
   rowIndices.forEach(rowIndex => {
     if (isDefined(rowIndex)) {
-      hoverableColumnData.xs = hoverableColumnData.xs.concat(
-        lineData[rowIndex].xs
-      )
-      hoverableColumnData.ys = hoverableColumnData.ys.concat(
-        lineData[rowIndex].ys
-      )
+      hoverableColumnData.xs = [
+        ...hoverableColumnData.xs,
+        ...lineData[rowIndex].xs,
+      ]
+      hoverableColumnData.ys = [
+        ...hoverableColumnData.ys,
+        ...lineData[rowIndex].ys,
+      ]
       groupColData
         .filter(index => index === rowIndex)
         .forEach(value => hoverableColumnData.groupColData.push(value))

--- a/stories/src/band.stories.tsx
+++ b/stories/src/band.stories.tsx
@@ -11,6 +11,7 @@ import {
   graphEdge1,
   hoverAlignment1,
   hoverAlignment2,
+  hoverAlignment3,
   mem1,
   mem2,
   noLowerAndUpper,
@@ -27,13 +28,109 @@ import {
   showAxesKnob,
   interpolationKnob,
   timeZoneKnob,
-  tooltipOrientationThresholdKnob,
   tooltipColorizeRowsKnob,
 } from './helpers'
 
 storiesOf('Band Chart', module)
   .addDecorator(withKnobs)
-  .add('Static CSV', () => {
+  .add('Static: groupBy applied', () => {
+    const colors = colorSchemeKnob()
+    const legendFont = legendFontKnob()
+    const tickFont = tickFontKnob()
+    const valueAxisLabel = text('Value Axis Label', '')
+    const xScale = xScaleKnob()
+    const yScale = yScaleKnob()
+    const timeZone = timeZoneKnob()
+    const timeFormat = select(
+      'Time Format',
+      {
+        'DD/MM/YYYY HH:mm:ss.sss': 'DD/MM/YYYY HH:mm:ss.sss',
+        'MM/DD/YYYY HH:mm:ss.sss': 'MM/DD/YYYY HH:mm:ss.sss',
+        'YYYY/MM/DD HH:mm:ss': 'YYYY/MM/DD HH:mm:ss',
+        'YYYY-MM-DD HH:mm:ss ZZ': 'YYYY-MM-DD HH:mm:ss ZZ',
+        'hh:mm a': 'hh:mm a',
+        'HH:mm': 'HH:mm',
+        'HH:mm:ss': 'HH:mm:ss',
+        'HH:mm:ss ZZ': 'HH:mm:ss ZZ',
+        'HH:mm:ss.sss': 'HH:mm:ss.sss',
+        'MMMM D, YYYY HH:mm:ss': 'MMMM D, YYYY HH:mm:ss',
+        'dddd, MMMM D, YYYY HH:mm:ss': 'dddd, MMMM D, YYYY HH:mm:ss',
+      },
+      'hh:mm a'
+    )
+    const interpolation = interpolationKnob()
+    const showAxes = showAxesKnob()
+    const lineWidth = number('Line Width', 3)
+    const lineOpacity = number('Line Opacity', 0.7)
+    const shadeOpacity = number('Shade Opacity', 0.3)
+    const hoverDimension = select(
+      'Hover Dimension',
+      {auto: 'auto', x: 'x', y: 'y', xy: 'xy'},
+      'auto'
+    )
+    const upperColumnName = text('upperColumnName', 'max')
+    const mainColumnName = text('mainColumnName', 'mean')
+    const lowerColumnName = text('lowerColumnName', 'min')
+    const legendOpacity = number('Legend Opacity', 1.0, {
+      range: true,
+      min: 0,
+      max: 1.0,
+      step: 0.05,
+    })
+    const legendOrientationThreshold = number('legendOrientationThreshold', 15)
+    const legendColorizeRows = tooltipColorizeRowsKnob()
+    const yTickStart = number('yTickStart', 0)
+    const yTickStep = number('yTickStep', 100)
+    const xTotalTicks = number('xTotalTicks', 20)
+
+    const config: Config = {
+      fluxResponse: hoverAlignment3,
+      valueFormatters: {
+        _time: timeFormatter({timeZone, format: timeFormat}),
+        _value: val =>
+          typeof val === 'number'
+            ? `${val.toFixed(2)}${
+                valueAxisLabel ? ` ${valueAxisLabel}` : valueAxisLabel
+              }`
+            : val,
+      },
+      xScale,
+      yScale,
+      legendFont,
+      tickFont,
+      showAxes,
+      legendOpacity,
+      legendOrientationThreshold,
+      legendColorizeRows,
+      xTotalTicks,
+      yTickStart,
+      yTickStep,
+      layers: [
+        {
+          type: 'band',
+          x: '_time',
+          y: '_value',
+          fill: ['result', 'env'],
+          interpolation,
+          colors,
+          lineWidth,
+          lineOpacity,
+          hoverDimension,
+          shadeOpacity,
+          upperColumnName,
+          mainColumnName,
+          lowerColumnName,
+        },
+      ],
+    }
+
+    return (
+      <PlotContainer>
+        <Plot config={config} />
+      </PlotContainer>
+    )
+  })
+  .add('Static: all string columns', () => {
     const staticData = select(
       'Static CSV',
       {
@@ -72,7 +169,7 @@ storiesOf('Band Chart', module)
         'MMMM D, YYYY HH:mm:ss': 'MMMM D, YYYY HH:mm:ss',
         'dddd, MMMM D, YYYY HH:mm:ss': 'dddd, MMMM D, YYYY HH:mm:ss',
       },
-      'YYYY-MM-DD HH:mm:ss ZZ'
+      'hh:mm a'
     )
     const fromFluxTable = fromFlux(staticData).table
     const interpolation = interpolationKnob()
@@ -94,8 +191,9 @@ storiesOf('Band Chart', module)
       max: 1.0,
       step: 0.05,
     })
-    const legendOrientationThreshold = tooltipOrientationThresholdKnob()
+    const legendOrientationThreshold = number('legendOrientationThreshold', 15)
     const legendColorizeRows = tooltipColorizeRowsKnob()
+    const xTotalTicks = number('xTotalTicks', 20)
 
     const config: Config = {
       fluxResponse: staticData,
@@ -116,6 +214,7 @@ storiesOf('Band Chart', module)
       legendOpacity,
       legendOrientationThreshold,
       legendColorizeRows,
+      xTotalTicks,
       layers: [
         {
           type: 'band',
@@ -187,7 +286,7 @@ storiesOf('Band Chart', module)
       max: 1.0,
       step: 0.05,
     })
-    const legendOrientationThreshold = tooltipOrientationThresholdKnob()
+    const legendOrientationThreshold = number('legendOrientationThreshold', 15)
     const legendColorizeRows = tooltipColorizeRowsKnob()
 
     const config: Config = {

--- a/stories/src/data/bandCSV.ts
+++ b/stories/src/data/bandCSV.ts
@@ -1250,6 +1250,750 @@ export const hoverAlignment2 = `#group,false,false,true,true,false,false,true,tr
 ,,1,2020-08-21T16:57:53.941439Z,2020-08-21T17:12:53.941439Z,2020-08-21T17:12:00Z,8,usage_system,cpu,cpu0,MBP15-TLUONG.local
 ,,1,2020-08-21T16:57:53.941439Z,2020-08-21T17:12:53.941439Z,2020-08-21T17:12:53.941439Z,13.872255489021956,usage_system,cpu,cpu0,MBP15-TLUONG.local
 `
+export const hoverAlignment3 = `#group,false,false,true,true,false,false,false,false,false,true,false,false,false
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string,string,string,string
+#default,min,,,,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,agg,env,interval,role,source
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T02:00:00Z,5,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T03:00:00Z,16,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T05:00:00Z,41,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T06:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T07:00:00Z,18,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T08:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T09:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T10:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T11:00:00Z,7,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T12:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T13:00:00Z,7,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T14:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T15:00:00Z,5,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T16:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T17:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T18:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T19:00:00Z,38,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T21:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T22:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Edg
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T23:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T00:00:00Z,28,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T01:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T03:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T04:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T05:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T06:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T07:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T08:00:00Z,9,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T09:00:00Z,5,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T10:00:00Z,78,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T11:00:00Z,98,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T12:00:00Z,29,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T13:00:00Z,19,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T14:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T15:00:00Z,164,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T16:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T17:00:00Z,34,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T18:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T19:00:00Z,14,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T20:00:00Z,42,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T21:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T22:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T23:00:00Z,16,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T00:00:00Z,6,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T01:00:00Z,101,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T02:00:00Z,42,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T04:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T05:00:00Z,131,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T06:00:00Z,28,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T07:00:00Z,7,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T08:00:00Z,7,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T09:00:00Z,14,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T10:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Raspbian Chromium
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T11:00:00Z,12,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T12:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T13:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T14:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T15:00:00Z,13,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T16:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Raspbian Chromium
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T17:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Raspbian Chromium
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T19:00:00Z,8,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T20:00:00Z,176,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T21:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T22:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T23:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T00:00:00Z,11,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T06:00:00Z,20,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T07:00:00Z,45,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T08:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T09:00:00Z,5,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T10:00:00Z,15,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T11:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T12:00:00Z,184,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T13:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T14:00:00Z,12,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T15:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T16:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T17:00:00Z,27,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T18:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T19:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T20:00:00Z,7,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T21:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T23:00:00Z,28,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Edg
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T01:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T02:00:00Z,11,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T05:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T07:00:00Z,253,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T08:00:00Z,79,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T09:00:00Z,90,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T10:00:00Z,80,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T11:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T12:00:00Z,170,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T13:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T14:00:00Z,17,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T15:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T16:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T17:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T18:00:00Z,30,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T19:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T20:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T21:00:00Z,21,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T22:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T23:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T00:00:00Z,11,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T03:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T10:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Raspbian Chromium
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T11:00:00Z,5,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T14:00:00Z,12,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T15:00:00Z,31,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T16:00:00Z,17,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T17:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T18:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T19:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T20:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T21:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T22:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T23:00:00Z,16,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Samsung Browser
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T00:00:00Z,7,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T02:00:00Z,105,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T03:00:00Z,73,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T04:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T05:00:00Z,63,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T06:00:00Z,10,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T07:00:00Z,19,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T08:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T09:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T10:00:00Z,19,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T11:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T12:00:00Z,15,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T13:00:00Z,53,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Grafana
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T14:00:00Z,23,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T15:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T16:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Edg
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T17:00:00Z,5,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T18:00:00Z,6,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Firefox
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T19:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T20:00:00Z,18,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T21:00:00Z,11,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T22:00:00Z,6,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Safari
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T23:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Chrome
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-10T00:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T02:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Edg
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T03:00:00Z,24,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T05:00:00Z,10,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T06:00:00Z,4,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Edg
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T07:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T08:00:00Z,24,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Raspbian Chromium
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T09:00:00Z,23,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Chrome
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T10:00:00Z,24,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Raspbian Chromium
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T11:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Edg
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T12:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Chrome
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T13:00:00Z,24,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T14:00:00Z,14,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T15:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T16:00:00Z,10,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Chrome
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T17:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T18:00:00Z,28,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Raspbian Chromium
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T19:00:00Z,10,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Edg
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T20:00:00Z,28,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Raspbian Chromium
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T21:00:00Z,13,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T22:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T23:00:00Z,18,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T00:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T01:00:00Z,23,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T02:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T03:00:00Z,17,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Chrome
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T04:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T05:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Chrome
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T06:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T08:00:00Z,11,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T09:00:00Z,34,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T11:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T14:00:00Z,4,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T15:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T17:00:00Z,112,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T18:00:00Z,43,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T19:00:00Z,44,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T20:00:00Z,15,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T21:00:00Z,96,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T22:00:00Z,9,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T00:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T02:00:00Z,7,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T03:00:00Z,1,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T04:00:00Z,153,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T05:00:00Z,618,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T06:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Chrome
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T07:00:00Z,24,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T08:00:00Z,29,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Chrome
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T13:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T14:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T15:00:00Z,85,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T16:00:00Z,14,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Chrome
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T17:00:00Z,455,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T19:00:00Z,22,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T20:00:00Z,15,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Chrome
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T21:00:00Z,8,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T22:00:00Z,12,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T23:00:00Z,7,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T01:00:00Z,1,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Chrome
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T02:00:00Z,1,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T03:00:00Z,8,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T05:00:00Z,12,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T06:00:00Z,21,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T07:00:00Z,48,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T08:00:00Z,12,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T09:00:00Z,73,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T10:00:00Z,30,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T12:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T14:00:00Z,114,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T15:00:00Z,41,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T16:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T18:00:00Z,46,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T20:00:00Z,20,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T01:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T02:00:00Z,4,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T11:00:00Z,76,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T12:00:00Z,136,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T13:00:00Z,49,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T03:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T06:00:00Z,13,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Edg
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T07:00:00Z,8,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T14:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T15:00:00Z,4,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T19:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T21:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T22:00:00Z,16,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T01:00:00Z,86,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T04:00:00Z,14,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T05:00:00Z,5,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Chrome
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T06:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T09:00:00Z,30,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T10:00:00Z,22,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T11:00:00Z,8,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Chrome
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T12:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T16:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T17:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T18:00:00Z,7,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T20:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T21:00:00Z,4,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T22:00:00Z,4,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T23:00:00Z,12,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Chrome
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-10T00:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,Firefox
+
+#group,false,false,true,true,false,false,false,false,false,true,false,false,false
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string,string,string,string
+#default,max,,,,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,agg,env,interval,role,source
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T02:00:00Z,5,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T03:00:00Z,16,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T05:00:00Z,41,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T06:00:00Z,127,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T07:00:00Z,40,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T08:00:00Z,58,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T09:00:00Z,106,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T10:00:00Z,159,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T11:00:00Z,131,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T12:00:00Z,222,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T13:00:00Z,208,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T14:00:00Z,41,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T15:00:00Z,197,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T16:00:00Z,106,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T17:00:00Z,29,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T18:00:00Z,189,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T19:00:00Z,38,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T21:00:00Z,86,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T22:00:00Z,10,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T23:00:00Z,6,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T00:00:00Z,28,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T01:00:00Z,193,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T03:00:00Z,45,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T04:00:00Z,104,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T05:00:00Z,63,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T06:00:00Z,28,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T07:00:00Z,7,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T08:00:00Z,105,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T09:00:00Z,65,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T10:00:00Z,247,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T11:00:00Z,336,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T12:00:00Z,60,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T13:00:00Z,392,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T14:00:00Z,182,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T15:00:00Z,611,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T16:00:00Z,54,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T17:00:00Z,144,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T18:00:00Z,42,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T19:00:00Z,107,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T20:00:00Z,246,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T21:00:00Z,71,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T22:00:00Z,54,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T23:00:00Z,41,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T00:00:00Z,6,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T01:00:00Z,101,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T02:00:00Z,42,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T04:00:00Z,3,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T05:00:00Z,131,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T06:00:00Z,28,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T07:00:00Z,73,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T08:00:00Z,24,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T09:00:00Z,149,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T10:00:00Z,86,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T11:00:00Z,126,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T12:00:00Z,603,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Grafana
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T13:00:00Z,343,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Grafana
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T14:00:00Z,95,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T15:00:00Z,105,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T16:00:00Z,70,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T17:00:00Z,35,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T19:00:00Z,30,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T20:00:00Z,176,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T21:00:00Z,61,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T22:00:00Z,18,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T23:00:00Z,46,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T00:00:00Z,11,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T06:00:00Z,20,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T07:00:00Z,45,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T08:00:00Z,77,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T09:00:00Z,78,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T10:00:00Z,361,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T11:00:00Z,213,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T12:00:00Z,184,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T13:00:00Z,254,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T14:00:00Z,244,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T15:00:00Z,221,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T16:00:00Z,255,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T17:00:00Z,149,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T18:00:00Z,61,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T19:00:00Z,56,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T20:00:00Z,55,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T21:00:00Z,5,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T23:00:00Z,74,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T01:00:00Z,10,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T02:00:00Z,11,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T05:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T07:00:00Z,253,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T08:00:00Z,79,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T09:00:00Z,90,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T10:00:00Z,80,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T11:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T12:00:00Z,170,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T13:00:00Z,67,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T14:00:00Z,246,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T15:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T16:00:00Z,38,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T17:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T18:00:00Z,30,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T19:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T20:00:00Z,8,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T21:00:00Z,21,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T22:00:00Z,47,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T23:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T00:00:00Z,38,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T03:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T10:00:00Z,7,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T11:00:00Z,5,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T14:00:00Z,30,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T15:00:00Z,31,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T16:00:00Z,17,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T17:00:00Z,10,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T18:00:00Z,17,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T19:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T20:00:00Z,2,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T21:00:00Z,41,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T22:00:00Z,43,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T23:00:00Z,100,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T00:00:00Z,86,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T02:00:00Z,105,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T03:00:00Z,73,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T04:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T05:00:00Z,63,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T06:00:00Z,10,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T07:00:00Z,19,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T08:00:00Z,321,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T09:00:00Z,153,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T10:00:00Z,241,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T11:00:00Z,484,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T12:00:00Z,783,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Grafana
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T13:00:00Z,197,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T14:00:00Z,177,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Grafana
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T15:00:00Z,383,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T16:00:00Z,71,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T17:00:00Z,58,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T18:00:00Z,106,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Grafana
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T19:00:00Z,53,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,Grafana
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T20:00:00Z,89,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T21:00:00Z,11,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T22:00:00Z,15,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T23:00:00Z,4,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-10T00:00:00Z,1,totalDuration,query_log,count,prod01-eu-west-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T02:00:00Z,26,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T03:00:00Z,24,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T05:00:00Z,34,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T06:00:00Z,39,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T07:00:00Z,26,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T08:00:00Z,100,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T09:00:00Z,47,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T10:00:00Z,75,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T11:00:00Z,38,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T12:00:00Z,26,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T13:00:00Z,24,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T14:00:00Z,38,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T15:00:00Z,26,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T16:00:00Z,38,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T17:00:00Z,38,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T18:00:00Z,132,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T19:00:00Z,59,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T20:00:00Z,141,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T21:00:00Z,31,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T22:00:00Z,60,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-03T23:00:00Z,55,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T00:00:00Z,20,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T01:00:00Z,23,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T02:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T03:00:00Z,35,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T04:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T05:00:00Z,4,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T06:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T08:00:00Z,11,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T09:00:00Z,34,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T11:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T14:00:00Z,4,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T15:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T17:00:00Z,112,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T18:00:00Z,43,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T19:00:00Z,44,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T20:00:00Z,66,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T21:00:00Z,96,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-04T22:00:00Z,9,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T00:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T02:00:00Z,7,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T03:00:00Z,1,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T04:00:00Z,153,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T05:00:00Z,618,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T06:00:00Z,4,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T07:00:00Z,24,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T08:00:00Z,80,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T13:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T14:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T15:00:00Z,85,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T16:00:00Z,28,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T17:00:00Z,455,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T19:00:00Z,22,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T20:00:00Z,36,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T21:00:00Z,36,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T22:00:00Z,12,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-05T23:00:00Z,7,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T01:00:00Z,4,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T02:00:00Z,1,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T03:00:00Z,8,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T05:00:00Z,12,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T06:00:00Z,21,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T07:00:00Z,48,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T08:00:00Z,12,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T09:00:00Z,73,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T10:00:00Z,30,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T12:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T14:00:00Z,114,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T15:00:00Z,41,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T16:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T18:00:00Z,46,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-06T20:00:00Z,20,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T01:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T02:00:00Z,4,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T11:00:00Z,76,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T12:00:00Z,136,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-07T13:00:00Z,49,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T03:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T06:00:00Z,84,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T07:00:00Z,8,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T14:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T15:00:00Z,4,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T19:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T21:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-08T22:00:00Z,16,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T01:00:00Z,86,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T04:00:00Z,14,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T05:00:00Z,13,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T06:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T09:00:00Z,30,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T10:00:00Z,22,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T11:00:00Z,26,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T12:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T16:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T17:00:00Z,6,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T18:00:00Z,49,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T20:00:00Z,2,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T21:00:00Z,4,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T22:00:00Z,43,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-09T23:00:00Z,24,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-10T00:00:00Z,130,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,53,totalDuration,query_log,count,prod01-us-east-1,1h,queryd-v1,All Browsers
+
+#group,false,false,true,true,true,false,false
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,double,dateTime:RFC3339
+#default,mean,,,,,,
+,result,table,_start,_stop,env,_value,_time
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,5,2020-11-03T02:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,16,2020-11-03T03:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,41,2020-11-03T05:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,84.66666666666667,2020-11-03T06:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,26.666666666666668,2020-11-03T07:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,29,2020-11-03T08:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,42.4,2020-11-03T09:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,63.6,2020-11-03T10:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,57.8,2020-11-03T11:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,74,2020-11-03T12:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,104,2020-11-03T13:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,27.333333333333332,2020-11-03T14:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,98.5,2020-11-03T15:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,42.4,2020-11-03T16:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,14.5,2020-11-03T17:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,94.5,2020-11-03T18:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,38,2020-11-03T19:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,43,2020-11-03T21:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,5,2020-11-03T22:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,4,2020-11-03T23:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,28,2020-11-04T00:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,96.5,2020-11-04T01:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,30,2020-11-04T03:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,69.33333333333333,2020-11-04T04:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,42,2020-11-04T05:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,18.666666666666668,2020-11-04T06:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,4.666666666666667,2020-11-04T07:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,70,2020-11-04T08:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,32.5,2020-11-04T09:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,164.66666666666666,2020-11-04T10:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,224,2020-11-04T11:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,40,2020-11-04T12:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,196,2020-11-04T13:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,91,2020-11-04T14:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,407.3333333333333,2020-11-04T15:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,36,2020-11-04T16:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,72,2020-11-04T17:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,28,2020-11-04T18:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,71.33333333333333,2020-11-04T19:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,164,2020-11-04T20:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,47.333333333333336,2020-11-04T21:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,27,2020-11-04T22:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,27.333333333333332,2020-11-04T23:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,6,2020-11-05T00:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,101,2020-11-05T01:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,42,2020-11-05T02:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,3,2020-11-05T04:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,131,2020-11-05T05:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,28,2020-11-05T06:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,48.666666666666664,2020-11-05T07:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,16,2020-11-05T08:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,59.6,2020-11-05T09:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,43,2020-11-05T10:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,63,2020-11-05T11:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,319,2020-11-05T12:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,123.25,2020-11-05T13:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,38,2020-11-05T14:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,52.5,2020-11-05T15:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,35,2020-11-05T16:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,17.5,2020-11-05T17:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,20,2020-11-05T19:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,176,2020-11-05T20:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,40.666666666666664,2020-11-05T21:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,9,2020-11-05T22:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,23,2020-11-05T23:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,11,2020-11-06T00:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,20,2020-11-06T06:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,45,2020-11-06T07:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,38.5,2020-11-06T08:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,31.2,2020-11-06T09:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,180.5,2020-11-06T10:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,106.5,2020-11-06T11:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,184,2020-11-06T12:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,127,2020-11-06T13:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,122,2020-11-06T14:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,110.5,2020-11-06T15:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,102,2020-11-06T16:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,74.5,2020-11-06T17:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,40.666666666666664,2020-11-06T18:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,37.333333333333336,2020-11-06T19:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,36.666666666666664,2020-11-06T20:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,3.3333333333333335,2020-11-06T21:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,49.333333333333336,2020-11-06T23:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,6.666666666666667,2020-11-07T01:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,11,2020-11-07T02:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,1,2020-11-07T05:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,253,2020-11-07T07:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,79,2020-11-07T08:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,90,2020-11-07T09:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,80,2020-11-07T10:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,4,2020-11-07T11:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,170,2020-11-07T12:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,44.666666666666664,2020-11-07T13:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,164,2020-11-07T14:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,2,2020-11-07T15:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,25.333333333333332,2020-11-07T16:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,2,2020-11-07T17:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,30,2020-11-07T18:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,4,2020-11-07T19:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,5.333333333333333,2020-11-07T20:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,21,2020-11-07T21:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,31.333333333333332,2020-11-07T22:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,4,2020-11-07T23:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,25.333333333333332,2020-11-08T00:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,2,2020-11-08T03:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,4.666666666666667,2020-11-08T10:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,5,2020-11-08T11:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,20,2020-11-08T14:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,31,2020-11-08T15:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,17,2020-11-08T16:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,6.666666666666667,2020-11-08T17:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,11.333333333333334,2020-11-08T18:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,2,2020-11-08T19:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,2,2020-11-08T20:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,27.333333333333332,2020-11-08T21:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,28.666666666666668,2020-11-08T22:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,50,2020-11-08T23:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,57.333333333333336,2020-11-09T00:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,105,2020-11-09T02:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,73,2020-11-09T03:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,1,2020-11-09T04:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,63,2020-11-09T05:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,10,2020-11-09T06:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,19,2020-11-09T07:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,214,2020-11-09T08:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,61.2,2020-11-09T09:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,96.4,2020-11-09T10:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,193.6,2020-11-09T11:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,196.16666666666666,2020-11-09T12:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,111.75,2020-11-09T13:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,71.75,2020-11-09T14:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,153.2,2020-11-09T15:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,35.5,2020-11-09T16:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,29,2020-11-09T17:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,60.8,2020-11-09T18:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,19.666666666666668,2020-11-09T19:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,59.333333333333336,2020-11-09T20:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,11,2020-11-09T21:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,10,2020-11-09T22:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,2.6666666666666665,2020-11-09T23:00:00Z
+,,0,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-eu-west-1,1,2020-11-10T00:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,17.333333333333332,2020-11-03T02:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,24,2020-11-03T03:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,22.666666666666668,2020-11-03T05:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,19.5,2020-11-03T06:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,17.333333333333332,2020-11-03T07:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,66.66666666666667,2020-11-03T08:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,31.333333333333332,2020-11-03T09:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,50,2020-11-03T10:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,19,2020-11-03T11:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,17.333333333333332,2020-11-03T12:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,24,2020-11-03T13:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,25.333333333333332,2020-11-03T14:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,17.333333333333332,2020-11-03T15:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,25.333333333333332,2020-11-03T16:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,19,2020-11-03T17:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,88,2020-11-03T18:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,29.5,2020-11-03T19:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,70.5,2020-11-03T20:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,20.666666666666668,2020-11-03T21:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,40,2020-11-03T22:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,36.666666666666664,2020-11-03T23:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,13.333333333333334,2020-11-04T00:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,23,2020-11-04T01:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2,2020-11-04T02:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,23.333333333333332,2020-11-04T03:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2,2020-11-04T04:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2.6666666666666665,2020-11-04T05:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2,2020-11-04T06:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,11,2020-11-04T08:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,34,2020-11-04T09:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2,2020-11-04T11:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,4,2020-11-04T14:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,6,2020-11-04T15:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,112,2020-11-04T17:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,43,2020-11-04T18:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,44,2020-11-04T19:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,44,2020-11-04T20:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,96,2020-11-04T21:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,9,2020-11-04T22:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2,2020-11-05T00:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,7,2020-11-05T02:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,1,2020-11-05T03:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,153,2020-11-05T04:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,618,2020-11-05T05:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2.6666666666666665,2020-11-05T06:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,24,2020-11-05T07:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,53.333333333333336,2020-11-05T08:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2,2020-11-05T13:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2,2020-11-05T14:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,85,2020-11-05T15:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,18.666666666666668,2020-11-05T16:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,455,2020-11-05T17:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,22,2020-11-05T19:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,24,2020-11-05T20:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,24,2020-11-05T21:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,12,2020-11-05T22:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,7,2020-11-05T23:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2.6666666666666665,2020-11-06T01:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,1,2020-11-06T02:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,8,2020-11-06T03:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,12,2020-11-06T05:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,21,2020-11-06T06:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,48,2020-11-06T07:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,12,2020-11-06T08:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,73,2020-11-06T09:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,30,2020-11-06T10:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2,2020-11-06T12:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,114,2020-11-06T14:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,41,2020-11-06T15:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2,2020-11-06T16:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,46,2020-11-06T18:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,20,2020-11-06T20:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2,2020-11-07T01:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,4,2020-11-07T02:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,76,2020-11-07T11:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,136,2020-11-07T12:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,49,2020-11-07T13:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,6,2020-11-08T03:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,56,2020-11-08T06:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,8,2020-11-08T07:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2,2020-11-08T14:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,4,2020-11-08T15:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,6,2020-11-08T19:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2,2020-11-08T21:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,16,2020-11-08T22:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,86,2020-11-09T01:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,14,2020-11-09T04:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,8.666666666666666,2020-11-09T05:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2,2020-11-09T06:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,30,2020-11-09T09:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,22,2020-11-09T10:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,17.333333333333332,2020-11-09T11:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,6,2020-11-09T12:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,6,2020-11-09T16:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,6,2020-11-09T17:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,32.666666666666664,2020-11-09T18:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,2,2020-11-09T20:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,4,2020-11-09T21:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,28.666666666666668,2020-11-09T22:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,16,2020-11-09T23:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,86.66666666666667,2020-11-10T00:00:00Z
+,,1,2020-11-03T00:23:45.428067991Z,2020-11-10T00:23:45.428067991Z,prod01-us-east-1,35.333333333333336,2020-11-10T00:23:45.428067991Z
+`
 
 export const mem1 = `#group,false,false,true,true,false,false,true,true,true
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string


### PR DESCRIPTION
Closes idpe 9144

Band chart was doing strange things with the hover dimensions. In any flux CSV response that comes from using "group by", the hover points become misaligned. To fix this:
- stop doing strange things with the hover dimensions
- define all of the hoverable points for Band chart and use that everywhere
- take advantage of having the line data aligned by band by looking up the corresponding upper and lower sections per band using a matching offset
- fix the aligning of line data by handling edge case where an "upper" or "lower" line is not associated with any "main" line
- memoize the calculation of the hoverable points to make hovering snappy and the user happy

<img width="1680" alt="Screen Shot 2020-11-17 at 7 27 54 PM" src="https://user-images.githubusercontent.com/10736577/99479736-98cec980-290b-11eb-9950-689e06c42069.png">
