### PR TITLE
feat: polish appearance of annotations

### DIFF
--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -70,15 +70,15 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
             key={`line-y-${annotationData.dimension}-${annotationData.startValue}-${annotationData.stopValue}`}
             x1="0"
             x2={width}
-            y1={annotationData.startValue}
-            y2={annotationData.startValue}
+            y1={Math.round(annotationData.startValue)}
+            y2={Math.round(annotationData.startValue)}
             stroke={annotationData.color}
           />
         ) : (
           <line
             key={`line-x-${annotationData.dimension}-${annotationData.startValue}-${annotationData.stopValue}`}
-            x1={annotationData.startValue}
-            x2={annotationData.startValue}
+            x1={Math.round(annotationData.startValue)}
+            x2={Math.round(annotationData.startValue)}
             y1="0"
             y2={height}
             stroke={annotationData.color}

--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -74,8 +74,9 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
             length={width}
             startValue={annotationData.startValue}
             stopValue={annotationData.stopValue}
-            stroke={annotationData.color}
+            color={annotationData.color}
             strokeWidth={lineWidth}
+            pin={annotationData.pin}
           />
         ) : (
           <AnnotationLine
@@ -84,8 +85,9 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
             length={height}
             startValue={annotationData.startValue}
             stopValue={annotationData.stopValue}
-            stroke={annotationData.color}
+            color={annotationData.color}
             strokeWidth={lineWidth}
+            pin={annotationData.pin}
           />
         )
       )}

--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -11,6 +11,7 @@ import {
 } from '../utils/annotationData'
 import {ANNOTATION_DEFAULT_HOVER_MARGIN} from '../constants/index'
 import {AnnotationHoverLayer} from './AnnotationHoverLayer'
+import {AnnotationLine} from './AnnotationLine'
 
 export interface AnnotationLayerProps extends LayerProps {
   spec: AnnotationLayerSpec
@@ -23,6 +24,7 @@ const ANNOTATION_OVERLAY_DEFAULT_STYLE = {
 
 export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props => {
   const {config, spec, width, height, hoverX, hoverY, xScale, yScale} = props
+  const lineWidth = config.lineWidth || 2
   const annotationsPositions = useMemo(
     () => getAnnotationsPositions(spec.annotationData, xScale, yScale),
     [spec.annotationData, xScale, yScale]
@@ -66,22 +68,24 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
       />
       {annotationsPositions.map(annotationData =>
         annotationData.dimension === 'y' ? (
-          <line
+          <AnnotationLine
+            dimension={annotationData.dimension}
             key={`line-y-${annotationData.dimension}-${annotationData.startValue}-${annotationData.stopValue}`}
-            x1="0"
-            x2={width}
-            y1={Math.round(annotationData.startValue)}
-            y2={Math.round(annotationData.startValue)}
+            length={width}
+            startValue={annotationData.startValue}
+            stopValue={annotationData.stopValue}
             stroke={annotationData.color}
+            strokeWidth={lineWidth}
           />
         ) : (
-          <line
+          <AnnotationLine
+            dimension={annotationData.dimension}
             key={`line-x-${annotationData.dimension}-${annotationData.startValue}-${annotationData.stopValue}`}
-            x1={Math.round(annotationData.startValue)}
-            x2={Math.round(annotationData.startValue)}
-            y1="0"
-            y2={height}
+            length={height}
+            startValue={annotationData.startValue}
+            stopValue={annotationData.stopValue}
             stroke={annotationData.color}
+            strokeWidth={lineWidth}
           />
         )
       )}

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -1,0 +1,48 @@
+import React, {FunctionComponent} from 'react'
+import {AnnotationDimension, AnnotationPinType} from '../types'
+
+interface AnnotationLineProps {
+  dimension: AnnotationDimension
+  stroke: string
+  strokeWidth: number
+  startValue: number
+  stopValue: number
+  length: number
+  pin: AnnotationPinType
+}
+
+export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
+  const {dimension, stroke, strokeWidth, startValue, length} = props
+
+  // This prevents blurry sub-pixel rendering as well as clipped lines
+  // If the line is at the edge of the canvas the stroke will be half obscured
+  // because the stroke is centered on the line. Giving a minimum value
+  // prevents the line from being clipped
+  const trimmedStart = Math.max(1, Math.round(startValue))
+
+  if (dimension === 'y') {
+    return (
+      <line
+        x1="0"
+        x2={length}
+        y1={trimmedStart}
+        y2={trimmedStart}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+      />
+    )
+  }
+
+  return (
+    <line
+      x1={trimmedStart}
+      x2={trimmedStart}
+      y1="0"
+      y2={length}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+    />
+  )
+}
+
+export default AnnotationLine

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -1,9 +1,9 @@
-import React, {FunctionComponent} from 'react'
+import React, {FunctionComponent, createElement} from 'react'
 import {AnnotationDimension, AnnotationPinType} from '../types'
 
 interface AnnotationLineProps {
   dimension: AnnotationDimension
-  stroke: string
+  color: string
   strokeWidth: number
   startValue: number
   stopValue: number
@@ -11,37 +11,88 @@ interface AnnotationLineProps {
   pin: AnnotationPinType
 }
 
+// These could become configurable values
+const PIN_CIRCLE_RADIUS = 4
+const PIN_TRIANGLE_HEIGHT = 10
+const PIN_TRIANGLE_WIDTH = 6
+
 export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
-  const {dimension, stroke, strokeWidth, startValue, length} = props
+  const {dimension, color, strokeWidth, startValue, length, pin} = props
 
   // This prevents blurry sub-pixel rendering as well as clipped lines
   // If the line is at the edge of the canvas the stroke will be half obscured
   // because the stroke is centered on the line. Giving a minimum value
   // prevents the line from being clipped
-  const trimmedStart = Math.max(1, Math.round(startValue))
+  const clampedStart = Math.max(1, Math.round(startValue))
 
   if (dimension === 'y') {
     return (
-      <line
-        x1="0"
-        x2={length}
-        y1={trimmedStart}
-        y2={trimmedStart}
-        stroke={stroke}
-        strokeWidth={strokeWidth}
-      />
+      <>
+        {pin === 'circle' &&
+          createElement('circle', {
+            r: PIN_CIRCLE_RADIUS,
+            fill: color,
+            cx: length - PIN_CIRCLE_RADIUS,
+            cy: clampedStart,
+          })}
+        {pin === 'start' &&
+          createElement('polygon', {
+            points: `${length - PIN_TRIANGLE_HEIGHT},${clampedStart} ${length -
+              PIN_TRIANGLE_HEIGHT / 2},${clampedStart +
+              PIN_TRIANGLE_WIDTH} ${length},${clampedStart}`,
+            fill: color,
+          })}
+        {pin === 'stop' &&
+          createElement('polygon', {
+            points: `${length - PIN_TRIANGLE_HEIGHT},${clampedStart} ${length -
+              PIN_TRIANGLE_HEIGHT / 2},${clampedStart -
+              PIN_TRIANGLE_WIDTH} ${length},${clampedStart}`,
+            fill: color,
+          })}
+        <line
+          x1="0"
+          x2={length}
+          y1={clampedStart}
+          y2={clampedStart}
+          stroke={color}
+          strokeWidth={strokeWidth}
+        />
+      </>
     )
   }
 
   return (
-    <line
-      x1={trimmedStart}
-      x2={trimmedStart}
-      y1="0"
-      y2={length}
-      stroke={stroke}
-      strokeWidth={strokeWidth}
-    />
+    <>
+      {pin === 'circle' &&
+        createElement('circle', {
+          r: PIN_CIRCLE_RADIUS,
+          fill: color,
+          cx: clampedStart,
+          cy: PIN_CIRCLE_RADIUS,
+        })}
+      {pin === 'start' &&
+        createElement('polygon', {
+          points: `${clampedStart},0 ${clampedStart +
+            PIN_TRIANGLE_WIDTH},${PIN_TRIANGLE_HEIGHT /
+            2} ${clampedStart},${PIN_TRIANGLE_HEIGHT}`,
+          fill: color,
+        })}
+      {pin === 'stop' &&
+        createElement('polygon', {
+          points: `${clampedStart},0 ${clampedStart -
+            PIN_TRIANGLE_WIDTH},${PIN_TRIANGLE_HEIGHT /
+            2} ${clampedStart},${PIN_TRIANGLE_HEIGHT}`,
+          fill: color,
+        })}
+      <line
+        x1={clampedStart}
+        x2={clampedStart}
+        y1="0"
+        y2={length}
+        stroke={color}
+        strokeWidth={strokeWidth}
+      />
+    </>
   )
 }
 

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {CSSProperties} from 'react'
 import {FunctionComponent} from 'react'
 import {createPortal} from 'react-dom'
 
@@ -37,6 +37,50 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
       dimension,
     }
   )
+
+  let tooltipCaretStyle: CSSProperties = {
+    position: 'absolute',
+    borderWidth: '10px',
+    borderStyle: 'solid',
+    borderColor: 'transparent',
+    zIndex: 2,
+  }
+  let tooltipCaretFillStyle
+
+  if (dimension === 'x') {
+    tooltipCaretStyle = {
+      ...tooltipCaretStyle,
+      borderTopColor: data.color,
+      left: '50%',
+      top: '100%',
+      transform: 'translateX(-50%)',
+    }
+
+    tooltipCaretFillStyle = {
+      ...tooltipCaretStyle,
+      borderTopColor: backgroundColor,
+      top: 'calc(100% - 4px)',
+      zIndex: 3,
+    }
+  }
+
+  if (dimension === 'y') {
+    tooltipCaretStyle = {
+      ...tooltipCaretStyle,
+      borderRightColor: data.color,
+      top: '50%',
+      right: '100%',
+      transform: 'translateY(-50%)',
+    }
+
+    tooltipCaretFillStyle = {
+      ...tooltipCaretStyle,
+      borderRightColor: backgroundColor,
+      right: 'calc(100% - 4px)',
+      zIndex: 3,
+    }
+  }
+
   return createPortal(
     <div
       className="giraffe-annotation-tooltip"
@@ -52,6 +96,8 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
         padding: '10px',
       }}
     >
+      <div style={tooltipCaretStyle} />
+      <div style={tooltipCaretFillStyle} />
       <div>{data.title}</div>
       <div>{data.description}</div>
     </div>,

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -27,6 +27,7 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
     x: dimension === 'x' ? startValue : width,
     y: dimension === 'y' ? startValue : 0,
   } as TooltipPosition
+
   const annotationTooltipElement = useTooltipElement(
     ANNOTATION_TOOLTIP_CONTAINER_NAME,
     {
@@ -46,6 +47,7 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
         font,
         backgroundColor,
         color: fontColor,
+        boxShadow: `0 0 4px 0px ${data.color}`,
         borderRadius: '3px',
         padding: '10px',
       }}

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -28,11 +28,19 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
     y: dimension === 'y' ? startValue : 0,
   } as TooltipPosition
 
+  const clampedXOffset = Math.round(
+    boundingReference ? boundingReference.x : position.x
+  )
+
+  const clampedYOffset = Math.round(
+    boundingReference ? boundingReference.y : position.y
+  )
+
   const annotationTooltipElement = useTooltipElement(
     ANNOTATION_TOOLTIP_CONTAINER_NAME,
     {
-      xOffset: Math.round(boundingReference ? boundingReference.x : position.x),
-      yOffset: Math.round(boundingReference ? boundingReference.y : position.y),
+      xOffset: clampedXOffset,
+      yOffset: clampedYOffset,
       position,
       dimension,
     }

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -30,8 +30,8 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
   const annotationTooltipElement = useTooltipElement(
     ANNOTATION_TOOLTIP_CONTAINER_NAME,
     {
-      xOffset: boundingReference ? boundingReference.x : position.x,
-      yOffset: boundingReference ? boundingReference.y : position.y,
+      xOffset: Math.round(boundingReference ? boundingReference.x : position.x),
+      yOffset: Math.round(boundingReference ? boundingReference.y : position.y),
       position,
       dimension,
     }

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -814,6 +814,7 @@ export interface StandardFunctionProps {
 
 export type AnnotationDimension = 'x' | 'y'
 
+export type AnnotationPinType = 'none' | 'circle' | 'start' | 'stop'
 export interface AnnotationMark {
   title: string
   description: string
@@ -821,4 +822,5 @@ export interface AnnotationMark {
   startValue: number
   stopValue: number
   dimension: AnnotationDimension
+  pin: AnnotationPinType
 }

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -218,6 +218,7 @@ export interface AnnotationLayerConfig {
   hoverMargin?: number
   svgAttributes?: SVGAttributes
   svgStyle?: CSS.Properties
+  lineWidth?: number
 }
 
 export interface CustomLayerRenderProps {

--- a/giraffe/src/utils/annotationData.ts
+++ b/giraffe/src/utils/annotationData.ts
@@ -10,6 +10,7 @@ export const getAnnotationsPositions = (
   annotationData.forEach(annotation => {
     annotationMarks.push({
       ...annotation,
+      pin: annotation.pin || 'none',
       startValue:
         annotation.dimension === 'y'
           ? yScale(annotation.startValue)

--- a/giraffe/src/utils/useTooltipStyle.ts
+++ b/giraffe/src/utils/useTooltipStyle.ts
@@ -134,7 +134,6 @@ export const useAnnotationStyle = (
       return {
         display: 'inline',
         position: 'fixed',
-        backgroundColor: 'yellow',
         left: `${clampedX}px`,
         top: `${clampedY}px`,
         zIndex: CLOCKFACE_Z_INDEX + LEAFLET_Z_INDEX + 1,

--- a/giraffe/src/utils/useTooltipStyle.ts
+++ b/giraffe/src/utils/useTooltipStyle.ts
@@ -126,8 +126,8 @@ export const useAnnotationStyle = (
         }
       }
 
-      const clampedX = Math.max(dx + x, x)
-      const clampedY = dy + y
+      const clampedX = Math.round(Math.max(dx + x, x))
+      const clampedY = Math.round(dy + y)
 
       /* Geo widget maps are rendered with z-index: 399, we have to set it above
        that so that tooltips are not rendered/are hidden below the map, */

--- a/stories/src/annotation.stories.tsx
+++ b/stories/src/annotation.stories.tsx
@@ -19,6 +19,7 @@ import {
   timeZoneKnob,
   tooltipOrientationThresholdKnob,
   tooltipColorizeRowsKnob,
+  annotationPinKnob,
 } from './helpers'
 
 import {annotationsTable, matchAnnotationsToTable} from './data/annotation'
@@ -84,6 +85,8 @@ storiesOf('Annotations', module)
       'auto'
     )
 
+    const pin = annotationPinKnob()
+
     const layers = [
       {
         type: 'annotation',
@@ -95,6 +98,7 @@ storiesOf('Annotations', module)
           table,
           x,
           y,
+          pin,
         }),
         fill,
         hoverDimension,
@@ -216,6 +220,8 @@ storiesOf('Annotations', module)
       hover: hoverHandler,
     }
 
+    const pin = annotationPinKnob()
+
     const layers = [
       {
         type: 'annotation',
@@ -227,6 +233,7 @@ storiesOf('Annotations', module)
           table,
           x,
           y,
+          pin,
         }),
         fill,
       },
@@ -331,12 +338,15 @@ storiesOf('Annotations', module)
       'auto'
     )
 
+    const pin = annotationPinKnob()
+
     const annotations = matchAnnotationsToTable({
       color: annotationColor,
       dimension: annotationDimension,
       table,
       x,
       y,
+      pin,
     })
     const annotationsSelections = multiSelect(
       'annotations',

--- a/stories/src/data/annotation.ts
+++ b/stories/src/data/annotation.ts
@@ -1,6 +1,7 @@
 import {
   AnnotationDimension,
   AnnotationMark,
+  AnnotationPinType,
   Table,
 } from '../../../giraffe/src/types'
 import {newTable} from '../../../giraffe/src'
@@ -36,12 +37,13 @@ interface SampleAnnotationsCreatorOptions {
   table: Table
   x: string
   y: string
+  pin: AnnotationPinType
 }
 
 export const matchAnnotationsToTable = (
   options: SampleAnnotationsCreatorOptions
 ): AnnotationMark[] => {
-  const {color, dimension = 'x', table} = options
+  const {color, dimension = 'x', table, pin} = options
   const values = table.getColumn(options[dimension], 'number')
   const annotationMarks: AnnotationMark[] = []
 
@@ -53,6 +55,7 @@ export const matchAnnotationsToTable = (
       dimension,
       startValue: value,
       stopValue: value,
+      pin,
     })
   })
 

--- a/stories/src/helpers.tsx
+++ b/stories/src/helpers.tsx
@@ -168,3 +168,6 @@ export const tooltipColorizeRowsKnob = () =>
   boolean('tooltipColorizeRows', true)
 
 export const tooltipDisableKnob = () => boolean('tooltipDisable', false)
+
+export const annotationPinKnob = () =>
+  select('pin', ['none', 'circle', 'start', 'stop'], 'none')


### PR DESCRIPTION
### Changes

- Clamp position values on annotation lines and tooltips
  - Using floats here will result in blurry rendering, so everything is rounded to a whole number
  - Up for debate but IMO sharp rendering > extreme precision
 - Add caret element to annotation tooltips
 - Introduce `pin` option for annotations that controls which pin head element is rendered
   - `circle` for single points in time
   - `start` & `stop` for ranges
   - `none` for... well none, duh
 - Change default line width on annotations to `2` to increase legibility
   - The existing `1` width seemed too faint and looked semi-transparent
   
### Preview

![Screen Shot 2021-01-14 at 3 03 38 PM](https://user-images.githubusercontent.com/2433762/104662989-d7210480-5680-11eb-92a0-e0eeb72a5ec3.png)
`tooltip in y axis`

![Screen Shot 2021-01-14 at 3 03 46 PM](https://user-images.githubusercontent.com/2433762/104662991-d8eac800-5680-11eb-97a0-8be663521bbd.png)
`tooltip in x axis`

![Screen Shot 2021-01-14 at 3 43 13 PM](https://user-images.githubusercontent.com/2433762/104662996-ddaf7c00-5680-11eb-8832-374c276e69a9.png)
`start`

![Screen Shot 2021-01-14 at 3 43 29 PM](https://user-images.githubusercontent.com/2433762/104662999-e011d600-5680-11eb-85b5-48ac7715bdb5.png)
`stop`

![Screen Shot 2021-01-14 at 3 43 44 PM](https://user-images.githubusercontent.com/2433762/104663005-e2743000-5680-11eb-83fd-4ce7b84325a2.png)
`circle`
