### PR TITLE
fix: update the doc link

### DIFF
--- a/giraffe/src/components/Geo.tsx
+++ b/giraffe/src/components/Geo.tsx
@@ -226,7 +226,7 @@ const Geo: FunctionComponent<Props> = props => {
           >
             Results are truncated.
             <a
-              href="https://docs.influxdata.com/chronograf/latest/guides/geo-widget#data-downsampling"
+              href="https://docs.influxdata.com/influxdb/cloud/visualize-data/visualization-types/map/"
               target="_blank"
             >
               More...


### PR DESCRIPTION
closes #519 
Alright so with this link updated this issue is closed. Also i checked with the truncated limits and although mapbox does not have any specific defined limits in the docs. And i did test the marker map since thats currently active map and it seems like beyond 2000 led to lag. I am writing and linking a separate issue to determine if we cause the lag or if its mapbox