### PR TITLE
fix: prevent resetting of domains when no interaction handlers are given

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/SizedPlot.test.tsx
+++ b/giraffe/src/components/SizedPlot.test.tsx
@@ -61,7 +61,7 @@ describe('the SizedPlot', () => {
         // when the user (for real) does a single click, then a mouse up happens.
         // chose mouse up because the single click listener wasn't triggering except on
         // double clicks
-        fireEvent.mouseUp(screen.getByTestId('giraffe-inner-plot'))
+        fireEvent.doubleClick(screen.getByTestId('giraffe-inner-plot'))
 
         expect(resetSpy).toHaveBeenCalled()
       })

--- a/giraffe/src/components/SizedPlot.test.tsx
+++ b/giraffe/src/components/SizedPlot.test.tsx
@@ -58,9 +58,6 @@ describe('the SizedPlot', () => {
           />
         )
 
-        // when the user (for real) does a single click, then a mouse up happens.
-        // chose mouse up because the single click listener wasn't triggering except on
-        // double clicks
         fireEvent.doubleClick(screen.getByTestId('giraffe-inner-plot'))
 
         expect(resetSpy).toHaveBeenCalled()
@@ -83,7 +80,7 @@ describe('the SizedPlot', () => {
           />
         )
         // when the user (for real) does a single click, then a mouse up happens.
-        // chose mouse up because the single click listener wasn't triggering except on
+        // choose mouse up because the single click listener wasn't triggering except on
         // double clicks
         fireEvent.mouseUp(screen.getByTestId('giraffe-inner-plot'))
 

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -97,11 +97,12 @@ export const SizedPlot: FunctionComponent<Props> = ({
     },
   }
 
+  const noOp = () => {}
   const singleClick = config.interactionHandlers?.singleClick
     ? () => {
         config.interactionHandlers.singleClick(plotInteraction)
       }
-    : () => {}
+    : noOp
 
   if (config.interactionHandlers?.hover) {
     config.interactionHandlers.hover(plotInteraction)

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -101,7 +101,7 @@ export const SizedPlot: FunctionComponent<Props> = ({
     ? () => {
         config.interactionHandlers.singleClick(plotInteraction)
       }
-    : memoizedResetDomains
+    : () => {}
 
   if (config.interactionHandlers?.hover) {
     config.interactionHandlers.hover(plotInteraction)
@@ -150,6 +150,7 @@ export const SizedPlot: FunctionComponent<Props> = ({
           cursor: `${userConfig.cursor || 'crosshair'}`,
         }}
         onMouseUp={callbacks.singleClick}
+        onDoubleClick={memoizedResetDomains}
         {...hoverTargetProps}
         {...dragTargetProps}
       >


### PR DESCRIPTION
Closes #507 

Brush behavior (click-dragging with the mouse) requires the user to release, which is considered a (long) single-click. Sized Plot was inadvertently resetting the domains right before the Brush behavior was applied. The steps described in #507 would be summarized as follows:

1. Start the zoom on x-axis by click-dragging
2. (Sized Plot resets all domains)
3. Release the click to complete the zoom
4. Brush behavior is applied on one dimension, the x-axis, and a new x-domain is set
--
5. Start the zoom on y-axis by click-dragging
6. (Sized Plot resets all domains --- OOPS! x-domain is now the original values before step 1)
7. Release the click to complete the zoom
8. Brush behavior is applied on one dimension, the y-axis, and a new y-domain is set

This is reproduceable with the axes flipped, doing 1 - 4 and 5-8 with the other axis.

To fix this, make the single-click a no-op if interaction handlers are not given. Also, ensure the double-click domain reset feature still works by not overloading it with the single-click behavior.

