### PR TITLE
fix: revert the bin limits on hover points and use a visual limit for the Tooltip

### DIFF
--- a/giraffe/src/components/Tooltip.tsx
+++ b/giraffe/src/components/Tooltip.tsx
@@ -45,6 +45,15 @@ export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
     : data
 
   const switchToVertical = columns.length > orientationThreshold
+
+  // 'switchToVertical': true
+  //   each column of data displays vertically, and
+  //   additional columns are next to the previous column, therefore,
+  //   the limit is the horizontal space (width)
+  // 'switchToVertical': false
+  //   each column of data displays horizontally, and
+  //   additional columns are stacked below the previous column, therefore,
+  //   the limit is the vertical space (height)
   const maxLength = switchToVertical ? width : height
 
   const styles = generateTooltipStyles(

--- a/giraffe/src/components/Tooltip.tsx
+++ b/giraffe/src/components/Tooltip.tsx
@@ -17,6 +17,7 @@ export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
   const tooltipElement = useTooltipElement()
 
   const {
+    width,
     height,
     legendFont: font,
     legendFontColor: fontColor,
@@ -44,6 +45,7 @@ export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
     : data
 
   const switchToVertical = columns.length > orientationThreshold
+  const maxLength = switchToVertical ? width : height
 
   const styles = generateTooltipStyles(
     columns,
@@ -78,7 +80,7 @@ export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
           <TooltipColumn
             key={name}
             name={name}
-            height={height}
+            maxLength={maxLength}
             values={values}
             columnStyle={styles.columns[i]}
             columnHeaderStyle={styles.headers}
@@ -95,7 +97,7 @@ Tooltip.displayName = 'Tooltip'
 
 interface TooltipColumnProps {
   name: string
-  height: number
+  maxLength: number
   values: string[]
   columnStyle: React.CSSProperties
   columnHeaderStyle: React.CSSProperties
@@ -104,19 +106,19 @@ interface TooltipColumnProps {
 
 const TooltipColumn: FunctionComponent<TooltipColumnProps> = ({
   name,
-  height,
+  maxLength,
   values,
   columnStyle,
   columnHeaderStyle,
   columnValueStyles,
 }) => {
-  const valuesLimitedByPlotHeight = values.slice(0, height)
+  const valuesLimitedByPlotDimensions = values.slice(0, maxLength)
   return (
     <div className="giraffe-tooltip-column" style={columnStyle}>
       <div className="giraffe-tooltip-column-header" style={columnHeaderStyle}>
         {name}
       </div>
-      {valuesLimitedByPlotHeight.map((value, i) => (
+      {valuesLimitedByPlotDimensions.map((value, i) => (
         <div
           className="giraffe-tooltip-column-value"
           key={i}

--- a/giraffe/src/components/Tooltip.tsx
+++ b/giraffe/src/components/Tooltip.tsx
@@ -17,6 +17,7 @@ export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
   const tooltipElement = useTooltipElement()
 
   const {
+    height,
     legendFont: font,
     legendFontColor: fontColor,
     legendFontBrightColor: fontBrightColor,
@@ -77,6 +78,7 @@ export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
           <TooltipColumn
             key={name}
             name={name}
+            height={height}
             values={values}
             columnStyle={styles.columns[i]}
             columnHeaderStyle={styles.headers}
@@ -93,6 +95,7 @@ Tooltip.displayName = 'Tooltip'
 
 interface TooltipColumnProps {
   name: string
+  height: number
   values: string[]
   columnStyle: React.CSSProperties
   columnHeaderStyle: React.CSSProperties
@@ -101,17 +104,19 @@ interface TooltipColumnProps {
 
 const TooltipColumn: FunctionComponent<TooltipColumnProps> = ({
   name,
+  height,
   values,
   columnStyle,
   columnHeaderStyle,
   columnValueStyles,
 }) => {
+  const valuesLimitedByPlotHeight = values.slice(0, height)
   return (
     <div className="giraffe-tooltip-column" style={columnStyle}>
       <div className="giraffe-tooltip-column-header" style={columnHeaderStyle}>
         {name}
       </div>
-      {values.map((value, i) => (
+      {valuesLimitedByPlotHeight.map((value, i) => (
         <div
           className="giraffe-tooltip-column-value"
           key={i}

--- a/giraffe/src/constants/index.ts
+++ b/giraffe/src/constants/index.ts
@@ -128,7 +128,6 @@ export const BAND_COLOR_SCALE_CONSTANT = 3
 
 export const TOOLTIP_MINIMUM_OPACITY = 0
 export const TOOLTIP_MAXIMUM_OPACITY = 1.0
-export const HOVER_POINTS_COUNT_LIMIT = 200
 
 export const CLOCKFACE_Z_INDEX = 9599
 

--- a/giraffe/src/utils/useHoverPointIndices.ts
+++ b/giraffe/src/utils/useHoverPointIndices.ts
@@ -95,10 +95,10 @@ export const useHoverPointIndices = (
  *
  * 3. When hovering, a typical screen size (laptop or desktop) fits around 200 rows
  *    in a readable font size. Any additional rows calculated will not be viewable
- *    on the screen. Any additional calculation is useless because no useful
+ *    on the screen. So, any additional calculation is useless because no useful
  *    information for the user will be viewable due to screen size.
  *
- * 4. Therefore, any exceesively large data set does a lot of useless work and
+ * 4. Therefore, any excessively large data set does a lot of useless work and
  *    adversely affects browser performance.
  *
  * 5. Limit the total number of points in each dimension and also each bin.

--- a/giraffe/src/utils/useHoverPointIndices.ts
+++ b/giraffe/src/utils/useHoverPointIndices.ts
@@ -5,8 +5,6 @@ import {useLazyMemo} from './useLazyMemo'
 import {isDefined} from './isDefined'
 import {minBy} from './extrema'
 
-import {HOVER_POINTS_COUNT_LIMIT} from '../constants'
-
 export const useHoverPointIndices = (
   mode: 'x' | 'y' | 'xy',
   mouseX: number,
@@ -47,6 +45,7 @@ export const useHoverPointIndices = (
   if (mode === 'x') {
     hoverLineIndices = lookupIndex1D(
       index.xBins,
+      index.maxCountPerXBin,
       mouseX,
       xScale.invert(mouseX),
       xColData,
@@ -56,6 +55,7 @@ export const useHoverPointIndices = (
   } else if (mode === 'y') {
     hoverLineIndices = lookupIndex1D(
       index.yBins,
+      index.maxCountPerYBin,
       mouseY,
       yScale.invert(mouseY),
       yColData,
@@ -79,9 +79,37 @@ export const useHoverPointIndices = (
   return hoverLineIndices
 }
 
+/************************************************************************
+ * When calculating hovered points in a graph:
+ *
+ * 1. The graph is divided into sections or "bins".
+ *    Bigger graphs (width, height), have more bins than smaller graphs.
+ *
+ * 2. All of the data points are assigned to the bins.
+ *    When comparing the same set of data points:
+ *     - large graphs have many bins with fewer data points per bin
+ *       ex: 50 data points = 10 bins x 5 data points each
+ *
+ *     - small graphs have fewer bins with many data points per bin
+ *       ex: 50 data points = 2 bins x 25 data points each
+ *
+ * 3. When hovering, a typical screen size (laptop or desktop) fits around 200 rows
+ *    in a readable font size. Any additional rows calculated will not be viewable
+ *    on the screen. Any additional calculation is useless because no useful
+ *    information for the user will be viewable due to screen size.
+ *
+ * 4. Therefore, any exceesively large data set does a lot of useless work and
+ *    adversely affects browser performance.
+ *
+ * 5. Limit the total number of points in each dimension and also each bin.
+ *    Keep in mind the considerations in 2.
+ */
+const TOTAL_POINTS_PER_HOVER_DIMENSION = 100_000
 const INDEX_BIN_WIDTH = 30
 
 type IndexTable = {
+  maxCountPerXBin: number
+  maxCountPerYBin: number
   xBins: number[][]
   yBins: number[][]
   xyBins: number[][][] // :-]
@@ -118,6 +146,8 @@ const buildIndex = (
   const yBinCount = Math.ceil(height / INDEX_BIN_WIDTH) + 1
 
   const indexTable = {
+    maxCountPerXBin: Math.ceil(TOTAL_POINTS_PER_HOVER_DIMENSION / xBinCount),
+    maxCountPerYBin: Math.ceil(TOTAL_POINTS_PER_HOVER_DIMENSION / yBinCount),
     xBins: range(xBinCount).map(_ => []),
     yBins: range(yBinCount).map(_ => []),
     xyBins: range(xBinCount).map(_ => range(yBinCount).map(_ => [])),
@@ -346,6 +376,7 @@ interface NearestIndexByGroup {
 */
 const lookupIndex1D = (
   bins: number[][],
+  maxCountPerBin: number,
   mouseCoord: number,
   dataCoord: number,
   colData: NumericColumnData,
@@ -377,6 +408,7 @@ const lookupIndex1D = (
 
   collectNearestIndices(
     nearestIndexByGroup,
+    maxCountPerBin,
     leftRowIndices,
     dataCoord,
     colData,
@@ -385,6 +417,7 @@ const lookupIndex1D = (
 
   collectNearestIndices(
     nearestIndexByGroup,
+    maxCountPerBin,
     rightRowIndices,
     dataCoord,
     colData,
@@ -406,13 +439,14 @@ const lookupIndex1D = (
 
 const collectNearestIndices = (
   acc: NearestIndexByGroup,
+  maxCountPerBin: number,
   rowIndices: number[],
   dataCoord: number,
   colData: NumericColumnData,
   groupColData: NumericColumnData
 ): void => {
   let counter = 0
-  while (counter < HOVER_POINTS_COUNT_LIMIT && counter < rowIndices.length) {
+  while (counter < maxCountPerBin && counter < rowIndices.length) {
     const index = rowIndices[counter]
     const group = groupColData[index]
     const distance = Math.floor(Math.abs(dataCoord - colData[index]))


### PR DESCRIPTION
Closes #394 

Previously, the limit on hover points was too low. It also did not scale with the size of the graph. Here is the fix.

- ~~increase the limit~~
- ~~scale the limit to account for width and height of the graph~~
- revert the limit because as currently implemented, the limit is a loss of data
- use a visual limit that is based on width, height, and legend orientation