### PR TITLE
fix: apply 'break-word' to prevent overflow of annotation tooltip text

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.7.6",
+  "version": "2.7.7",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -96,6 +96,10 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
     }
   }
 
+  const textContainerStyle: CSSProperties = {
+    overflowWrap: 'break-word',
+  }
+
   return createPortal(
     <div
       className="giraffe-annotation-tooltip"
@@ -115,8 +119,8 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
     >
       <div style={tooltipCaretStyle} />
       <div style={tooltipCaretFillStyle} />
-      <div style={{overflowWrap: 'break-word'}}>{data.title}</div>
-      <div style={{overflowWrap: 'break-word'}}>{data.description}</div>
+      <div style={textContainerStyle}>{data.title}</div>
+      <div style={textContainerStyle}>{data.description}</div>
     </div>,
     annotationTooltipElement
   )

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -115,8 +115,8 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
     >
       <div style={tooltipCaretStyle} />
       <div style={tooltipCaretFillStyle} />
-      <div>{data.title}</div>
-      <div>{data.description}</div>
+      <div style={{overflowWrap: 'break-word'}}>{data.title}</div>
+      <div style={{overflowWrap: 'break-word'}}>{data.description}</div>
     </div>,
     annotationTooltipElement
   )


### PR DESCRIPTION
closes: #543

This fixes an issue where the text is a single very long string without breaks was overflowing out of the div.

fix: add css property:  `overflowWrap: 'break-word'`

Note for the reviewer: I tried making a variable to apply the common style to both the title and description `div` elements but kept getting typescript errors. The following was not working.

```
const textContainerStyle = {
    overflowWrap: 'break-word',
  }

...

 <div style={textContainerStyle}>{data.title}</div>
```

Before vs After:

<img width="1440" alt="Screen Shot 2021-04-16 at 1 13 16 PM" src="https://user-images.githubusercontent.com/18511823/115079465-0fb9bf80-9eb6-11eb-8e94-8d8e8e773c1c.png">

<img width="614" alt="Screen Shot 2021-04-16 at 1 13 58 PM" src="https://user-images.githubusercontent.com/18511823/115079466-10eaec80-9eb6-11eb-9bcd-d7629cf02bae.png">

