### PR TITLE
fix: use better positioning for the AnnotationTooltip caret and add maxWitdh to tooltip

### DIFF
--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -50,7 +50,7 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
   )
 
   let tooltipCaretStyle: CSSProperties = {
-    position: 'absolute',
+    position: 'fixed',
     borderWidth: '7px',
     borderStyle: 'solid',
     borderColor: 'transparent',
@@ -62,15 +62,15 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
     tooltipCaretStyle = {
       ...tooltipCaretStyle,
       borderTopColor: data.color,
-      left: '50%',
-      top: '100%',
+      left: `${clampedXOffset + position.x}px`,
+      top: `${clampedYOffset + position.y}px`,
       transform: 'translateX(-50%)',
     }
 
     tooltipCaretFillStyle = {
       ...tooltipCaretStyle,
       borderTopColor: backgroundColor,
-      top: 'calc(100% - 4px)',
+      top: `calc(${clampedYOffset + position.y}px - 4px)`,
       zIndex: 3,
     }
   }
@@ -78,6 +78,7 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
   if (dimension === 'y') {
     tooltipCaretStyle = {
       ...tooltipCaretStyle,
+      position: 'absolute',
       borderRightColor: data.color,
       top: '50%',
       right: '100%',

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -3,7 +3,10 @@ import {FunctionComponent} from 'react'
 import {createPortal} from 'react-dom'
 
 import {Config, AnnotationMark, TooltipPosition} from '../types'
-import {ANNOTATION_TOOLTIP_CONTAINER_NAME} from '../constants'
+import {
+  ANNOTATION_TOOLTIP_CONTAINER_NAME,
+  ANNOTATION_DEFAULT_MAX_WIDTH,
+} from '../constants'
 import {useTooltipElement} from '../utils/useTooltipElement'
 
 interface Props {
@@ -106,6 +109,8 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
         boxShadow: `0 0 4px 0px ${data.color}`,
         borderRadius: '3px',
         padding: '10px',
+        display: 'inline-block',
+        maxWidth: `${ANNOTATION_DEFAULT_MAX_WIDTH}px`,
       }}
     >
       <div style={tooltipCaretStyle} />

--- a/giraffe/src/constants/index.ts
+++ b/giraffe/src/constants/index.ts
@@ -143,6 +143,7 @@ export const CLOCKFACE_Z_INDEX = 9599
 export const TICK_COUNT_LIMIT = 1000
 
 export const ANNOTATION_DEFAULT_HOVER_MARGIN = 20
+export const ANNOTATION_DEFAULT_MAX_WIDTH = 200
 
 export const ANNOTATION_TOOLTIP_CONTAINER_NAME =
   'giraffe-annotation-tooltip-container'

--- a/stories/src/helpers.tsx
+++ b/stories/src/helpers.tsx
@@ -11,8 +11,8 @@ export const PlotContainer = ({children}) => (
   <div
     style={{
       width: 'calc(100vw - 100px)',
-      height: 'calc(100vh - 100px)',
-      margin: '50px',
+      height: 'calc(100vh - 125px)',
+      margin: '75px 50px 50px 50px',
     }}
   >
     {children}


### PR DESCRIPTION
closes: #525
addresses: https://github.com/influxdata/ui/issues/1121

we realized that we need a way to handle the tooltip caret position, [issues:  #525, https://github.com/influxdata/ui/issues/1121]. This PR attempts to provide a solution. Following is a brief about of how how we ended up with this solution. 

First we thought that the issue in https://github.com/influxdata/ui/issues/1121 would be solved by limiting the width of the tooltip box. But we quickly realized that there are some edge cases (literally) which we don't think would be covered by just limiting the size of the tooltip.

For example, this annotation in the corner renders its caret, in between the two lines, because at it's current state its programmed to render the caret in the middle of the tooltip box.

![image](https://user-images.githubusercontent.com/18511823/113816748-13b54700-972a-11eb-8366-aed97640d517.png)

To address this, one solution is to re-think the caret position. Currently, we position the caret in the center of the tooltip box, if we position it on top of the annotation line instead, we can handle those edge-case corner renders. This is what it looks like after the change:

<img width="242" alt="Screen Shot 2021-04-06 at 10 49 03 PM" src="https://user-images.githubusercontent.com/18511823/113816867-4b23f380-972a-11eb-8d07-9e94774dd82d.png">

<img width="1246" alt="Screen Shot 2021-04-06 at 10 48 57 PM" src="https://user-images.githubusercontent.com/18511823/113816886-5119d480-972a-11eb-81f8-4d72115464a5.png">

In the UI with a long name:

<img width="664" alt="Screen Shot 2021-04-08 at 10 54 57 AM" src="https://user-images.githubusercontent.com/18511823/114074110-df8c7400-9858-11eb-98fd-7b95b348784d.png">
