### PR TITLE
fix: remove webpack's compilerOptions.rootDir to allow renaming the repo when cloning

### DIFF
--- a/stories/.storybook/webpack.config.js
+++ b/stories/.storybook/webpack.config.js
@@ -37,7 +37,6 @@ module.exports = ({config}) => {
           options: {
             ignoreDiagnostics: ['6133'],
             compilerOptions: {
-              rootDir: '../../giraffe',
               outDir: null,
               declaration: false,
             },


### PR DESCRIPTION
Closes #497 