### PR TITLE
feat: small caret size and dashed annnotation line

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -16,8 +16,8 @@ interface AnnotationLineProps {
 
 // These could become configurable values
 const PIN_CIRCLE_RADIUS = 4
-const PIN_TRIANGLE_HEIGHT = 18
-const PIN_TRIANGLE_WIDTH = 11
+const PIN_TRIANGLE_HEIGHT = 8
+const PIN_TRIANGLE_WIDTH = 6
 
 export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
   const {dimension, color, strokeWidth, startValue, length, pin} = props
@@ -70,7 +70,21 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
   }
 
   return (
+    // a separate line layer on the annotation line is required on top,
+    // because the dashed line doesnt allow for a continuous click-able target
+    // this top layer has an opacity of 0 so is not visible.
     <>
+      <line
+        x1={clampedStart}
+        x2={clampedStart}
+        y1="0"
+        y2={length}
+        stroke={color}
+        strokeOpacity={0}
+        strokeWidth={strokeWidth}
+        id={props.id}
+        className={`${styles['giraffe-annotation-hover']} giraffe-annotation-line`}
+      />
       <line
         x1={clampedStart}
         x2={clampedStart}
@@ -80,6 +94,7 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
         strokeWidth={strokeWidth}
         id={props.id}
         className={`${styles['giraffe-annotation-hover']} giraffe-annotation-line`}
+        strokeDasharray={'4'}
       />
       {pin === 'circle' &&
         createElement('circle', {


### PR DESCRIPTION
This PR addresses some annotation UX/Visuals stuff: 

The issues were:
* The caret (click target) on the top was a bit too big and ended up covering too much of the graph.
* The annotation lines being solid feel intrusive and that there wasn't enough of a separation between annotations and the actual graph.

We address this by making the caret small and the annotation line a dashed line.

Screenshot:

<img width="800" alt="Screen Shot 2021-04-14 at 4 16 48 PM" src="https://user-images.githubusercontent.com/18511823/114792465-45876880-9d3d-11eb-834a-c68aef6f5041.png">


