### PR TITLE
fix: fix tooltip positioning when on the edge of the screen

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/constants/index.ts
+++ b/giraffe/src/constants/index.ts
@@ -143,7 +143,7 @@ export const CLOCKFACE_Z_INDEX = 9599
 export const TICK_COUNT_LIMIT = 1000
 
 export const ANNOTATION_DEFAULT_HOVER_MARGIN = 20
-export const ANNOTATION_DEFAULT_MAX_WIDTH = 200
+export const ANNOTATION_DEFAULT_MAX_WIDTH = 250
 
 export const ANNOTATION_TOOLTIP_CONTAINER_NAME =
   'giraffe-annotation-tooltip-container'

--- a/giraffe/src/utils/legend/useTooltipStyle.ts
+++ b/giraffe/src/utils/legend/useTooltipStyle.ts
@@ -147,8 +147,8 @@ export const useAnnotationStyle = (
       return {
         display: 'inline-block',
         position: 'fixed',
-        top: `${clampedY}px`,
         left: `${clampedX}px`,
+        top: `${clampedY}px`,
         zIndex: CLOCKFACE_Z_INDEX + LEAFLET_Z_INDEX + 1,
       }
     }

--- a/giraffe/src/utils/legend/useTooltipStyle.ts
+++ b/giraffe/src/utils/legend/useTooltipStyle.ts
@@ -137,7 +137,7 @@ export const useAnnotationStyle = (
 
       // When the annotation is in the far edge of the screen, the position.left value
       // overrides the width of the tooltip and makes its width smaller than its max-width.
-      // Fix the left value so that the tooltip is at its max width.
+      // Position the left edge of the tooltip such that the tooltip occupies its max width.
       if (
         window.innerWidth - clampedX < ANNOTATION_DEFAULT_MAX_WIDTH &&
         tooltipWidth >= ANNOTATION_DEFAULT_MAX_WIDTH

--- a/giraffe/src/utils/legend/useTooltipStyle.ts
+++ b/giraffe/src/utils/legend/useTooltipStyle.ts
@@ -1,6 +1,6 @@
 import {useLayoutStyle} from '../useLayoutStyle'
 import {useRefMousePos} from '../useMousePos'
-import {CLOCKFACE_Z_INDEX, LEAFLET_Z_INDEX} from '../../constants'
+import {ANNOTATION_DEFAULT_MAX_WIDTH, CLOCKFACE_Z_INDEX, LEAFLET_Z_INDEX} from '../../constants'
 import {AnnotationTooltipOptions} from '../../types'
 
 const MARGIN_X = 30
@@ -107,9 +107,12 @@ export const useAnnotationStyle = (
           display: 'none',
         }
       }
-
+      // xOffset : start x-coordinate value of the plot layer
+      // yOffset : start y-coordinate value of the plot layer
+      // (xOffset, yOffset) is the origin of this plot
+      // dx      : the distance to the middle of the tooltip from the parent plot container left edge
       let dx = xOffset - tooltipWidth / 2
-      if (dx + x + tooltipWidth > window.innerWidth) {
+      if (dx + tooltipWidth > window.innerWidth) {
         dx = 0 - tooltipWidth / 2 + window.innerWidth - (x + xOffset)
       }
       let dy = Math.max(yOffset - tooltipHeight, 0)
@@ -125,16 +128,23 @@ export const useAnnotationStyle = (
         }
       }
 
-      const clampedX = Math.round(Math.max(dx + x, x))
+      let clampedX = Math.round(x + dx)
       const clampedY = Math.round(dy + y)
+
+      // When the annotation is in the far edge of the screen, the position.left value
+      // overrides the width of the tooltip and makes its width smaller than its max-width.
+      // Fix the left value so that the tooltip is at its max width.
+      if (window.innerWidth - clampedX < ANNOTATION_DEFAULT_MAX_WIDTH) {
+        clampedX = window.innerWidth - ANNOTATION_DEFAULT_MAX_WIDTH
+      }
 
       /* Geo widget maps are rendered with z-index: 399, we have to set it above
        that so that tooltips are not rendered/are hidden below the map, */
       return {
-        display: 'inline',
+        display: 'inline-block',
         position: 'fixed',
-        left: `${clampedX}px`,
         top: `${clampedY}px`,
+        left: `${clampedX}px`,
         zIndex: CLOCKFACE_Z_INDEX + LEAFLET_Z_INDEX + 1,
       }
     }

--- a/giraffe/src/utils/legend/useTooltipStyle.ts
+++ b/giraffe/src/utils/legend/useTooltipStyle.ts
@@ -138,7 +138,10 @@ export const useAnnotationStyle = (
       // When the annotation is in the far edge of the screen, the position.left value
       // overrides the width of the tooltip and makes its width smaller than its max-width.
       // Fix the left value so that the tooltip is at its max width.
-      if (window.innerWidth - clampedX < ANNOTATION_DEFAULT_MAX_WIDTH) {
+      if (
+        window.innerWidth - clampedX < ANNOTATION_DEFAULT_MAX_WIDTH &&
+        tooltipWidth >= ANNOTATION_DEFAULT_MAX_WIDTH
+      ) {
         clampedX = window.innerWidth - ANNOTATION_DEFAULT_MAX_WIDTH
       }
 

--- a/giraffe/src/utils/legend/useTooltipStyle.ts
+++ b/giraffe/src/utils/legend/useTooltipStyle.ts
@@ -1,6 +1,10 @@
 import {useLayoutStyle} from '../useLayoutStyle'
 import {useRefMousePos} from '../useMousePos'
-import {ANNOTATION_DEFAULT_MAX_WIDTH, CLOCKFACE_Z_INDEX, LEAFLET_Z_INDEX} from '../../constants'
+import {
+  ANNOTATION_DEFAULT_MAX_WIDTH,
+  CLOCKFACE_Z_INDEX,
+  LEAFLET_Z_INDEX,
+} from '../../constants'
 import {AnnotationTooltipOptions} from '../../types'
 
 const MARGIN_X = 30


### PR DESCRIPTION
Closes: https://github.com/influxdata/giraffe/issues/535

We had an edge case that we missed when calculating the tooltip position. Previous behavior would calculate the positioning when the annotation is on the edge. This PR fixes it so the calculation is correct and the tooltip position is right. 

Co-authored by: Bucky Schwarz (@hoorayimhelping) 

Screenshot:

Big sized tooltip:

<img width="1440" alt="Screen Shot 2021-04-13 at 5 49 53 PM" src="https://user-images.githubusercontent.com/18511823/114638521-a866fa00-9c80-11eb-9093-1297990507f8.png">

Medium-sized tooltip:

<img width="1440" alt="Screen Shot 2021-04-13 at 6 16 00 PM" src="https://user-images.githubusercontent.com/18511823/114640240-82435900-9c84-11eb-8301-07be2b9fe443.png">


Small sized tooltip:

<img width="1440" alt="Screen Shot 2021-04-13 at 6 18 00 PM" src="https://user-images.githubusercontent.com/18511823/114640266-95562900-9c84-11eb-82de-38929edd08a3.png">


Annotation away from the edge works fine too:

<img width="1440" alt="Screen Shot 2021-04-13 at 6 19 00 PM" src="https://user-images.githubusercontent.com/18511823/114640323-b9b20580-9c84-11eb-85ae-bdd62294165a.png">

