### PR TITLE
build: updating node-notifier

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,7 +1251,7 @@
     jest-runtime "^24.9.0"
     jest-util "^24.9.0"
     jest-worker "^24.6.0"
-    node-notifier "^5.4.2"
+    node-notifier "^8.0.1"
     slash "^2.0.0"
     source-map "^0.6.0"
     string-length "^2.0.0"


### PR DESCRIPTION
We are currently getting a warning from dependabot that this library has a security breach, so im updating it to the version with the newest fix