### PR TITLE
fix: don't import the entire damn geo component structure to get a value

### DIFF
--- a/giraffe/src/components/Geo.tsx
+++ b/giraffe/src/components/Geo.tsx
@@ -26,7 +26,6 @@ import {
 import {Config, Table} from '../types'
 
 // Constants
-export const LEAFLET_Z_INDEX = 399
 const ZOOM_FRACTION = 8
 
 interface Props extends Partial<GeoLayerConfig> {

--- a/giraffe/src/constants/index.ts
+++ b/giraffe/src/constants/index.ts
@@ -138,3 +138,6 @@ export const ANNOTATION_DEFAULT_HOVER_MARGIN = 20
 
 export const ANNOTATION_TOOLTIP_CONTAINER_NAME =
   'giraffe-annotation-tooltip-container'
+
+// Geo stuff
+export const LEAFLET_Z_INDEX = 399

--- a/giraffe/src/utils/useTooltipStyle.ts
+++ b/giraffe/src/utils/useTooltipStyle.ts
@@ -1,7 +1,6 @@
 import {useLayoutStyle} from './useLayoutStyle'
 import {useRefMousePos} from './useMousePos'
-import {LEAFLET_Z_INDEX} from '../components/Geo'
-import {CLOCKFACE_Z_INDEX} from '../constants'
+import {CLOCKFACE_Z_INDEX, LEAFLET_Z_INDEX} from '../constants'
 import {AnnotationTooltipOptions} from '../types'
 
 const MARGIN_X = 30


### PR DESCRIPTION
Funny story. I was doing some experimenting with loading Giraffe on the server using a minimal component configuration. And I just couldn't for the life of me understand why I was getting leaflet leaflet errors when I clearly didn't include any leaflet stuff.

I did some digging and it turns out - and this is just _hilarious_ - that some Geo code includes the entire Geo component structure to get a constant that's defined in the `Geo` component and only used in one file. 🙄 