### PR TITLE
fix: filter out the closest annotation to the mouse to show tootip on

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/utils/annotationData.ts
+++ b/giraffe/src/utils/annotationData.ts
@@ -1,4 +1,5 @@
 import {AnnotationMark, LineHoverDimension, Scale} from '../types'
+import {min} from 'd3-array'
 
 export const getAnnotationsPositions = (
   annotationData: AnnotationMark[],
@@ -33,6 +34,10 @@ const isWithinHoverableArea = (
   return (
     startValue - margin <= hoverPosition && stopValue + margin >= hoverPosition
   )
+}
+
+const distanceToMousePointer = (annotationMark: AnnotationMark, hoverPosition: number) => {
+  return Math.abs(hoverPosition - annotationMark.startValue)
 }
 
 /***********************************************************************************
@@ -75,6 +80,19 @@ export const getAnnotationHoverIndices = (
             ))
         ) {
           result.push(i)
+
+          if (result.length > 1) {
+            const distances = []
+            result.forEach(i => {
+              const dist = distanceToMousePointer(
+                annotationData[i],
+                dimension === 'x' ? hoverX : hoverY
+              )
+              distances.push(dist)
+            })
+            const closestAnnotation = result[distances.indexOf(min(distances))]
+            result = [closestAnnotation]
+          }
         }
         return result
       }, [])

--- a/giraffe/src/utils/annotationData.ts
+++ b/giraffe/src/utils/annotationData.ts
@@ -40,6 +40,24 @@ const distanceToMousePointer = (
   annotationMark: AnnotationMark,
   hoverPosition: number
 ) => {
+  // check if the Annotation is a range type
+  if (annotationMark.startValue !== annotationMark.stopValue) {
+    if (
+      annotationMark.startValue <= hoverPosition &&
+      hoverPosition <= annotationMark.stopValue
+    ) {
+      // hover position is in the range, effective distance is 0
+      return 0
+    } else {
+      const distanceToStartLine = Math.abs(
+        hoverPosition - annotationMark.startValue
+      )
+      const distanceToStopLine = Math.abs(
+        hoverPosition - annotationMark.stopValue
+      )
+      return Math.min(distanceToStartLine, distanceToStopLine)
+    }
+  }
   return Math.abs(hoverPosition - annotationMark.startValue)
 }
 

--- a/giraffe/src/utils/annotationData.ts
+++ b/giraffe/src/utils/annotationData.ts
@@ -48,18 +48,17 @@ const distanceToMousePointer = (
     ) {
       // hover position is in the range, effective distance is 0
       return 0
-    } else {
-      // distance is the shortest of:
-      // the distance between hoverPosition and annotation.startValue,
-      // and the distance between hoverPosition and annotation.stopValue
-      const distanceToStartLine = Math.abs(
-        hoverPosition - annotationMark.startValue
-      )
-      const distanceToStopLine = Math.abs(
-        hoverPosition - annotationMark.stopValue
-      )
-      return Math.min(distanceToStartLine, distanceToStopLine)
     }
+    // distance is the shortest of:
+    // the distance between hoverPosition and annotation.startValue,
+    // and the distance between hoverPosition and annotation.stopValue
+    const distanceToStartLine = Math.abs(
+      hoverPosition - annotationMark.startValue
+    )
+    const distanceToStopLine = Math.abs(
+      hoverPosition - annotationMark.stopValue
+    )
+    return Math.min(distanceToStartLine, distanceToStopLine)
   }
   return Math.abs(hoverPosition - annotationMark.startValue)
 }

--- a/giraffe/src/utils/annotationData.ts
+++ b/giraffe/src/utils/annotationData.ts
@@ -49,7 +49,7 @@ const distanceToMousePointer = (
       // hover position is in the range, effective distance is 0
       return 0
     } else {
-      // hoverPosition has a distance that is shortest of:
+      // distance is the shortest of:
       // the distance between hoverPosition and annotation.startValue,
       // and the distance between hoverPosition and annotation.stopValue
       const distanceToStartLine = Math.abs(

--- a/giraffe/src/utils/annotationData.ts
+++ b/giraffe/src/utils/annotationData.ts
@@ -49,6 +49,9 @@ const distanceToMousePointer = (
       // hover position is in the range, effective distance is 0
       return 0
     } else {
+      // hoverPosition has a distance that is shortest of:
+      // the distance between hoverPosition and annotation.startValue,
+      // and the distance between hoverPosition and annotation.stopValue
       const distanceToStartLine = Math.abs(
         hoverPosition - annotationMark.startValue
       )

--- a/giraffe/src/utils/annotationData.ts
+++ b/giraffe/src/utils/annotationData.ts
@@ -36,7 +36,10 @@ const isWithinHoverableArea = (
   )
 }
 
-const distanceToMousePointer = (annotationMark: AnnotationMark, hoverPosition: number) => {
+const distanceToMousePointer = (
+  annotationMark: AnnotationMark,
+  hoverPosition: number
+) => {
   return Math.abs(hoverPosition - annotationMark.startValue)
 }
 


### PR DESCRIPTION
closes: #531
https://github.com/influxdata/ui/issues/1117

 Tooltips are covering each other when annotations are close to each other. We want to only show a single annotation tooltip at once.

We filter out the annotation to show the tooltip, by calculating what annotation is closest by distance to the mouse pointer.

TODO: bump up giraffe version for publishing
Video:


https://user-images.githubusercontent.com/18511823/114090196-f6889180-986b-11eb-805c-54b67d2095c6.mov

