### PR TITLE
chore: export the TimeFormatterFactoryOptions interface

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/index.ts
+++ b/giraffe/src/index.ts
@@ -10,6 +10,7 @@ export {
   binaryPrefixFormatter,
   siPrefixFormatter,
   timeFormatter,
+  TimeFormatterFactoryOptions,
 } from './utils/formatters'
 export {getDomainDataFromLines} from './utils/lineData'
 

--- a/giraffe/src/utils/formatters.ts
+++ b/giraffe/src/utils/formatters.ts
@@ -102,7 +102,7 @@ interface TimeFormatter extends Formatter {
   _GIRAFFE_FORMATTER_TYPE: FormatterType.Time
 }
 
-interface TimeFormatterFactoryOptions {
+export interface TimeFormatterFactoryOptions {
   // BCP 47 language tag or "default"
   locale?: string
 


### PR DESCRIPTION
As a follow-up to https://github.com/influxdata/ui/issues/768 and to allow consuming apps to improve time formatting, expose the options that are configurable.