### PR TITLE
test: ignore 6133 declared but never read errors in stories

### DIFF
--- a/stories/.storybook/webpack.config.js
+++ b/stories/.storybook/webpack.config.js
@@ -35,6 +35,7 @@ module.exports = ({config}) => {
         {
           loader: require.resolve('ts-loader'),
           options: {
+            ignoreDiagnostics: ['6133'],
             compilerOptions: {
               rootDir: '../../giraffe',
               outDir: null,


### PR DESCRIPTION
This will let you comment out variable usage without having to comment out declarations when you're writing or testing stories.