### PR TITLE
docs: updates giraffe examples doc

### DIFF
--- a/examples/Listing_of_giraffe_samples.md
+++ b/examples/Listing_of_giraffe_samples.md
@@ -40,6 +40,8 @@ https://github.com/ShmuelLotman/giraffe_sample </td><td>  Histogram </td><td> Di
 <td>https://github.com/ChitlangeSahas/influxdata-giraffe-demo </td><td>  Table </td><td>  Direct API </td><td> React </td></tr>
 <tr>
 <td>https://github.com/influxdata/influxdb-client-js/blob/master/examples/giraffe.html </td><td>  Line </td><td>  InfluxDB Client </td><td> HTML </td></tr>
+<tr>
+<td>https://github.com/genehynson/telegraf-giraffe-iss </td><td> Map </td><td> InfluxDB Client </td><td> Node/React </td></tr>
 
 
 

--- a/examples/Listing_of_giraffe_samples.md
+++ b/examples/Listing_of_giraffe_samples.md
@@ -3,7 +3,7 @@ Listing of Giraffe Samples
 
 The following of a listing of sample React/Js projects that render different types of InfluxDB Plots (visualizations) using a variety of methods, with the Giraffe library.  
 
-The Influx Connection Type specifies whether a direct REST API call is used (direct) or whether the helper JavaScript library InfluxDBClient (@influxdata/influxdb-client) is used.
+The Influx Connection Type specifies whether a direct REST API call is used (direct) or whether the helper JavaScript library InfluxDBClient ([@influxdata/influxdb-client-js](https://github.com/influxdata/influxdb-client-js)) is used.
 
 The Project Structure describes whether a client/server approach was used (Node/React), or whether a single React application (React) was written.
 


### PR DESCRIPTION
updates name and link to influx-client-js library

adds ISS Giraffe example