### PR TITLE
fix(hoverInteraction): use hoverEvent.x, not hoverX to report position of cursor

### DIFF
--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -79,8 +79,8 @@ export const SizedPlot: FunctionComponent<Props> = ({
   const plotInteraction: InteractionHandlerArguments = {
     hoverX: hoverEvent.x,
     hoverY: hoverEvent.y,
-    valueX: env.xScale.invert(hoverX),
-    valueY: env.yScale.invert(hoverY),
+    valueX: env.xScale.invert(hoverEvent.x),
+    valueY: env.yScale.invert(hoverEvent.y),
     xDomain: env.xDomain,
     yDomain: env.yDomain,
     resetDomains: () => {


### PR DESCRIPTION
closes #453 

Tested using the docker changes Gene introduced.

### Testing Instructions
1. checkout master
1. build
1. let ui hot reload
1. go [to this line in `XYPlot`](https://github.com/influxdata/ui/blob/master/src/shared/components/XYPlot.tsx#L233)
    1. add this line somewhere: `console.log(plotInteraction.valueX)`
1. double click on the graph observe that it's the start of the domain
1. checkout `bucky_fix_incorrect_valueX`
1. wait for ui to hotreload
1. double click on the graph and observe the correct time