### PR TITLE
fix: pass <Plot> children down

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/Plot.tsx
+++ b/giraffe/src/components/Plot.tsx
@@ -11,6 +11,7 @@ interface PlotProps {
 }
 
 export const Plot: FunctionComponent<PlotProps> = ({
+  children,
   config,
   axesCanvasRef = useRef<HTMLCanvasElement>(null),
   layerCanvasRef = useRef<HTMLCanvasElement>(null),
@@ -24,7 +25,9 @@ export const Plot: FunctionComponent<PlotProps> = ({
           height={config.height}
           layerCanvasRef={layerCanvasRef}
           width={config.width}
-        />
+        >
+          {children}
+        </PlotResizer>
       </div>
     )
   }
@@ -38,7 +41,9 @@ export const Plot: FunctionComponent<PlotProps> = ({
           height={height}
           layerCanvasRef={layerCanvasRef}
           width={width}
-        />
+        >
+          {children}
+        </PlotResizer>
       )}
     </AutoSizer>
   )


### PR DESCRIPTION
Fixes failing e2e tests in ui's pipeline where the version is 2.7.2 or 2.7.3

`<Plot>` children were not being passed down and therefore the existing code in ui ignored everything between `<Plot></Plot>` such as the old way of doing Graph + Single Stat