### PR TITLE
fix:  proposed fix for issue 440 - Mapcenter

### DIFF
--- a/giraffe/src/components/Geo.tsx
+++ b/giraffe/src/components/Geo.tsx
@@ -120,13 +120,6 @@ const Geo: FunctionComponent<Props> = props => {
     }
   }
 
-  const calcDataCenter = (lats: number[], lons: number[]) => {
-    const latMax = lats.reduce((a, b) => Math.max(a, b))
-    const latMin = lats.reduce((a, b) => Math.min(a, b))
-    const lonMax = lons.reduce((a, b) => Math.max(a, b))
-    const lonMin = lons.reduce((a, b) => Math.min(a, b))
-    return {lat: (latMax + latMin) / 2, lon: (lonMax + lonMin) / 2}
-  }
   const cMeth = centerMethod ? centerMethod : 'fixed'
   let mapCenter = {lat: lat, lon: lon}
 
@@ -146,26 +139,8 @@ const Geo: FunctionComponent<Props> = props => {
       case 'fixed':
         break
       case 'center':
-        if (
-          table.length > 0 &&
-          table.getColumn('lat') &&
-          table.getColumn('lon')
-        ) {
-          const lats = (table.getColumn('lat') as any).map(el => parseFloat(el))
-          const lons = (table.getColumn('lon') as any).map(el => parseFloat(el))
-          latLon = calcDataCenter(lats, lons)
-          mapCenter = {lat: latLon.lat, lon: latLon.lon}
-        } else if (table.length > 0 && table.getColumn('s2_cell_id')) {
-          const lats = []
-          const lons = []
-          for (let i = 0; i < preprocessedTable.getRowCount(); i++) {
-            const ltln = preprocessedTable.getLatLon(i)
-            lats.push(ltln.lat)
-            lons.push(ltln.lon)
-          }
-          latLon = calcDataCenter(lats, lons)
-          mapCenter = {lat: latLon.lat, lon: latLon.lon}
-        }
+        latLon = preprocessedTable.getCenterPoint()
+        mapCenter = {lat: latLon.lat, lon: latLon.lon}
         break
       default:
         if (typeof cMeth === 'number') {

--- a/giraffe/src/components/Geo.tsx
+++ b/giraffe/src/components/Geo.tsx
@@ -113,9 +113,17 @@ const Geo: FunctionComponent<Props> = props => {
   }
 
   const latLon = preprocessedTable.getLatLon(0)
-  const mapCenter = {
-    lat: latLon ? latLon.lat : lat,
-    lon: latLon ? latLon.lon : lon,
+  //  const mapCenter = {
+  //    lat: latLon ? latLon.lat : lat,
+  //    lon: latLon ? latLon.lon : lon,
+  //  }
+
+  let mapCenter
+
+  if (lat > 90.0 || lat < -90.0 || lon > 180.0 || lon < -180.0) {
+    mapCenter = {lat: latLon.lat, lon: latLon.lon}
+  } else {
+    mapCenter = {lat: lat, lon: lon}
   }
 
   return (

--- a/giraffe/src/components/GeoLayer.tsx
+++ b/giraffe/src/components/GeoLayer.tsx
@@ -116,6 +116,7 @@ const onAutoResize = (
     allowPanAndZoom,
     detectCoordinateFields,
     mapStyle,
+    centerMethod,
   } = config
   const {
     latOnLastRender,
@@ -149,6 +150,7 @@ const onAutoResize = (
         onViewportChange={onViewportChange(props, lastRenderProperties)}
         allowPanAndZoom={allowPanAndZoom}
         tileServerConfiguration={config.tileServerConfiguration}
+        centerMethod={centerMethod}
       />
     </div>
   )

--- a/giraffe/src/components/geo/processing/GeoTable.ts
+++ b/giraffe/src/components/geo/processing/GeoTable.ts
@@ -12,6 +12,8 @@ export interface GeoTable {
 
   getLatLon(index: number): LatLon
 
+  getCenterPoint(): LatLon
+
   getTimeString(index: number): string
 
   isTruncated(): boolean

--- a/giraffe/src/components/geo/processing/NativeGeoTable.ts
+++ b/giraffe/src/components/geo/processing/NativeGeoTable.ts
@@ -19,6 +19,9 @@ export class NativeGeoTable extends AbstractGeoTable {
     super(getDataEncoding(table))
     this.table = table
     this.maxRows = maxRows
+    if (this.table.getColumn(LAT_COLUMN) && this.table.getColumn(LON_COLUMN)) {
+      this.latLonToNumber()
+    }
   }
 
   getRowCount() {
@@ -33,6 +36,20 @@ export class NativeGeoTable extends AbstractGeoTable {
     return column[
       index * Math.max(1, Math.floor(this.table.length / this.maxRows))
     ] as number
+  }
+
+  colToNumber(colName: string) {
+    const column = this.table.getColumn(colName)
+    if (column && typeof column[0] !== 'number') {
+      for (let i = 0; i < column.length; i++) {
+        column[i] = parseFloat(column[i] as string)
+      }
+    }
+  }
+
+  latLonToNumber() {
+    this.colToNumber(LAT_COLUMN)
+    this.colToNumber(LON_COLUMN)
   }
 
   getS2CellID(index: number): string {

--- a/giraffe/src/types/geo.ts
+++ b/giraffe/src/types/geo.ts
@@ -6,7 +6,7 @@ export interface GeoLayerConfig {
   allowPanAndZoom: boolean
   mapStyle?: string
   detectCoordinateFields: boolean
-  centerMethod?: 'center' | 'first' | 'fixed' | number
+  centerMethod?: 'center' | 'first' | 'fixed' | 'last' | number
 
   onViewportChange?: (lat: number, lon: number, zoom: number) => void
   onUpdateViewport?: (lat: number, lon: number, zoom: number) => void

--- a/giraffe/src/types/geo.ts
+++ b/giraffe/src/types/geo.ts
@@ -6,6 +6,7 @@ export interface GeoLayerConfig {
   allowPanAndZoom: boolean
   mapStyle?: string
   detectCoordinateFields: boolean
+  centerMethod?: 'center' | 'first' | 'fixed' | number
 
   onViewportChange?: (lat: number, lon: number, zoom: number) => void
   onUpdateViewport?: (lat: number, lon: number, zoom: number) => void

--- a/stories/src/geo.stories.tsx
+++ b/stories/src/geo.stories.tsx
@@ -61,6 +61,7 @@ const specialKnobs = () => {
     first: 'first',
     fixed: 'fixed',
     center: 'center',
+    last: 'last',
     '1': 1,
     '2': 2,
     '3': 3,


### PR DESCRIPTION
This proposes a fix for issue #440.  It adds a `centerMethod` property to `GeoLayerConfig`with a default value of `fixed`, which strictly respects the already existing properties `lat` and `lon`.

Other values for `centerMethod` will center the map on the first, last or nth value in the table, or will calculate the center value.   