### PR TITLE
fix: use lat lon fields and values instead of s2_cell_id

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/Geo.tsx
+++ b/giraffe/src/components/Geo.tsx
@@ -80,14 +80,7 @@ const Geo: FunctionComponent<Props> = props => {
   const {table, detectCoordinateFields} = props
   const [preprocessedTable, setPreprocessedTable] = useState(
     table
-      ? preprocessData(
-          table,
-          getRowLimit(props.layers),
-          detectCoordinateFields,
-          preprocessedTable => {
-            setPreprocessedTable(preprocessedTable)
-          }
-        )
+      ? preprocessData(table, getRowLimit(props.layers), detectCoordinateFields)
       : null
   )
 
@@ -95,14 +88,9 @@ const Geo: FunctionComponent<Props> = props => {
     const newTable = preprocessData(
       props.table,
       getRowLimit(props.layers),
-      props.detectCoordinateFields,
-      preprocessedTable => {
-        setPreprocessedTable(preprocessedTable)
-      }
+      props.detectCoordinateFields
     )
-    if (newTable) {
-      setPreprocessedTable(newTable)
-    }
+    setPreprocessedTable(newTable)
   }, [table, detectCoordinateFields])
 
   const onViewportChange = (viewport: {center?: number[]; zoom?: number}) => {

--- a/giraffe/src/components/geo/processing/tableProcessing.ts
+++ b/giraffe/src/components/geo/processing/tableProcessing.ts
@@ -30,7 +30,7 @@ export const preprocessData = (
 ): GeoTable => {
   if (autoPivoting && isPivotSensible(table)) {
     // don't delay rendering with data calculation
-      return new PivotedGeoTable(table, rowLimit)
+    return new PivotedGeoTable(table, rowLimit)
   }
   return new NativeGeoTable(table, rowLimit)
 }

--- a/giraffe/src/components/geo/processing/tableProcessing.ts
+++ b/giraffe/src/components/geo/processing/tableProcessing.ts
@@ -4,9 +4,6 @@ import {isPivotSensible, PivotedGeoTable} from './PivotedGeoTable'
 import {NativeGeoTable} from './NativeGeoTable'
 import {Table} from '../../../types'
 
-// Utils
-import {EmptyGeoTable} from './EmptyGeoTable'
-
 // Constants
 export const FIELD_COLUMN = '_field'
 export const VALUE_COLUMN = '_value'
@@ -33,10 +30,7 @@ export const preprocessData = (
 ): GeoTable => {
   if (autoPivoting && isPivotSensible(table)) {
     // don't delay rendering with data calculation
-    setTimeout(() => {
-      new PivotedGeoTable(table, rowLimit)
-    }, 0)
-    return new EmptyGeoTable()
+      return new PivotedGeoTable(table, rowLimit)
   }
   return new NativeGeoTable(table, rowLimit)
 }

--- a/giraffe/src/components/geo/processing/tableProcessing.ts
+++ b/giraffe/src/components/geo/processing/tableProcessing.ts
@@ -29,13 +29,12 @@ export const GEO_HASH_COLUMN = 's2_cell_id'
 export const preprocessData = (
   table: Table,
   rowLimit: number,
-  autoPivoting: boolean,
-  onFinalTable: (table: GeoTable) => void
+  autoPivoting: boolean
 ): GeoTable => {
   if (autoPivoting && isPivotSensible(table)) {
     // don't delay rendering with data calculation
     setTimeout(() => {
-      onFinalTable(new PivotedGeoTable(table, rowLimit))
+      new PivotedGeoTable(table, rowLimit)
     }, 0)
     return new EmptyGeoTable()
   }


### PR DESCRIPTION
Closes #513 
Improving Geo code, so that it return a Pivoted table when fields contain lat lon instead of using `s2_cell_id` to calculate GeoHash Coordinates.