### PR TITLE
feat: implement Annotation Tooltip

### DIFF
--- a/giraffe/src/components/AnnotationHoverLayer.tsx
+++ b/giraffe/src/components/AnnotationHoverLayer.tsx
@@ -8,7 +8,6 @@ interface AnnotationHoverLayerProps extends AnnotationLayerProps {
   boundingReference: DOMRect
   hoverRowIndices: number[]
   width: number
-  height: number
 }
 
 export const AnnotationHoverLayer: FunctionComponent<AnnotationHoverLayerProps> = props => {
@@ -18,23 +17,19 @@ export const AnnotationHoverLayer: FunctionComponent<AnnotationHoverLayerProps> 
     hoverRowIndices,
     boundingReference,
     width,
-    height,
   } = props
 
-  const annotationTooltipData = annotationPositions.filter((_, i) =>
-    hoverRowIndices.includes(i)
-  )
+  const hoveredAnnotations = (_, i: number) => hoverRowIndices.includes(i)
 
   return (
     <>
-      {annotationTooltipData.map(annotationData => (
+      {annotationPositions.filter(hoveredAnnotations).map(annotationData => (
         <AnnotationTooltip
           key={`annotation-tooltip-${annotationData.dimension}-${annotationData.startValue}-${annotationData.stopValue}`}
           config={plotConfig}
           data={annotationData}
           boundingReference={boundingReference}
           width={width}
-          height={height}
         />
       ))}
     </>

--- a/giraffe/src/components/AnnotationHoverLayer.tsx
+++ b/giraffe/src/components/AnnotationHoverLayer.tsx
@@ -1,0 +1,42 @@
+import React, {FunctionComponent} from 'react'
+import {AnnotationMark} from '../types'
+import {AnnotationLayerProps} from './AnnotationLayer'
+import {AnnotationTooltip} from './AnnotationTooltip'
+
+interface AnnotationHoverLayerProps extends AnnotationLayerProps {
+  annotationPositions: AnnotationMark[]
+  boundingReference: DOMRect
+  hoverRowIndices: number[]
+  width: number
+  height: number
+}
+
+export const AnnotationHoverLayer: FunctionComponent<AnnotationHoverLayerProps> = props => {
+  const {
+    annotationPositions,
+    plotConfig,
+    hoverRowIndices,
+    boundingReference,
+    width,
+    height,
+  } = props
+
+  const annotationTooltipData = annotationPositions.filter((_, i) =>
+    hoverRowIndices.includes(i)
+  )
+
+  return (
+    <>
+      {annotationTooltipData.map(annotationData => (
+        <AnnotationTooltip
+          key={`annotation-tooltip-${annotationData.dimension}-${annotationData.startValue}-${annotationData.stopValue}`}
+          config={plotConfig}
+          data={annotationData}
+          boundingReference={boundingReference}
+          width={width}
+          height={height}
+        />
+      ))}
+    </>
+  )
+}

--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -63,7 +63,6 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
         boundingReference={boundingRect}
         hoverRowIndices={hoverRowIndices}
         width={width}
-        height={height}
       />
       {annotationsPositions.map(annotationData =>
         annotationData.dimension === 'y' ? (

--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -1,44 +1,88 @@
-import React, {FunctionComponent, useMemo} from 'react'
-import {AnnotationLayerConfig, AnnotationLayerSpec, LayerProps} from '../types'
-import {getAnnotationsPositions} from '../utils/annotationData'
+import React, {CSSProperties, FunctionComponent, useMemo, useRef} from 'react'
+import {
+  AnnotationLayerConfig,
+  AnnotationLayerSpec,
+  LayerProps,
+  LineHoverDimension,
+} from '../types'
+import {
+  getAnnotationHoverIndices,
+  getAnnotationsPositions,
+} from '../utils/annotationData'
+import {ANNOTATION_DEFAULT_HOVER_MARGIN} from '../constants/index'
+import {AnnotationHoverLayer} from './AnnotationHoverLayer'
 
-interface AnnotationLayerProps extends LayerProps {
+export interface AnnotationLayerProps extends LayerProps {
   spec: AnnotationLayerSpec
   config: AnnotationLayerConfig
 }
 
 const ANNOTATION_OVERLAY_DEFAULT_STYLE = {
-  width: '100%',
-  height: '100%',
-}
+  position: 'absolute',
+} as CSSProperties
 
 export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props => {
-  const {height, width, spec, xScale, yScale} = props
+  const {config, spec, width, height, hoverX, hoverY, xScale, yScale} = props
   const annotationsPositions = useMemo(
     () => getAnnotationsPositions(spec.annotationData, xScale, yScale),
     [spec.annotationData, xScale, yScale]
   )
+  const svgRef = useRef<SVGSVGElement>(null)
+
+  let hoverDimension = 'xy' as LineHoverDimension
+  if (config.hoverDimension === 'x' || config.hoverDimension === 'y') {
+    hoverDimension = config.hoverDimension
+  }
+
+  const hoverMargin = config.hoverMargin
+    ? config.hoverMargin
+    : ANNOTATION_DEFAULT_HOVER_MARGIN
+
+  const hoverRowIndices = getAnnotationHoverIndices(
+    hoverDimension,
+    hoverMargin,
+    annotationsPositions,
+    hoverX,
+    hoverY
+  )
+
+  let boundingRect: DOMRect
+  if (svgRef.current) {
+    boundingRect = svgRef.current.getBoundingClientRect()
+  }
 
   return (
-    <svg style={{...ANNOTATION_OVERLAY_DEFAULT_STYLE}}>
-      {annotationsPositions.map((annotation, i) =>
-        annotation.direction === 'y' ? (
+    <svg
+      className="giraffe-layer giraffe-layer-annotation"
+      ref={svgRef}
+      style={{...ANNOTATION_OVERLAY_DEFAULT_STYLE, width, height}}
+    >
+      <AnnotationHoverLayer
+        {...props}
+        annotationPositions={annotationsPositions}
+        boundingReference={boundingRect}
+        hoverRowIndices={hoverRowIndices}
+        width={width}
+        height={height}
+      />
+      {annotationsPositions.map(annotationData =>
+        annotationData.dimension === 'y' ? (
           <line
-            key={i}
+            key={`line-y-${annotationData.dimension}-${annotationData.startValue}-${annotationData.stopValue}`}
             x1="0"
             x2={width}
-            y1={annotation.startValue}
-            y2={annotation.startValue}
-            stroke={annotation.color}
+            y1={annotationData.startValue}
+            y2={annotationData.startValue}
+            stroke={annotationData.color}
           />
         ) : (
           <line
-            key={i}
-            x1={annotation.startValue}
-            x2={annotation.startValue}
+            key={`line-x-${annotationData.dimension}-${annotationData.startValue}-${annotationData.stopValue}`}
+            x1={annotationData.startValue}
+            x2={annotationData.startValue}
             y1="0"
             y2={height}
-            stroke={annotation.color}
+            stroke={annotationData.color}
           />
         )
       )}

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import {FunctionComponent} from 'react'
+import {createPortal} from 'react-dom'
+
+import {Config, AnnotationMark, TooltipPosition} from '../types'
+import {ANNOTATION_TOOLTIP_CONTAINER_NAME} from '../constants'
+import {useTooltipElement} from '../utils/useTooltipElement'
+
+interface Props {
+  config: Config
+  data: AnnotationMark
+  boundingReference: DOMRect
+  width: number
+  height: number
+}
+
+export const AnnotationTooltip: FunctionComponent<Props> = props => {
+  const {config, data, boundingReference, width} = props
+  const {
+    legendFont: font,
+    legendFontColor: fontColor,
+    legendBackgroundColor: backgroundColor,
+    legendBorder: border,
+  } = config
+  const {dimension, startValue} = data || {}
+
+  const position = {
+    x: dimension === 'x' ? startValue : width,
+    y: dimension === 'y' ? startValue : 0,
+  } as TooltipPosition
+  const annotationTooltipElement = useTooltipElement(
+    ANNOTATION_TOOLTIP_CONTAINER_NAME,
+    {
+      xOffset: boundingReference ? boundingReference.x : position.x,
+      yOffset: boundingReference ? boundingReference.y : position.y,
+      position,
+      dimension,
+    }
+  )
+  return createPortal(
+    <div
+      className="giraffe-annotation-tooltip"
+      data-testid="giraffe-anntation-tooltip"
+      style={{
+        border,
+        borderColor: data.color,
+        font,
+        backgroundColor,
+        color: fontColor,
+        borderRadius: '3px',
+        padding: '10px',
+      }}
+    >
+      <div>{data.title}</div>
+      <div>{data.description}</div>
+    </div>,
+    annotationTooltipElement
+  )
+}

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -7,20 +7,19 @@ import {ANNOTATION_TOOLTIP_CONTAINER_NAME} from '../constants'
 import {useTooltipElement} from '../utils/useTooltipElement'
 
 interface Props {
+  boundingReference: DOMRect
   config: Config
   data: AnnotationMark
-  boundingReference: DOMRect
   width: number
-  height: number
 }
 
 export const AnnotationTooltip: FunctionComponent<Props> = props => {
-  const {config, data, boundingReference, width} = props
+  const {boundingReference, config, data, width} = props
   const {
-    legendFont: font,
-    legendFontColor: fontColor,
     legendBackgroundColor: backgroundColor,
     legendBorder: border,
+    legendFont: font,
+    legendFontColor: fontColor,
   } = config
   const {dimension, startValue} = data || {}
 

--- a/giraffe/src/components/Tooltip.tsx
+++ b/giraffe/src/components/Tooltip.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
-  const tooltipElement = useTooltipElement()
+  const tooltipElement = useTooltipElement('giraffe-tooltip-container')
 
   const {
     width,

--- a/giraffe/src/constants/index.ts
+++ b/giraffe/src/constants/index.ts
@@ -132,3 +132,8 @@ export const TOOLTIP_MAXIMUM_OPACITY = 1.0
 export const CLOCKFACE_Z_INDEX = 9599
 
 export const TICK_COUNT_LIMIT = 1000
+
+export const ANNOTATION_DEFAULT_HOVER_MARGIN = 20
+
+export const ANNOTATION_TOOLTIP_CONTAINER_NAME =
+  'giraffe-annotation-tooltip-container'

--- a/giraffe/src/transforms/annotation.test.ts
+++ b/giraffe/src/transforms/annotation.test.ts
@@ -50,7 +50,7 @@ describe('annotation transform', () => {
         color: 'green',
         startValue: 1606862528103,
         stopValue: 1606862528103,
-        direction: 'x',
+        dimension: 'x',
       },
       {
         title: 'annotation 1',
@@ -58,7 +58,7 @@ describe('annotation transform', () => {
         color: 'green',
         startValue: 1606862628103,
         stopValue: 1606862628103,
-        direction: 'x',
+        dimension: 'x',
       },
       {
         title: 'annotation 2',
@@ -66,7 +66,7 @@ describe('annotation transform', () => {
         color: 'green',
         startValue: 1606862728103,
         stopValue: 1606862728103,
-        direction: 'x',
+        dimension: 'x',
       },
       {
         title: 'annotation 3',
@@ -74,7 +74,7 @@ describe('annotation transform', () => {
         color: 'green',
         startValue: 1706862728103,
         stopValue: 1706862728103,
-        direction: 'x',
+        dimension: 'x',
       },
       {
         title: 'annotation 4',
@@ -82,7 +82,7 @@ describe('annotation transform', () => {
         color: 'green',
         startValue: 0,
         stopValue: 0,
-        direction: 'x',
+        dimension: 'x',
       },
     ] as AnnotationMark[]
     const annotations = annotationTransform(

--- a/giraffe/src/transforms/annotation.test.ts
+++ b/giraffe/src/transforms/annotation.test.ts
@@ -102,4 +102,76 @@ describe('annotation transform', () => {
       )
     )
   })
+
+  it('removes duplicate annotations in the same dimension', () => {
+    const inputAnnotations = [
+      {
+        title: 'Annotation!',
+        description: 'Hi, i may be an imposter',
+        color: 'green',
+        startValue: 1606862528103,
+        stopValue: 1606862528103,
+        dimension: 'x',
+      },
+      {
+        title: 'Annotation!',
+        description: 'Hi, i may be an imposter',
+        color: 'green',
+        startValue: 1606862528103,
+        stopValue: 1606862528103,
+        dimension: 'x',
+      },
+      {
+        title: 'Annotation!',
+        description: 'Hi, i may be an imposter',
+        color: 'green',
+        startValue: 5,
+        stopValue: 5,
+        dimension: 'y',
+      },
+      {
+        title: 'Annotation!',
+        description: 'Hi, i may be an imposter',
+        color: 'green',
+        startValue: 1606862628103,
+        stopValue: 1606862628103,
+        dimension: 'x',
+      },
+      {
+        title: 'Annotation!',
+        description: 'Hi, i may be an imposter',
+        color: 'green',
+        startValue: 1606862728103,
+        stopValue: 1606862728103,
+        dimension: 'x',
+      },
+      {
+        title: 'Annotation!',
+        description: 'Hi, i may be an imposter',
+        color: 'green',
+        startValue: 5.1,
+        stopValue: 5.1,
+        dimension: 'y',
+      },
+      {
+        title: 'Annotation!',
+        description: 'Hi, i may be an imposter',
+        color: 'green',
+        startValue: 5.1,
+        stopValue: 5.1,
+        dimension: 'y',
+      },
+    ] as AnnotationMark[]
+    const annotations = annotationTransform(
+      table,
+      inputAnnotations,
+      TIME,
+      VALUE,
+      ['cpu']
+    ).annotationData
+
+    expect(Array.isArray(annotations)).toEqual(true)
+    expect(inputAnnotations.length > annotations.length).toEqual(true)
+    expect(annotations.length).toEqual(5)
+  })
 })

--- a/giraffe/src/transforms/annotation.ts
+++ b/giraffe/src/transforms/annotation.ts
@@ -37,25 +37,32 @@ export const annotationTransform = (
     }
   }
 
-  const annotationData: AnnotationMark[] = []
-
+  // A hash of all input annotations is needed to:
+  // - keep only the first occurence of an annotation with the same
+  //   dimension, startValue, stopValue
+  // - ensure 'y' dimension annotations are within yDomain
+  // - ensure 'x' dimension annotations are within xDomain
+  const annotationMap = {}
   if (Array.isArray(inputAnnotations)) {
     for (let i = 0; i < inputAnnotations.length; i += 1) {
-      // Keep only the annotations within their respective domains
-      // 'y' direction annotations should be within yDomain
-      // 'x' direction annotations should be within xDomain
       if (
-        (inputAnnotations[i].direction === 'y' &&
+        !annotationMap[
+          `${inputAnnotations[i].dimension}-${inputAnnotations[i].startValue}-${inputAnnotations[i].stopValue}`
+        ] &&
+        ((inputAnnotations[i].dimension === 'y' &&
           yMin <= inputAnnotations[i].startValue &&
           inputAnnotations[i].stopValue <= yMax) ||
-        (inputAnnotations[i].direction === 'x' &&
-          xMin <= inputAnnotations[i].startValue &&
-          inputAnnotations[i].stopValue <= xMax)
+          (inputAnnotations[i].dimension === 'x' &&
+            xMin <= inputAnnotations[i].startValue &&
+            inputAnnotations[i].stopValue <= xMax))
       ) {
-        annotationData.push(inputAnnotations[i])
+        annotationMap[
+          `${inputAnnotations[i].dimension}-${inputAnnotations[i].startValue}-${inputAnnotations[i].stopValue}`
+        ] = inputAnnotations[i]
       }
     }
   }
+  const annotationData: AnnotationMark[] = Object.values(annotationMap)
 
   return {
     type: 'annotation',

--- a/giraffe/src/transforms/annotation.ts
+++ b/giraffe/src/transforms/annotation.ts
@@ -45,10 +45,9 @@ export const annotationTransform = (
   const annotationMap = {}
   if (Array.isArray(inputAnnotations)) {
     for (let i = 0; i < inputAnnotations.length; i += 1) {
+      const uniqueKey = `${inputAnnotations[i].dimension}-${inputAnnotations[i].startValue}-${inputAnnotations[i].stopValue}`
       if (
-        !annotationMap[
-          `${inputAnnotations[i].dimension}-${inputAnnotations[i].startValue}-${inputAnnotations[i].stopValue}`
-        ] &&
+        !annotationMap[uniqueKey] &&
         ((inputAnnotations[i].dimension === 'y' &&
           yMin <= inputAnnotations[i].startValue &&
           inputAnnotations[i].stopValue <= yMax) ||
@@ -56,9 +55,7 @@ export const annotationTransform = (
             xMin <= inputAnnotations[i].startValue &&
             inputAnnotations[i].stopValue <= xMax))
       ) {
-        annotationMap[
-          `${inputAnnotations[i].dimension}-${inputAnnotations[i].startValue}-${inputAnnotations[i].stopValue}`
-        ] = inputAnnotations[i]
+        annotationMap[uniqueKey] = inputAnnotations[i]
       }
     }
   }

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -195,7 +195,9 @@ export interface AnnotationLayerConfig {
   x: string
   y: string
   annotations: AnnotationMark[]
-  fill?: string[]
+  fill: string[]
+  hoverDimension?: LineHoverDimension | 'auto'
+  hoverMargin?: number
   svgAttributes?: SVGAttributes
   svgStyle?: CSS.Properties
 }
@@ -669,6 +671,25 @@ export interface TooltipColumn {
 
 export type TooltipData = TooltipColumn[]
 
+export interface TooltipPosition {
+  x: number
+  y: number
+}
+
+export interface AnnotationTooltipOptions {
+  dimension: AnnotationDimension
+  position: TooltipPosition
+  xOffset: number
+  yOffset: number
+}
+
+export interface AnnotationTooltipData {
+  title: string
+  description: string
+  fontColor: string
+  position: TooltipPosition
+}
+
 export type LineInterpolation =
   | 'linear'
   | 'monotoneX'
@@ -786,7 +807,7 @@ export interface StandardFunctionProps {
   className?: string
 }
 
-export type AnnotationDirection = 'x' | 'y'
+export type AnnotationDimension = 'x' | 'y'
 
 export interface AnnotationMark {
   title: string
@@ -794,5 +815,5 @@ export interface AnnotationMark {
   color: string
   startValue: number
   stopValue: number
-  direction?: AnnotationDirection
+  dimension: AnnotationDimension
 }

--- a/giraffe/src/utils/annotationData.ts
+++ b/giraffe/src/utils/annotationData.ts
@@ -1,9 +1,9 @@
-import {AnnotationMark} from '../types'
+import {AnnotationMark, LineHoverDimension, Scale} from '../types'
 
 export const getAnnotationsPositions = (
   annotationData: AnnotationMark[],
-  xScale: Function,
-  yScale: Function
+  xScale: Scale,
+  yScale: Scale
 ): AnnotationMark[] => {
   const annotationMarks: AnnotationMark[] = []
 
@@ -11,14 +11,71 @@ export const getAnnotationsPositions = (
     annotationMarks.push({
       ...annotation,
       startValue:
-        annotation.direction === 'y'
+        annotation.dimension === 'y'
           ? yScale(annotation.startValue)
           : xScale(annotation.startValue),
       stopValue:
-        annotation.direction === 'y'
+        annotation.dimension === 'y'
           ? yScale(annotation.stopValue)
           : xScale(annotation.stopValue),
     })
   })
   return annotationMarks
+}
+
+const isWithinHoverableArea = (
+  startValue: number,
+  stopValue: number,
+  margin: number,
+  hoverPosition: number
+): boolean => {
+  return (
+    startValue - margin <= hoverPosition && stopValue + margin >= hoverPosition
+  )
+}
+
+/***********************************************************************************
+ * ANNOTATIONS HOVERING
+ *
+ * hover dimension 'xy' means find annotations only near the mouse position
+ * hover dimension 'x' means find annotations along the x-axis at mouse position
+ * hover dimension 'y' means find annotations along the y-axis at mouse position
+ * hover dimension 'auto' means 'xy' see above
+ *
+ * Check to see if mouse position is within annotation's hoverable area only when
+ *   hover dimension is 'xy' or hover dimension is same as annotation dimension
+ *
+ * Cross dimensions means the annotation is always hovered, occurs when:
+ *   hover dimension is 'x' && annotation dimension is 'y'
+ *   hover dimension is 'y' && annotation dimension is 'x'
+ *
+ */
+export const getAnnotationHoverIndices = (
+  hoverDimension: LineHoverDimension,
+  hoverMargin: number,
+  annotationData: AnnotationMark[],
+  hoverX: number,
+  hoverY: number
+): number[] => {
+  return Array.isArray(annotationData)
+    ? annotationData.reduce((result, annotation, i) => {
+        if (hoverX === null || hoverY === null) {
+          return result
+        }
+        const {dimension, startValue, stopValue} = annotation
+        if (
+          (hoverDimension !== 'xy' && hoverDimension !== dimension) ||
+          ((hoverDimension === 'xy' || hoverDimension === dimension) &&
+            isWithinHoverableArea(
+              startValue,
+              stopValue,
+              hoverMargin,
+              dimension === 'x' ? hoverX : hoverY
+            ))
+        ) {
+          result.push(i)
+        }
+        return result
+      }, [])
+    : []
 }

--- a/giraffe/src/utils/useTooltipElement.ts
+++ b/giraffe/src/utils/useTooltipElement.ts
@@ -1,6 +1,8 @@
 import {useRef, useEffect} from 'react'
 
-import {useTooltipStyle} from '../utils/useTooltipStyle'
+import {AnnotationTooltipOptions} from '../types'
+import {ANNOTATION_TOOLTIP_CONTAINER_NAME} from '../constants'
+import {useTooltipStyle, useAnnotationStyle} from '../utils/useTooltipStyle'
 
 /*
   Returns a DOM node that a tooltip can be rendered inside.
@@ -12,19 +14,26 @@ import {useTooltipStyle} from '../utils/useTooltipStyle'
   The returned node is intended to be used with `React.createPortal`. It is
   appended to the end of the document to circumvent z-index issues.
 */
-export const useTooltipElement = () => {
+export const useTooltipElement = (
+  className: string,
+  options?: AnnotationTooltipOptions
+) => {
   const ref = useRef<HTMLDivElement>(null)
 
   if (ref.current === null) {
     ref.current = document.createElement('div')
-    ref.current.classList.add('giraffe-tooltip-container')
+    ref.current.classList.add(className)
 
     document.body.appendChild(ref.current)
   }
 
   useEffect(() => () => document.body.removeChild(ref.current), [])
 
-  useTooltipStyle(ref.current)
+  if (className == ANNOTATION_TOOLTIP_CONTAINER_NAME) {
+    useAnnotationStyle(ref.current, options)
+  } else {
+    useTooltipStyle(ref.current)
+  }
 
   return ref.current
 }

--- a/giraffe/src/utils/useTooltipStyle.ts
+++ b/giraffe/src/utils/useTooltipStyle.ts
@@ -84,7 +84,6 @@ export const useAnnotationStyle = (
   //                 |
   //                 |
   //
-  //
   // Position the tooltip to the right of the annotation for horizontal annotations, like this:
   //
   //             ┌─────────────┐
@@ -98,7 +97,7 @@ export const useAnnotationStyle = (
   // - If the tooltip does not fit above a vertical annotation due to screen size,
   //   shift it to overlay the top part of the annotation
   //
-  // - If the tooltip does not fith to the right of a horizontal annotation due to screen size,
+  // - If the tooltip does not fit to the right of a horizontal annotation due to screen size,
   //   shift it to overlay the right part of the annotation
   //
   useLayoutStyle(

--- a/giraffe/src/utils/useTooltipStyle.ts
+++ b/giraffe/src/utils/useTooltipStyle.ts
@@ -2,6 +2,7 @@ import {useLayoutStyle} from './useLayoutStyle'
 import {useRefMousePos} from './useMousePos'
 import {LEAFLET_Z_INDEX} from '../components/Geo'
 import {CLOCKFACE_Z_INDEX} from '../constants'
+import {AnnotationTooltipOptions} from '../types'
 
 const MARGIN_X = 30
 
@@ -24,39 +25,121 @@ export const useTooltipStyle = (el: HTMLDivElement) => {
   // - If the tooltip overflows the top or bottom of the screen (with a bit of
   //   margin), shift it just enough so that it is fully back inside the screen
   //
-  useLayoutStyle(el, ({offsetWidth, offsetHeight}) => {
-    if (x === null || y === null) {
+  useLayoutStyle(
+    el,
+    ({offsetWidth: tooltipWidth, offsetHeight: tooltipHeight}) => {
+      if (x === null || y === null) {
+        return {
+          display: 'none',
+        }
+      }
+
+      let dx = MARGIN_X
+      let dy = 0 - tooltipHeight / 2
+
+      if (x + dx + tooltipWidth > window.innerWidth) {
+        dx = 0 - MARGIN_X - tooltipWidth
+      }
+
+      if (y + dy + tooltipHeight > window.innerHeight) {
+        dy -= y + dy + tooltipHeight - window.innerHeight
+      }
+
+      if (y + dy < 0) {
+        dy += 0 - (y + dy)
+      }
+
+      const clampedX = Math.max(x + dx, 8)
+      const clampedY = Math.max(y + dy, 8)
+
+      /* Geo widget maps are rendered with z-index: 399, we have to set it above
+       that so that tooltips are not rendered/are hidden below the map, */
       return {
-        display: 'none',
+        display: 'inline',
+        position: 'fixed',
+        left: `${clampedX}px`,
+        top: `${clampedY}px`,
+        zIndex: CLOCKFACE_Z_INDEX + LEAFLET_Z_INDEX + 1,
       }
     }
+  )
+}
 
-    let dx = MARGIN_X
-    let dy = 0 - offsetHeight / 2
+export const useAnnotationStyle = (
+  el: HTMLDivElement,
+  options: AnnotationTooltipOptions
+) => {
+  const {dimension, position, xOffset, yOffset} = options || {}
+  const {x, y} = position || {x: null, y: null}
 
-    if (x + dx + offsetWidth > window.innerWidth) {
-      dx = 0 - MARGIN_X - offsetWidth
-    }
+  // Position the tooltip above the annotation for vertical annotations, like this:
+  //
+  //          ┌─────────────┐
+  //          │             │
+  //          │   tooltip   │
+  //          │             │
+  //          └─────────────┘
+  //                 |
+  //                 |
+  //                 |
+  //                 |
+  //
+  //
+  // Position the tooltip to the right of the annotation for horizontal annotations, like this:
+  //
+  //             ┌─────────────┐
+  //             │             │
+  //    ---------│   tooltip   │
+  //             │             │
+  //             └─────────────┘
+  //
+  // The positioning is subject to the following restrictions:
+  //
+  // - If the tooltip does not fit above a vertical annotation due to screen size,
+  //   shift it to overlay the top part of the annotation
+  //
+  // - If the tooltip does not fith to the right of a horizontal annotation due to screen size,
+  //   shift it to overlay the right part of the annotation
+  //
+  useLayoutStyle(
+    el,
+    ({offsetWidth: tooltipWidth, offsetHeight: tooltipHeight}) => {
+      if (x === null || y === null) {
+        return {
+          display: 'none',
+        }
+      }
 
-    if (y + dy + offsetHeight > window.innerHeight) {
-      dy -= y + dy + offsetHeight - window.innerHeight
-    }
+      let dx = xOffset - tooltipWidth / 2
+      if (dx + x + tooltipWidth > window.innerWidth) {
+        dx = 0 - tooltipWidth / 2 + window.innerWidth - (x + xOffset)
+      }
+      let dy = Math.max(yOffset - tooltipHeight, 0)
 
-    if (y + dy < 0) {
-      dy += 0 - (y + dy)
-    }
+      if (dimension === 'y') {
+        dx = xOffset
+        if (dx + x + tooltipWidth > window.innerWidth) {
+          dx = 0 - tooltipWidth + window.innerWidth - (dx + x)
+        }
+        dy = yOffset - tooltipHeight / 2
+        if (dy + y + tooltipHeight > window.innerHeight) {
+          dy = 0 - tooltipHeight + window.innerHeight - (dy + y)
+        }
+      }
 
-    const clampedX = Math.max(x + dx, 8)
-    const clampedY = Math.max(y + dy, 8)
+      const clampedX = Math.max(dx + x, x)
+      const clampedY = dy + y
 
-    /* Geo widget maps are rendered with z-index: 399, we have to set it above
+      /* Geo widget maps are rendered with z-index: 399, we have to set it above
        that so that tooltips are not rendered/are hidden below the map, */
-    return {
-      display: 'inline',
-      position: 'fixed',
-      left: `${clampedX}px`,
-      top: `${clampedY}px`,
-      zIndex: CLOCKFACE_Z_INDEX + LEAFLET_Z_INDEX + 1,
+      return {
+        display: 'inline',
+        position: 'fixed',
+        backgroundColor: 'yellow',
+        left: `${clampedX}px`,
+        top: `${clampedY}px`,
+        zIndex: CLOCKFACE_Z_INDEX + LEAFLET_Z_INDEX + 1,
+      }
     }
-  })
+  )
 }

--- a/stories/src/annotation.stories.tsx
+++ b/stories/src/annotation.stories.tsx
@@ -217,7 +217,7 @@ storiesOf('Annotations', module)
         type: 'annotation',
         x,
         y,
-        annotations: annotationsSelections.map((valueString, i) => ({
+        annotations: annotationsSelections.map((valueString: string) => ({
           title: 'Hi!',
           description: `value: ${valueString}`,
           color: annotationColor,
@@ -342,16 +342,14 @@ storiesOf('Annotations', module)
         type: 'annotation',
         x,
         y,
-        annotations: annotationsInput
-          .split(',')
-          .map((valueString: string, i: number) => ({
-            title: 'Hi',
-            description: `value is ${valueString}`,
-            color: annotationColor,
-            dimension: annotationDimension,
-            startValue: Number(valueString),
-            stopValue: Number(valueString),
-          })),
+        annotations: annotationsInput.split(',').map((valueString: string) => ({
+          title: 'Hi',
+          description: `value is ${valueString}`,
+          color: annotationColor,
+          dimension: annotationDimension,
+          startValue: Number(valueString),
+          stopValue: Number(valueString),
+        })),
         fill,
         hoverDimension,
       },

--- a/stories/src/annotation.stories.tsx
+++ b/stories/src/annotation.stories.tsx
@@ -29,8 +29,8 @@ storiesOf('Annotations', module)
     const table = annotationsTable
     const includeLineLayer = boolean('Line Layer', false)
     const annotationColor = text('Annotation color string', 'green')
-    const annotationDirection = select(
-      'Annotation Direction',
+    const annotationDimension = select(
+      'Annotation Dimension',
       {
         x: 'x',
         y: 'y',
@@ -90,12 +90,13 @@ storiesOf('Annotations', module)
         y,
         annotations: matchAnnotationsToTable({
           color: annotationColor,
-          direction: annotationDirection,
+          dimension: annotationDimension,
           table,
           x,
           y,
         }),
         fill,
+        hoverDimension,
       },
     ] as LayerConfig[]
 
@@ -141,8 +142,8 @@ storiesOf('Annotations', module)
     const table = annotationsTable
     const includeLineLayer = boolean('Line Layer', true)
     const annotationColor = text('Annotation color string', 'green')
-    const annotationDirection = select(
-      'Annotation Direction',
+    const annotationDimension = select(
+      'Annotation Dimension',
       {
         x: 'x',
         y: 'y',
@@ -197,7 +198,7 @@ storiesOf('Annotations', module)
 
     const annotations = matchAnnotationsToTable({
       color: annotationColor,
-      direction: annotationDirection,
+      dimension: annotationDimension,
       table,
       x,
       y,
@@ -205,7 +206,10 @@ storiesOf('Annotations', module)
     const annotationsSelections = multiSelect(
       'annotations',
       annotations.map(annotation => String(annotation.startValue)).sort(),
-      annotations.map(annotation => String(annotation.startValue)).sort()
+      annotations
+        .filter((_, i) => (i % 4 === 0 ? true : false))
+        .map(annotation => String(annotation.startValue))
+        .sort()
     )
 
     const layers = [
@@ -214,14 +218,15 @@ storiesOf('Annotations', module)
         x,
         y,
         annotations: annotationsSelections.map((valueString, i) => ({
-          title: `annotation at index ${i}`,
-          description: `Hi, I am an annotation that starts at ${valueString} and ends at ${valueString}`,
+          title: 'Hi!',
+          description: `value: ${valueString}`,
           color: annotationColor,
-          direction: annotationDirection,
+          dimension: annotationDimension,
           startValue: Number(valueString),
           stopValue: Number(valueString),
         })),
         fill,
+        hoverDimension,
       },
     ] as LayerConfig[]
 
@@ -267,8 +272,8 @@ storiesOf('Annotations', module)
     const table = annotationsTable
     const includeLineLayer = boolean('Line Layer', true)
     const annotationColor = text('Annotation color string', 'green')
-    const annotationDirection = select(
-      'Annotation Direction',
+    const annotationDimension = select(
+      'Annotation Dimension',
       {
         x: 'x',
         y: 'y',
@@ -283,9 +288,9 @@ storiesOf('Annotations', module)
         ? String(table.getColumn(x, 'number')[0])
         : String(table.getColumn(y, 'number')[0])
     )
-    const currentTime = text('_time', String(Date.now()))
+    const currentTime = text('_time', String(Date.now() + 1000 * 60 * 6))
 
-    const columnKey = annotationDirection === 'y' ? y : x
+    const columnKey = annotationDimension === 'y' ? y : x
     const annotationsInput = columnKey === TIME ? currentTime : currentValue
 
     const tickFont = tickFontKnob()
@@ -340,14 +345,15 @@ storiesOf('Annotations', module)
         annotations: annotationsInput
           .split(',')
           .map((valueString: string, i: number) => ({
-            title: `annotation at index ${i}`,
-            description: `Hi, I am an annotation that starts at ${valueString} and ends at ${valueString}`,
+            title: 'Hi',
+            description: `value is ${valueString}`,
             color: annotationColor,
-            direction: annotationDirection,
+            dimension: annotationDimension,
             startValue: Number(valueString),
             stopValue: Number(valueString),
           })),
         fill,
+        hoverDimension,
       },
     ] as LayerConfig[]
 

--- a/stories/src/annotation.stories.tsx
+++ b/stories/src/annotation.stories.tsx
@@ -37,6 +37,7 @@ storiesOf('Annotations', module)
       },
       'x'
     )
+    const annotationHoverMargin = number('Annotation Hover Margin', 10)
     const tickFont = tickFontKnob()
     const valueAxisLabel = text('Value Axis Label', 'foo')
     const x = xKnob(table)
@@ -97,6 +98,7 @@ storiesOf('Annotations', module)
         }),
         fill,
         hoverDimension,
+        hoverMargin: annotationHoverMargin,
       },
     ] as LayerConfig[]
 
@@ -150,6 +152,7 @@ storiesOf('Annotations', module)
       },
       'x'
     )
+    const annotationHoverMargin = number('Annotation Hover Margin', 10)
     const tickFont = tickFontKnob()
     const valueAxisLabel = text('Value Axis Label', 'foo')
     const x = xKnob(table)
@@ -227,6 +230,7 @@ storiesOf('Annotations', module)
         })),
         fill,
         hoverDimension,
+        hoverMargin: annotationHoverMargin,
       },
     ] as LayerConfig[]
 
@@ -280,6 +284,7 @@ storiesOf('Annotations', module)
       },
       'x'
     )
+    const annotationHoverMargin = number('Annotation Hover Margin', 10)
     const x = xKnob(table)
     const y = yKnob(table)
     const currentValue = text(
@@ -352,6 +357,7 @@ storiesOf('Annotations', module)
         })),
         fill,
         hoverDimension,
+        hoverMargin: annotationHoverMargin,
       },
     ] as LayerConfig[]
 

--- a/stories/src/data/annotation.ts
+++ b/stories/src/data/annotation.ts
@@ -1,13 +1,13 @@
 import {
-  AnnotationDirection,
+  AnnotationDimension,
   AnnotationMark,
   Table,
 } from '../../../giraffe/src/types'
 import {newTable} from '../../../giraffe/src'
 
 const now = Date.now()
-const numberOfRecords = 10
-const recordsPerLine = 10
+const numberOfRecords = 20
+const recordsPerLine = 20
 const maxValue = 10
 
 const TIME_COL = []
@@ -32,7 +32,7 @@ export const annotationsTable = newTable(numberOfRecords)
 
 interface SampleAnnotationsCreatorOptions {
   color: string
-  direction: AnnotationDirection
+  dimension: AnnotationDimension
   table: Table
   x: string
   y: string
@@ -41,16 +41,16 @@ interface SampleAnnotationsCreatorOptions {
 export const matchAnnotationsToTable = (
   options: SampleAnnotationsCreatorOptions
 ): AnnotationMark[] => {
-  const {color, direction = 'x', table} = options
-  const values = table.getColumn(options[direction], 'number')
+  const {color, dimension = 'x', table} = options
+  const values = table.getColumn(options[dimension], 'number')
   const annotationMarks: AnnotationMark[] = []
 
   values.forEach((value: number, i: number) => {
     annotationMarks.push({
-      title: `annotation at index ${i}`,
-      description: `Hi, I am an annotation that starts at ${value} and ends at ${value}`,
+      title: `Hi!`,
+      description: `annotation at index ${i}`,
       color: typeof color === 'string' ? color : DEFAULT_COLOR,
-      direction,
+      dimension,
       startValue: value,
       stopValue: value,
     })


### PR DESCRIPTION
Closes #400 

Notable interface change:
AnnotationMark previously used **"direction"** as the property name to indicate vertical (direction: 'x') or horizontal (direction: 'y'). This property name will change to **"dimension"** which is less confusing, more accurate, and consistent with the rest of the code.

Annotation tooltip, initial implementation:
<img width="1680" alt="Screen Shot 2020-12-10 at 9 09 12 PM" src="https://user-images.githubusercontent.com/10736577/101865781-0f866d80-3b2c-11eb-80e9-c9b2f2017799.png">
