### PR TITLE
chore: use fullscreen layout in storybook to remove unncessary scrollbars

### DIFF
--- a/stories/.storybook/config.js
+++ b/stories/.storybook/config.js
@@ -14,6 +14,7 @@ addParameters({
     }),
     panelPosition: 'right',
   },
+  layout: 'fullscreen',
 })
 
 function loadStories() {


### PR DESCRIPTION
Looks like Storybook changed their styling of the page to insert padding when "fullscreen" is not selected. This causes scrollbars to appear.

Let's remove them.

BEFORE:
<img width="1680" alt="Screen Shot 2021-04-26 at 3 41 47 PM" src="https://user-images.githubusercontent.com/10736577/116160146-5d98a980-a6a6-11eb-98f8-deded02b9c18.png">

AFTER:
<img width="1680" alt="Screen Shot 2021-04-26 at 3 41 54 PM" src="https://user-images.githubusercontent.com/10736577/116160180-65584e00-a6a6-11eb-9d9e-31d7cb332ef6.png">

