### PR TITLE
feat: annotations pin target onClick handler

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -55,7 +55,7 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
 
   const handleClick = event => {
     if (config.handleAnnotationClick) {
-      config.handleAnnotationClick(event.currentTarget.id)
+      config.handleAnnotationClick(event.target.id)
     }
   }
 
@@ -66,13 +66,6 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
       style={{...ANNOTATION_OVERLAY_DEFAULT_STYLE, width, height}}
       onClick={handleClick}
     >
-      <AnnotationHoverLayer
-        {...props}
-        annotationPositions={annotationsPositions}
-        boundingReference={boundingRect}
-        hoverRowIndices={hoverRowIndices}
-        width={width}
-      />
       {annotationsPositions.map(annotationData =>
         annotationData.dimension === 'y' ? (
           <AnnotationLine
@@ -100,6 +93,13 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
           />
         )
       )}
+      <AnnotationHoverLayer
+        {...props}
+        annotationPositions={annotationsPositions}
+        boundingReference={boundingRect}
+        hoverRowIndices={hoverRowIndices}
+        width={width}
+      />
     </svg>
   )
 }

--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -3,12 +3,14 @@ import {
   AnnotationLayerConfig,
   AnnotationLayerSpec,
   LayerProps,
+  LineHoverDimension,
 } from '../types'
 import {
+  getAnnotationHoverIndices,
   getAnnotationsPositions,
 } from '../utils/annotationData'
-// import {ANNOTATION_DEFAULT_HOVER_MARGIN} from '../constants/index'
-// import {AnnotationHoverLayer} from './AnnotationHoverLayer'
+import {ANNOTATION_DEFAULT_HOVER_MARGIN} from '../constants/index'
+import {AnnotationHoverLayer} from './AnnotationHoverLayer'
 import {AnnotationLine} from './AnnotationLine'
 
 export interface AnnotationLayerProps extends LayerProps {
@@ -21,7 +23,7 @@ const ANNOTATION_OVERLAY_DEFAULT_STYLE = {
 } as CSSProperties
 
 export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props => {
-  const {config, spec, width, height, xScale, yScale} = props
+  const {config, spec, width, height, xScale, yScale, hoverX, hoverY} = props
   const lineWidth = config.lineWidth || 2
   const annotationsPositions = useMemo(
     () => getAnnotationsPositions(spec.annotationData, xScale, yScale),
@@ -29,41 +31,46 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
   )
   const svgRef = useRef<SVGSVGElement>(null)
 
-  // let hoverDimension = 'xy' as LineHoverDimension
-  // if (config.hoverDimension === 'x' || config.hoverDimension === 'y') {
-  //   hoverDimension = config.hoverDimension
-  // }
-  //
-  // const hoverMargin = config.hoverMargin
-  //   ? config.hoverMargin
-  //   : ANNOTATION_DEFAULT_HOVER_MARGIN
-  //
-  // const hoverRowIndices = getAnnotationHoverIndices(
-  //   hoverDimension,
-  //   hoverMargin,
-  //   annotationsPositions,
-  //   hoverX,
-  //   hoverY
-  // )
-  //
-  // let boundingRect: DOMRect
-  // if (svgRef.current) {
-  //   boundingRect = svgRef.current.getBoundingClientRect()
-  // }
+  let hoverDimension = 'xy' as LineHoverDimension
+  if (config.hoverDimension === 'x' || config.hoverDimension === 'y') {
+    hoverDimension = config.hoverDimension
+  }
+
+  const hoverMargin = config.hoverMargin
+    ? config.hoverMargin
+    : ANNOTATION_DEFAULT_HOVER_MARGIN
+
+  const hoverRowIndices = getAnnotationHoverIndices(
+    hoverDimension,
+    hoverMargin,
+    annotationsPositions,
+    hoverX,
+    hoverY
+  )
+
+  let boundingRect: DOMRect
+  if (svgRef.current) {
+    boundingRect = svgRef.current.getBoundingClientRect()
+  }
+
+  const handleClick = event => {
+    config.handleAnnotationClick(event.currentTarget.id)
+  }
 
   return (
     <svg
       className="giraffe-layer giraffe-layer-annotation"
       ref={svgRef}
       style={{...ANNOTATION_OVERLAY_DEFAULT_STYLE, width, height}}
+      onClick={handleClick}
     >
-      {/*<AnnotationHoverLayer*/}
-      {/*  {...props}*/}
-      {/*  annotationPositions={annotationsPositions}*/}
-      {/*  boundingReference={boundingRect}*/}
-      {/*  hoverRowIndices={hoverRowIndices}*/}
-      {/*  width={width}*/}
-      {/*/>*/}
+      <AnnotationHoverLayer
+        {...props}
+        annotationPositions={annotationsPositions}
+        boundingReference={boundingRect}
+        hoverRowIndices={hoverRowIndices}
+        width={width}
+      />
       {annotationsPositions.map(annotationData =>
         annotationData.dimension === 'y' ? (
           <AnnotationLine
@@ -75,6 +82,7 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
             color={annotationData.color}
             strokeWidth={lineWidth}
             pin={annotationData.pin}
+            id={annotationData.id}
           />
         ) : (
           <AnnotationLine
@@ -86,6 +94,7 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
             color={annotationData.color}
             strokeWidth={lineWidth}
             pin={annotationData.pin}
+            id={annotationData.id}
           />
         )
       )}

--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -66,6 +66,13 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
       style={{...ANNOTATION_OVERLAY_DEFAULT_STYLE, width, height}}
       onClick={handleClick}
     >
+      <AnnotationHoverLayer
+        {...props}
+        annotationPositions={annotationsPositions}
+        boundingReference={boundingRect}
+        hoverRowIndices={hoverRowIndices}
+        width={width}
+      />
       {annotationsPositions.map(annotationData =>
         annotationData.dimension === 'y' ? (
           <AnnotationLine
@@ -93,13 +100,6 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
           />
         )
       )}
-      <AnnotationHoverLayer
-        {...props}
-        annotationPositions={annotationsPositions}
-        boundingReference={boundingRect}
-        hoverRowIndices={hoverRowIndices}
-        width={width}
-      />
     </svg>
   )
 }

--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -54,7 +54,7 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
   }
 
   const handleClick = event => {
-    if (config.handleAnnotationClick) {
+    if (config.handleAnnotationClick && event.target.id) {
       config.handleAnnotationClick(event.target.id)
     }
   }

--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -23,7 +23,7 @@ const ANNOTATION_OVERLAY_DEFAULT_STYLE = {
 } as CSSProperties
 
 export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props => {
-  const {config, spec, width, height, xScale, yScale, hoverX, hoverY} = props
+  const {config, spec, width, height, hoverX, hoverY, xScale, yScale} = props
   const lineWidth = config.lineWidth || 2
   const annotationsPositions = useMemo(
     () => getAnnotationsPositions(spec.annotationData, xScale, yScale),

--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -54,7 +54,9 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
   }
 
   const handleClick = event => {
-    config.handleAnnotationClick(event.currentTarget.id)
+    if (config.handleAnnotationClick) {
+      config.handleAnnotationClick(event.currentTarget.id)
+    }
   }
 
   return (

--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -3,14 +3,12 @@ import {
   AnnotationLayerConfig,
   AnnotationLayerSpec,
   LayerProps,
-  LineHoverDimension,
 } from '../types'
 import {
-  getAnnotationHoverIndices,
   getAnnotationsPositions,
 } from '../utils/annotationData'
-import {ANNOTATION_DEFAULT_HOVER_MARGIN} from '../constants/index'
-import {AnnotationHoverLayer} from './AnnotationHoverLayer'
+// import {ANNOTATION_DEFAULT_HOVER_MARGIN} from '../constants/index'
+// import {AnnotationHoverLayer} from './AnnotationHoverLayer'
 import {AnnotationLine} from './AnnotationLine'
 
 export interface AnnotationLayerProps extends LayerProps {
@@ -23,7 +21,7 @@ const ANNOTATION_OVERLAY_DEFAULT_STYLE = {
 } as CSSProperties
 
 export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props => {
-  const {config, spec, width, height, hoverX, hoverY, xScale, yScale} = props
+  const {config, spec, width, height, xScale, yScale} = props
   const lineWidth = config.lineWidth || 2
   const annotationsPositions = useMemo(
     () => getAnnotationsPositions(spec.annotationData, xScale, yScale),
@@ -31,27 +29,27 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
   )
   const svgRef = useRef<SVGSVGElement>(null)
 
-  let hoverDimension = 'xy' as LineHoverDimension
-  if (config.hoverDimension === 'x' || config.hoverDimension === 'y') {
-    hoverDimension = config.hoverDimension
-  }
-
-  const hoverMargin = config.hoverMargin
-    ? config.hoverMargin
-    : ANNOTATION_DEFAULT_HOVER_MARGIN
-
-  const hoverRowIndices = getAnnotationHoverIndices(
-    hoverDimension,
-    hoverMargin,
-    annotationsPositions,
-    hoverX,
-    hoverY
-  )
-
-  let boundingRect: DOMRect
-  if (svgRef.current) {
-    boundingRect = svgRef.current.getBoundingClientRect()
-  }
+  // let hoverDimension = 'xy' as LineHoverDimension
+  // if (config.hoverDimension === 'x' || config.hoverDimension === 'y') {
+  //   hoverDimension = config.hoverDimension
+  // }
+  //
+  // const hoverMargin = config.hoverMargin
+  //   ? config.hoverMargin
+  //   : ANNOTATION_DEFAULT_HOVER_MARGIN
+  //
+  // const hoverRowIndices = getAnnotationHoverIndices(
+  //   hoverDimension,
+  //   hoverMargin,
+  //   annotationsPositions,
+  //   hoverX,
+  //   hoverY
+  // )
+  //
+  // let boundingRect: DOMRect
+  // if (svgRef.current) {
+  //   boundingRect = svgRef.current.getBoundingClientRect()
+  // }
 
   return (
     <svg
@@ -59,13 +57,13 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
       ref={svgRef}
       style={{...ANNOTATION_OVERLAY_DEFAULT_STYLE, width, height}}
     >
-      <AnnotationHoverLayer
-        {...props}
-        annotationPositions={annotationsPositions}
-        boundingReference={boundingRect}
-        hoverRowIndices={hoverRowIndices}
-        width={width}
-      />
+      {/*<AnnotationHoverLayer*/}
+      {/*  {...props}*/}
+      {/*  annotationPositions={annotationsPositions}*/}
+      {/*  boundingReference={boundingRect}*/}
+      {/*  hoverRowIndices={hoverRowIndices}*/}
+      {/*  width={width}*/}
+      {/*/>*/}
       {annotationsPositions.map(annotationData =>
         annotationData.dimension === 'y' ? (
           <AnnotationLine

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -41,6 +41,7 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
               PIN_TRIANGLE_HEIGHT / 2},${clampedStart +
               PIN_TRIANGLE_WIDTH} ${length},${clampedStart}`,
             fill: color,
+            onClick: () => {console.log("thing clicked")}
           })}
         {pin === 'stop' &&
           createElement('polygon', {

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -9,6 +9,7 @@ interface AnnotationLineProps {
   stopValue: number
   length: number
   pin: AnnotationPinType
+  id: string
 }
 
 // These could become configurable values
@@ -75,10 +76,9 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
           points: `${clampedStart - PIN_TRIANGLE_WIDTH},0
           ${clampedStart + PIN_TRIANGLE_WIDTH},0 
           ${clampedStart},${PIN_TRIANGLE_HEIGHT}`,
-          onClick: (event) => {
-            event.nativeEvent.stopImmediatePropagation();
-            console.log("thing clicked")},
           fill: color,
+          style: {cursor: 'pointer'},
+          id: props.id,
         })}
       {pin === 'stop' &&
         createElement('polygon', {

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -14,8 +14,8 @@ interface AnnotationLineProps {
 
 // These could become configurable values
 const PIN_CIRCLE_RADIUS = 4
-const PIN_TRIANGLE_HEIGHT = 10
-const PIN_TRIANGLE_WIDTH = 6
+const PIN_TRIANGLE_HEIGHT = 18
+const PIN_TRIANGLE_WIDTH = 11
 
 export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
   const {dimension, color, strokeWidth, startValue, length, pin} = props

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -38,16 +38,19 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
           })}
         {pin === 'start' &&
           createElement('polygon', {
-            points: `${length - PIN_TRIANGLE_HEIGHT},${clampedStart} ${length -
-              PIN_TRIANGLE_HEIGHT / 2},${clampedStart +
-              PIN_TRIANGLE_WIDTH} ${length},${clampedStart}`,
+            points: `${length - PIN_TRIANGLE_HEIGHT}, ${clampedStart} ${length -
+              PIN_TRIANGLE_HEIGHT / 2}, ${clampedStart +
+              PIN_TRIANGLE_WIDTH} ${length}, ${clampedStart}`,
             fill: color,
+            style: {cursor: 'pointer'},
+            id: props.id,
+            className: 'giraffe-annotation-click-target',
           })}
         {pin === 'stop' &&
           createElement('polygon', {
-            points: `${length - PIN_TRIANGLE_HEIGHT},${clampedStart} ${length -
-              PIN_TRIANGLE_HEIGHT / 2},${clampedStart -
-              PIN_TRIANGLE_WIDTH} ${length},${clampedStart}`,
+            points: `${length - PIN_TRIANGLE_HEIGHT}, ${clampedStart} ${length -
+              PIN_TRIANGLE_HEIGHT / 2}, ${clampedStart -
+              PIN_TRIANGLE_WIDTH} ${length}, ${clampedStart}`,
             fill: color,
           })}
         <line
@@ -73,18 +76,19 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
         })}
       {pin === 'start' &&
         createElement('polygon', {
-          points: `${clampedStart - PIN_TRIANGLE_WIDTH},0
-          ${clampedStart + PIN_TRIANGLE_WIDTH},0 
-          ${clampedStart},${PIN_TRIANGLE_HEIGHT}`,
+          points: `${clampedStart - PIN_TRIANGLE_WIDTH}, 0
+          ${clampedStart + PIN_TRIANGLE_WIDTH}, 0
+          ${clampedStart}, ${PIN_TRIANGLE_HEIGHT}`,
           fill: color,
           style: {cursor: 'pointer'},
           id: props.id,
+          className: 'giraffe-annotation-click-target',
         })}
       {pin === 'stop' &&
         createElement('polygon', {
-          points: `${clampedStart},0 ${clampedStart -
-            PIN_TRIANGLE_WIDTH},${PIN_TRIANGLE_HEIGHT /
-            2} ${clampedStart},${PIN_TRIANGLE_HEIGHT}`,
+          points: `${clampedStart}, 0 ${clampedStart -
+            PIN_TRIANGLE_WIDTH}, ${PIN_TRIANGLE_HEIGHT /
+            2} ${clampedStart}, ${PIN_TRIANGLE_HEIGHT}`,
           fill: color,
         })}
       <line
@@ -94,6 +98,7 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
         y2={length}
         stroke={color}
         strokeWidth={strokeWidth}
+        className="giraffe-annotation-line"
       />
     </>
   )

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -41,7 +41,6 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
               PIN_TRIANGLE_HEIGHT / 2},${clampedStart +
               PIN_TRIANGLE_WIDTH} ${length},${clampedStart}`,
             fill: color,
-            onClick: () => {console.log("thing clicked")}
           })}
         {pin === 'stop' &&
           createElement('polygon', {
@@ -76,6 +75,9 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
           points: `${clampedStart - PIN_TRIANGLE_WIDTH},0
           ${clampedStart + PIN_TRIANGLE_WIDTH},0 
           ${clampedStart},${PIN_TRIANGLE_HEIGHT}`,
+          onClick: (event) => {
+            event.nativeEvent.stopImmediatePropagation();
+            console.log("thing clicked")},
           fill: color,
         })}
       {pin === 'stop' &&

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -72,9 +72,9 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
         })}
       {pin === 'start' &&
         createElement('polygon', {
-          points: `${clampedStart},0 ${clampedStart +
-            PIN_TRIANGLE_WIDTH},${PIN_TRIANGLE_HEIGHT /
-            2} ${clampedStart},${PIN_TRIANGLE_HEIGHT}`,
+          points: `${clampedStart - PIN_TRIANGLE_WIDTH},0
+          ${clampedStart + PIN_TRIANGLE_WIDTH},0 
+          ${clampedStart},${PIN_TRIANGLE_HEIGHT}`,
           fill: color,
         })}
       {pin === 'stop' &&

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -25,7 +25,7 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
 
   const position = {
     x: dimension === 'x' ? startValue : width,
-    y: dimension === 'y' ? startValue : 0,
+    y: dimension === 'y' ? startValue : -10,
   } as TooltipPosition
 
   const clampedXOffset = Math.round(

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -23,7 +23,7 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
   } = config
   const {dimension, startValue} = data || {}
 
-  // move this sucker 15 pixels up to get out of the way of the annotation click target
+  // move this 15 pixels up to get out of the way of the annotation click target
   const yAxisTooltipOffset = -15
 
   const position = {

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -25,7 +25,7 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
 
   const position = {
     x: dimension === 'x' ? startValue : width,
-    y: dimension === 'y' ? startValue : -10,
+    y: dimension === 'y' ? startValue : -15,
   } as TooltipPosition
 
   const clampedXOffset = Math.round(

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -23,9 +23,12 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
   } = config
   const {dimension, startValue} = data || {}
 
+  // move this sucker 15 pixels up to get out of the way of the annotation click target
+  const yAxisTooltipOffset = -15
+
   const position = {
     x: dimension === 'x' ? startValue : width,
-    y: dimension === 'y' ? startValue : -15,
+    y: dimension === 'y' ? startValue : yAxisTooltipOffset,
   } as TooltipPosition
 
   const clampedXOffset = Math.round(

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -98,12 +98,7 @@ export const SizedPlot: FunctionComponent<Props> = ({
   }
 
   const singleClick = config.interactionHandlers?.singleClick
-    ? (event) => {
-    console.log(config.layers)
-    console.log(env.xScale.invert(event.clientX))
-    console.log(env.xScale.invert(config.layers[1]['annotations'][0].startValue))
-    // const annotation = config.layers[1].annotations[0].startValue
-    //     console.log(annotation)
+    ? () => {
         config.interactionHandlers.singleClick(plotInteraction)
       }
     : memoizedResetDomains

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -98,7 +98,12 @@ export const SizedPlot: FunctionComponent<Props> = ({
   }
 
   const singleClick = config.interactionHandlers?.singleClick
-    ? () => {
+    ? (event) => {
+    console.log(config.layers)
+    console.log(env.xScale.invert(event.clientX))
+    console.log(env.xScale.invert(config.layers[1]['annotations'][0].startValue))
+    // const annotation = config.layers[1].annotations[0].startValue
+    //     console.log(annotation)
         config.interactionHandlers.singleClick(plotInteraction)
       }
     : memoizedResetDomains

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -98,7 +98,16 @@ export const SizedPlot: FunctionComponent<Props> = ({
   }
 
   const singleClick = config.interactionHandlers?.singleClick
-    ? () => {
+    ? event => {
+        // If a click happens on an annotation line or annotation click handler, don't call the interaction handler.
+        // There's already an annotation-specific handler for this, that'll handle this.
+        if (
+          event.target.classList.contains('giraffe-annotation-click-target') ||
+          event.target.classList.contains('giraffe-annotation-line')
+        ) {
+          return
+        }
+
         config.interactionHandlers.singleClick(plotInteraction)
       }
     : memoizedResetDomains

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -827,5 +827,5 @@ export interface AnnotationMark {
   stopValue: number
   dimension: AnnotationDimension
   pin: AnnotationPinType
-  id: string
+  id?: string
 }

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -220,6 +220,7 @@ export interface AnnotationLayerConfig {
   svgAttributes?: SVGAttributes
   svgStyle?: CSS.Properties
   lineWidth?: number
+  handleAnnotationClick?: (id: string) => void
 }
 
 export interface CustomLayerRenderProps {
@@ -826,4 +827,5 @@ export interface AnnotationMark {
   stopValue: number
   dimension: AnnotationDimension
   pin: AnnotationPinType
+  id: string
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "private": true,
-  "workspaces": ["giraffe", "stories"],
+  "workspaces": [
+    "giraffe",
+    "stories"
+  ],
   "scripts": {
     "lint": "eslint '{giraffe,stories}/src/**/*.{ts,tsx}'",
     "prettier": "prettier --config .prettierrc.json --check '{giraffe,stories}/**/*.{ts,tsx}'",


### PR DESCRIPTION
Adds an onClick handler to the `annotationLine` polygon [triangle] pin. This would enable the retrieval of the ID of the annotation clicked, in UI and perform edit/delete operations on the respective annotations. 

This PR will also adjust where the tooltip is rendered so that it isn't in the way of the triangle target.

Will have to bump up Giraffe version for publishing. 

Screenshot for reference: 

<img width="894" alt="Screen Shot 2021-03-25 at 12 53 23 PM" src="https://user-images.githubusercontent.com/18511823/112547983-bf4cb780-8d78-11eb-924b-3b7ae607725f.png">

