### PR TITLE
Add style loader for react leaflet

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -92,6 +92,7 @@
     "react-virtualized-auto-sizer": "^1.0.2",
     "s2-geometry": "^1.2.10",
     "sass-loader": "^10.0.3",
+    "style-loader": "^2.0.0",
     "ts-jest": "^24.0.0",
     "typescript": "3.8.3",
     "unraw": "2.0.0",

--- a/giraffe/webpack.config.js
+++ b/giraffe/webpack.config.js
@@ -49,7 +49,15 @@ module.exports = {
       },
       {
         test: /\.s?css$/i,
+        exclude: /leaflet\.css/,
         use: ['css-loader', 'sass-loader'],
+      },
+      {
+        test: /leaflet\.css/,
+        use: [
+          {loader: 'style-loader'},
+          'css-loader',
+        ],
       },
       {
         test: /\.(png|svg|jpg|gif)$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12845,6 +12845,14 @@ style-loader@^1.2.1:
     loader-utils "^2.0.0"
     schema-utils "^2.6.6"
 
+style-loader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-2.0.0.tgz#9669602fd4690740eaaec137799a03addbbc393c"
+  integrity sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 stylis-rule-sheet@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"


### PR DESCRIPTION
This is the minimal configuration needed to get webpack correctly bundling leaflet CSS. We'll optimize the size of our bundle in the near future