### PR TITLE
feat(publish): add confirmation to publish script, add more error messaging

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -5,13 +5,14 @@
   "module": "src/index.js",
   "license": "MIT",
   "scripts": {
-    "test": "jest --collectCoverage --maxWorkers=2",
-    "test:watch": "jest --collectCoverage --watch --verbose false",
     "build": "rm -rf dist && NODE_ENV=production webpack --config webpack.config.js",
-    "start": "webpack --config webpack.config.js --watch --progress",
     "lint": "eslint '{src,../stories/src}/**/*.{ts,tsx}'",
     "prettier": "prettier --config ../.prettierrc.json --check '{src,../stories/src}/**/*.{ts,tsx}'",
     "prettier:fix": "prettier --config ../.prettierrc.json --write '{src,../stories/src}/**/*.{ts,tsx}'",
+    "publish": "echo 'To publish giraffe, run ./publish $version'",
+    "start": "webpack --config webpack.config.js --watch --progress",
+    "test": "jest --collectCoverage --maxWorkers=2",
+    "test:watch": "jest --collectCoverage --watch --verbose false",
     "typecheck": "tsc --noEmit --pretty"
   },
   "keywords": [

--- a/giraffe/publish
+++ b/giraffe/publish
@@ -1,6 +1,32 @@
 #!/bin/bash
 
-set -e 
+set -e
+
+# Ensure there's a version number
+if [ $# -eq 0 ]; then
+  echo "Please specify a SemVer version to publish 'X.Y.Z(-PRERELEASE)(+BUILD)'"
+  exit 1
+fi
+
+VERSION_NUMBER=$1
+
+# regex taken from: https://github.com/fsaintjacques/semver-tool/blob/master/src/semver
+NAT='0|[1-9][0-9]*'
+ALPHANUM='[0-9]*[A-Za-z-][0-9A-Za-z-]*'
+IDENT="$NAT|$ALPHANUM"
+FIELD='[0-9A-Za-z-]+'
+
+SEMVER_REGEX="\
+^[vV]?\
+($NAT)\\.($NAT)\\.($NAT)\
+(\\-(${IDENT})(\\.(${IDENT}))*)?\
+(\\+${FIELD}(\\.${FIELD})*)?$"
+
+# Make sure our version is an actual semantic version
+if [[ ! $VERSION_NUMBER =~ $SEMVER_REGEX ]]; then
+  echo "The version needs to follow a SemVer naming scheme 'X.Y.Z(-PRERELEASE)(+BUILD)'"
+  exit 1
+fi
 
 # Make sure our working dir is the dir of the publish script
 cd $(dirname ${BASH_SOURCE[0]})
@@ -29,12 +55,22 @@ yarn -s install --frozen-lockfile
 echo "Building production build"
 yarn run build
 
-RELEASE_TYPE=${1:-patch}
+echo "Giraffe built successfully!"
 
-echo "Tagging and publishing $RELEASE_TYPE release"
-yarn -s publish --$RELEASE_TYPE --access=public
+# Lifted from https://stackoverflow.com/a/3232082/92446
+read -r -p "Are you sure you want to publish the build to npm? [y/N] " response
+case "$response" in
+    [yY][eE][sS]|[yY])
+        echo "Tagging and publishing $VERSION_NUMBER release"
+        yarn -s publish --$VERSION_NUMBER --access=public
 
-echo "Pushing git commit and tag"
-git push --follow-tags
+        echo "Pushing git commit and tag"
+        git push --follow-tags
 
-echo "Publish successful!"
+        echo "Publish successful!"
+        ;;
+    *)
+        echo "Understandable, have a great day. Exiting without publishing."
+        exit 1
+        ;;
+esac

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "lint": "eslint '{giraffe,stories}/src/**/*.{ts,tsx}'",
     "prettier": "prettier --config .prettierrc.json --check '{giraffe,stories}/**/*.{ts,tsx}'",
-    "prettier:fix": "prettier --config .prettierrc.json --write '{giraffe,stories}/**/*.{ts,tsx}'"
+    "prettier:fix": "prettier --config .prettierrc.json --write '{giraffe,stories}/**/*.{ts,tsx}'",
+    "publish": "echo 'To publish giraffe, run ./giraffe/publish $version'"
   }
 }


### PR DESCRIPTION
Closes #395

#### Added yarn scripts with messages:

```bash
~/Development/giraffe>yarn run publish
yarn run v1.22.4
$ echo 'To publish giraffe, run ./giraffe/publish $version'
To publish giraffe, run ./giraffe/publish $version
✨  Done in 0.06s.
```

```bash
~/Development/giraffe/giraffe>yarn run publish
yarn run v1.22.4
$ echo 'To publish giraffe, run ./publish $version'
To publish giraffe, run ./publish $version
✨  Done in 0.06s.
```

#### Made version number required:
```bash
~/Development/giraffe/giraffe>./publish
Please specify a SemVer version to publish 'X.Y.Z(-PRERELEASE)(+BUILD)'
```

#### Added validation to semantic version
```bash
~/Development/giraffe/giraffe>./publish yeah-buddy
The version needs to follow a SemVer naming scheme 'X.Y.Z(-PRERELEASE)(+BUILD)'

~/Development/giraffe/giraffe>./publish 1.23
The version needs to follow a SemVer naming scheme 'X.Y.Z(-PRERELEASE)(+BUILD)'

~/Development/giraffe/giraffe>./publish 1.2.x
The version needs to follow a SemVer naming scheme 'X.Y.Z(-PRERELEASE)(+BUILD)'
```

### Added confirmation before publishing
```bash
~/Development/giraffe/giraffe>./publish 1.0.3
Fetching git remotes
Installing dependencies
Building production build
Giraffe built successfully!
Are you sure you want to publish the build to npm? [y/N] n
Understandable, have a great day. Exiting without publishing.

~/Development/giraffe/giraffe>./publish 1.0.3
Fetching git remotes
Installing dependencies
Building production build
Giraffe built successfully!
Are you sure you want to publish the build to npm? [y/N] y
Tagging and publishing 1.0.3 release
Pushing git commit and tag
Publish successful!
```