### PR TITLE
feat: add additional columns to Static Legend for stacked line layer

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/StaticLegendBox.tsx
+++ b/giraffe/src/components/StaticLegendBox.tsx
@@ -53,11 +53,17 @@ export const StaticLegendBox: FunctionComponent<StaticLegendBoxProps> = props =>
   const layerConfig = configOverride.layers[staticLegendOverride.layer]
   const valueColumnKey = layerConfig[staticLegendOverride.valueAxis]
 
+  const position = Array.isArray(
+    (spec as LineLayerSpec).stackedDomainValueColumn
+  )
+    ? 'stacked'
+    : 'overlaid'
   const legendData = convertLineSpec(
     staticLegendOverride,
     spec as LineLayerSpec,
     columnFormatter,
-    valueColumnKey
+    valueColumnKey,
+    position
   )
   const {
     legendBackgroundColor: backgroundColor,

--- a/giraffe/src/transforms/line.ts
+++ b/giraffe/src/transforms/line.ts
@@ -117,13 +117,20 @@ export const lineTransform = (
     lineData[groupID].xs.push(x)
     lineData[groupID].ys.push(y)
 
+    // remember the latest (most recent) index for each group
     if (!isDefined(latestIndices[groupID])) {
       latestIndices[groupID] = i
     } else if (yColumnKey === TIME) {
-      if (y > yCol[latestIndices[groupID]]) {
+      if (
+        y > yCol[latestIndices[groupID]] ||
+        !isDefined(yCol[latestIndices[groupID]])
+      ) {
         latestIndices[groupID] = i
       }
-    } else if (x > xCol[latestIndices[groupID]]) {
+    } else if (
+      x > xCol[latestIndices[groupID]] ||
+      !isDefined(xCol[latestIndices[groupID]])
+    ) {
       latestIndices[groupID] = i
     }
 

--- a/giraffe/src/transforms/line.ts
+++ b/giraffe/src/transforms/line.ts
@@ -1,7 +1,7 @@
 import {
   CumulativeValuesByTime,
   DomainLabel,
-  LatestValueIndexMap,
+  LatestIndexMap,
   LineData,
   LineLayerSpec,
   LinePosition,
@@ -74,7 +74,10 @@ export const lineTransform = (
   const fillScale = getNominalColorScale(fillColumnMap, colors)
   const lineData: LineData = {}
   let stackedValuesByTime: CumulativeValuesByTime = {}
-  const latestValueIndices: LatestValueIndexMap = {}
+  const latestIndices: LatestIndexMap = {
+    xs: {},
+    ys: {},
+  }
 
   if (position === 'stacked') {
     if (yColumnKey === VALUE) {
@@ -115,13 +118,8 @@ export const lineTransform = (
     }
     lineData[groupID].xs.push(x)
     lineData[groupID].ys.push(y)
-
-    if (
-      (yColumnKey === VALUE && y === y) ||
-      (xColumnKey === VALUE && x === x)
-    ) {
-      latestValueIndices[groupID] = i
-    }
+    latestIndices.xs[groupID] = i
+    latestIndices.ys[groupID] = i
 
     if (x < xMin) {
       xMin = x
@@ -160,7 +158,7 @@ export const lineTransform = (
     xColumnType: table.getColumnType(xColumnKey),
     yColumnType: table.getColumnType(yColumnKey),
     scales: {fill: fillScale},
-    columnGroupMaps: {fill: fillColumnMap, latestValueIndices},
+    columnGroupMaps: {fill: fillColumnMap, latestIndices},
     stackedDomainValueColumn,
   }
 }

--- a/giraffe/src/transforms/line.ts
+++ b/giraffe/src/transforms/line.ts
@@ -75,10 +75,7 @@ export const lineTransform = (
   const fillScale = getNominalColorScale(fillColumnMap, colors)
   const lineData: LineData = {}
   let stackedValuesByTime: CumulativeValuesByTime = {}
-  const latestIndices: LatestIndexMap = {
-    xs: {},
-    ys: {},
-  }
+  const latestIndices: LatestIndexMap = {}
 
   if (position === 'stacked') {
     if (yColumnKey === VALUE) {
@@ -120,19 +117,14 @@ export const lineTransform = (
     lineData[groupID].xs.push(x)
     lineData[groupID].ys.push(y)
 
-    if (
-      yColumnKey === TIME &&
-      (!isDefined(latestIndices.ys[groupID]) ||
-        y > yCol[latestIndices.ys[groupID]])
-    ) {
-      latestIndices.ys[groupID] = i
-      latestIndices.xs[groupID] = i
-    } else if (
-      !isDefined(latestIndices.xs[groupID]) ||
-      x > xCol[latestIndices.xs[groupID]]
-    ) {
-      latestIndices.xs[groupID] = i
-      latestIndices.ys[groupID] = i
+    if (!isDefined(latestIndices[groupID])) {
+      latestIndices[groupID] = i
+    } else if (yColumnKey === TIME) {
+      if (y > yCol[latestIndices[groupID]]) {
+        latestIndices[groupID] = i
+      }
+    } else if (x > xCol[latestIndices[groupID]]) {
+      latestIndices[groupID] = i
     }
 
     if (x < xMin) {

--- a/giraffe/src/transforms/line.ts
+++ b/giraffe/src/transforms/line.ts
@@ -8,9 +8,10 @@ import {
   NumericColumnData,
   Table,
 } from '../types'
-import {FILL, VALUE} from '../constants/columnKeys'
+import {FILL, TIME, VALUE} from '../constants/columnKeys'
 import {createGroupIDColumn, getNominalColorScale} from './'
 import {getDomainDataFromLines} from '../utils/lineData'
+import {isDefined} from '../utils/isDefined'
 
 export const mapCumulativeValuesToTimeRange = (
   timesCol: NumericColumnData,
@@ -118,8 +119,21 @@ export const lineTransform = (
     }
     lineData[groupID].xs.push(x)
     lineData[groupID].ys.push(y)
-    latestIndices.xs[groupID] = i
-    latestIndices.ys[groupID] = i
+
+    if (
+      yColumnKey === TIME &&
+      (!isDefined(latestIndices.ys[groupID]) ||
+        y > yCol[latestIndices.ys[groupID]])
+    ) {
+      latestIndices.ys[groupID] = i
+      latestIndices.xs[groupID] = i
+    } else if (
+      !isDefined(latestIndices.xs[groupID]) ||
+      x > xCol[latestIndices.xs[groupID]]
+    ) {
+      latestIndices.xs[groupID] = i
+      latestIndices.ys[groupID] = i
+    }
 
     if (x < xMin) {
       xMin = x

--- a/giraffe/src/transforms/line.ts
+++ b/giraffe/src/transforms/line.ts
@@ -1,6 +1,7 @@
 import {
   CumulativeValuesByTime,
   DomainLabel,
+  LatestValueIndexMap,
   LineData,
   LineLayerSpec,
   LinePosition,
@@ -73,6 +74,7 @@ export const lineTransform = (
   const fillScale = getNominalColorScale(fillColumnMap, colors)
   const lineData: LineData = {}
   let stackedValuesByTime: CumulativeValuesByTime = {}
+  const latestValueIndices: LatestValueIndexMap = {}
 
   if (position === 'stacked') {
     if (yColumnKey === VALUE) {
@@ -114,6 +116,13 @@ export const lineTransform = (
     lineData[groupID].xs.push(x)
     lineData[groupID].ys.push(y)
 
+    if (
+      (yColumnKey === VALUE && y === y) ||
+      (xColumnKey === VALUE && x === x)
+    ) {
+      latestValueIndices[groupID] = i
+    }
+
     if (x < xMin) {
       xMin = x
     }
@@ -139,7 +148,6 @@ export const lineTransform = (
     )
   }
 
-  //todo:  look at stackdomainvalue column for stacked data for static legend
   return {
     type: 'line',
     inputTable,
@@ -152,7 +160,7 @@ export const lineTransform = (
     xColumnType: table.getColumnType(xColumnKey),
     yColumnType: table.getColumnType(yColumnKey),
     scales: {fill: fillScale},
-    columnGroupMaps: {fill: fillColumnMap},
+    columnGroupMaps: {fill: fillColumnMap, latestValueIndices},
     stackedDomainValueColumn,
   }
 }

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -809,12 +809,12 @@ export interface ColumnGroupMap {
 }
 
 export interface LatestIndexMap {
-  xs: {
-    [columnKey: string]: number
-  }
-  ys: {
-    [columnKey: string]: number
-  }
+  // each Column in a Table contains a single array even when there are multiple series
+  //   for example, a line graph has multiple lines (series), but each Column has only one array
+  // Static Legend needs to know where each line (series) ends, to render the "latest"
+  //   - "latest" is the timestamp with the highest value in each line (series)
+  //   - Keep a map of the highest timestamp's index for each series
+  [columnKey: string]: number
 }
 
 export type LineData = {

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -622,7 +622,7 @@ export interface LineLayerSpec {
   }
   columnGroupMaps: {
     fill: ColumnGroupMap
-    latestValueIndices: LatestValueIndexMap
+    latestIndices: LatestIndexMap
   }
   stackedDomainValueColumn?: NumericColumnData
 }
@@ -808,8 +808,13 @@ export interface ColumnGroupMap {
   mappings: Array<{[columnKey: string]: any}>
 }
 
-export interface LatestValueIndexMap {
-  [columnKey: string]: number
+export interface LatestIndexMap {
+  xs: {
+    [columnKey: string]: number
+  }
+  ys: {
+    [columnKey: string]: number
+  }
 }
 
 export type LineData = {

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -622,6 +622,7 @@ export interface LineLayerSpec {
   }
   columnGroupMaps: {
     fill: ColumnGroupMap
+    latestValueIndices: LatestValueIndexMap
   }
   stackedDomainValueColumn?: NumericColumnData
 }
@@ -805,6 +806,10 @@ export interface ColumnGroupMap {
   // A group ID `i` takes on the values specified by `mappings[i]` for the
   // column keys that specify the grouping
   mappings: Array<{[columnKey: string]: any}>
+}
+
+export interface LatestValueIndexMap {
+  [columnKey: string]: number
 }
 
 export type LineData = {

--- a/giraffe/src/utils/fixtures/randomTable.ts
+++ b/giraffe/src/utils/fixtures/randomTable.ts
@@ -1,5 +1,5 @@
-import {newTable} from './newTable'
-import {LayerTypes} from '../types'
+import {newTable} from '../newTable'
+import {LayerTypes} from '../../types'
 import memoizeOne from 'memoize-one'
 
 const getRandomNumber = (

--- a/giraffe/src/utils/legend/sort.test.ts
+++ b/giraffe/src/utils/legend/sort.test.ts
@@ -1,5 +1,5 @@
 import {getDataSortOrder} from './sort'
-import {getRandomTable} from '../randomTable'
+import {getRandomTable} from '../fixtures/randomTable'
 import {lineTransform} from '../../transforms/line'
 import {NINETEEN_EIGHTY_FOUR} from '../../constants/colorSchemes'
 import {DomainLabel} from '../../types'

--- a/giraffe/src/utils/legend/sort.test.ts
+++ b/giraffe/src/utils/legend/sort.test.ts
@@ -30,9 +30,7 @@ describe('getDataSortOrder', () => {
       lineOption
     )
 
-    const latestIndices = Object.values(
-      lineSpec.columnGroupMaps.latestIndices.ys
-    )
+    const latestIndices = Object.values(lineSpec.columnGroupMaps.latestIndices)
     const sortOrder = getDataSortOrder(
       lineSpec.lineData,
       latestIndices,
@@ -54,9 +52,7 @@ describe('getDataSortOrder', () => {
     )
     const {stackedDomainValueColumn} = lineSpec
 
-    const latestIndices = Object.values(
-      lineSpec.columnGroupMaps.latestIndices.ys
-    )
+    const latestIndices = Object.values(lineSpec.columnGroupMaps.latestIndices)
     const sortOrder = getDataSortOrder(
       lineSpec.lineData,
       latestIndices,

--- a/giraffe/src/utils/legend/sort.test.ts
+++ b/giraffe/src/utils/legend/sort.test.ts
@@ -1,0 +1,81 @@
+import {getDataSortOrder} from './sort'
+import {getRandomTable} from '../randomTable'
+import {lineTransform} from '../../transforms/line'
+import {NINETEEN_EIGHTY_FOUR} from '../../constants/colorSchemes'
+import {DomainLabel} from '../../types'
+
+describe('getDataSortOrder', () => {
+  const xColKey = '_time'
+  const yColKey = '_value'
+  const maxValue = 100
+  const numberOfRecords = 200
+  const recordsPerLine = 10
+  const fillColKeys = ['cpu', 'host', 'machine']
+  const table = getRandomTable(
+    maxValue,
+    true,
+    numberOfRecords,
+    recordsPerLine,
+    fillColKeys
+  )
+
+  it('overlaid line graphs should be unsorted', () => {
+    const lineOption = 'overlaid'
+    const lineSpec = lineTransform(
+      table,
+      xColKey,
+      yColKey,
+      fillColKeys,
+      NINETEEN_EIGHTY_FOUR,
+      lineOption
+    )
+
+    const latestIndices = Object.values(
+      lineSpec.columnGroupMaps.latestIndices.ys
+    )
+    const sortOrder = getDataSortOrder(
+      lineSpec.lineData,
+      latestIndices,
+      lineOption,
+      DomainLabel.Y
+    )
+    expect(latestIndices).toEqual(sortOrder)
+  })
+
+  it('stacked line graphs should be sorted in descending order', () => {
+    const lineOption = 'stacked'
+    const lineSpec = lineTransform(
+      table,
+      xColKey,
+      yColKey,
+      fillColKeys,
+      NINETEEN_EIGHTY_FOUR,
+      lineOption
+    )
+    const {stackedDomainValueColumn} = lineSpec
+
+    const latestIndices = Object.values(
+      lineSpec.columnGroupMaps.latestIndices.ys
+    )
+    const sortOrder = getDataSortOrder(
+      lineSpec.lineData,
+      latestIndices,
+      lineOption,
+      DomainLabel.Y
+    )
+    expect(sortOrder.length).toBeGreaterThanOrEqual(2)
+    sortOrder.forEach((columnIndex, index) => {
+      if (index < sortOrder.length - 1) {
+        expect(
+          stackedDomainValueColumn[columnIndex] >
+            stackedDomainValueColumn[columnIndex + 1]
+        )
+      } else {
+        expect(
+          stackedDomainValueColumn[columnIndex] <
+            stackedDomainValueColumn[columnIndex + 1]
+        )
+      }
+    })
+  })
+})

--- a/giraffe/src/utils/legend/sort.test.ts
+++ b/giraffe/src/utils/legend/sort.test.ts
@@ -19,7 +19,7 @@ describe('getDataSortOrder', () => {
     fillColKeys
   )
 
-  it('overlaid line graphs should be unsorted', () => {
+  it('leaves overlaid line graphs unsorted', () => {
     const lineOption = 'overlaid'
     const lineSpec = lineTransform(
       table,
@@ -42,7 +42,7 @@ describe('getDataSortOrder', () => {
     expect(latestIndices).toEqual(sortOrder)
   })
 
-  it('stacked line graphs should be sorted in descending order', () => {
+  it('sorts stacked line graphs in descending order', () => {
     const lineOption = 'stacked'
     const lineSpec = lineTransform(
       table,

--- a/giraffe/src/utils/legend/sort.ts
+++ b/giraffe/src/utils/legend/sort.ts
@@ -12,19 +12,20 @@ export const getDataSortOrder = (
 
   const domainLabelName = domainLabel || DomainLabel.Y
 
-  const dataMap = {}
-  const measurementValues = Object.keys(lineData).reduce(
-    (accumulator, id) => accumulator.concat(lineData[id][domainLabelName]),
+  const numberMap = {}
+  const numericalValues = Object.keys(lineData).reduce(
+    (combinedNumericalValues, id) =>
+      combinedNumericalValues.concat(lineData[id][domainLabelName]),
     []
   )
   const sortable = []
-  rowIndices.forEach(hoveredRowIndex => {
-    if (!dataMap[measurementValues[hoveredRowIndex]]) {
-      dataMap[measurementValues[hoveredRowIndex]] = []
+  rowIndices.forEach(rowIndex => {
+    if (!numberMap[numericalValues[rowIndex]]) {
+      numberMap[numericalValues[rowIndex]] = []
     }
-    dataMap[measurementValues[hoveredRowIndex]].push(hoveredRowIndex)
-    sortable.push(measurementValues[hoveredRowIndex])
+    numberMap[numericalValues[rowIndex]].push(rowIndex)
+    sortable.push(numericalValues[rowIndex])
   })
   sortable.sort((first, second) => second - first)
-  return sortable.map(measurement => dataMap[measurement].shift())
+  return sortable.map(numericalValue => numberMap[numericalValue].shift())
 }

--- a/giraffe/src/utils/legend/sort.ts
+++ b/giraffe/src/utils/legend/sort.ts
@@ -1,0 +1,30 @@
+import {DomainLabel, LineData, LinePosition} from '../../types'
+
+export const getDataSortOrder = (
+  lineData: LineData,
+  rowIndices: number[],
+  position: LinePosition,
+  domainLabel?: DomainLabel
+): number[] => {
+  if (!position || position === 'overlaid') {
+    return rowIndices
+  }
+
+  const domainLabelName = domainLabel || DomainLabel.Y
+
+  const dataMap = {}
+  const measurementValues = Object.keys(lineData).reduce(
+    (accumulator, id) => accumulator.concat(lineData[id][domainLabelName]),
+    []
+  )
+  const sortable = []
+  rowIndices.forEach(hoveredRowIndex => {
+    if (!dataMap[measurementValues[hoveredRowIndex]]) {
+      dataMap[measurementValues[hoveredRowIndex]] = []
+    }
+    dataMap[measurementValues[hoveredRowIndex]].push(hoveredRowIndex)
+    sortable.push(measurementValues[hoveredRowIndex])
+  })
+  sortable.sort((first, second) => second - first)
+  return sortable.map(measurement => dataMap[measurement].shift())
+}

--- a/giraffe/src/utils/legend/staticLegend.test.ts
+++ b/giraffe/src/utils/legend/staticLegend.test.ts
@@ -20,7 +20,7 @@ describe('convertLineSpec', () => {
     fillColumnKeys
   )
 
-  it('overlaid line graphs have certain columns', () => {
+  it('creates certain columns for overlaid line graphs', () => {
     const position = 'overlaid'
     const lineSpec = lineTransform(
       sampleTable,
@@ -50,7 +50,7 @@ describe('convertLineSpec', () => {
     })
   })
 
-  it('stacked line graphs have certain columns', () => {
+  it('creates ertain columns for stacked line graphs', () => {
     const position = 'stacked'
     const addtionalColumKeys = ['cumulative', 'lines']
     const lineSpec = lineTransform(

--- a/giraffe/src/utils/legend/staticLegend.test.ts
+++ b/giraffe/src/utils/legend/staticLegend.test.ts
@@ -50,7 +50,7 @@ describe('convertLineSpec', () => {
     })
   })
 
-  it('creates ertain columns for stacked line graphs', () => {
+  it('creates certain columns for stacked line graphs', () => {
     const position = 'stacked'
     const addtionalColumKeys = ['cumulative', 'lines']
     const lineSpec = lineTransform(

--- a/giraffe/src/utils/legend/staticLegend.test.ts
+++ b/giraffe/src/utils/legend/staticLegend.test.ts
@@ -2,7 +2,7 @@ import {convertLineSpec} from './staticLegend'
 import {NINETEEN_EIGHTY_FOUR} from '../../constants/colorSchemes'
 import {STATIC_LEGEND_DEFAULTS} from '../../constants/index'
 import {lineTransform} from '../../transforms/line'
-import {getRandomTable} from '../randomTable'
+import {getRandomTable} from '../fixtures/randomTable'
 
 describe('convertLineSpec', () => {
   const xColKey = '_time'

--- a/giraffe/src/utils/legend/staticLegend.test.ts
+++ b/giraffe/src/utils/legend/staticLegend.test.ts
@@ -2,7 +2,7 @@ import {convertLineSpec} from './staticLegend'
 import {NINETEEN_EIGHTY_FOUR} from '../../constants/colorSchemes'
 import {STATIC_LEGEND_DEFAULTS} from '../../constants/index'
 import {lineTransform} from '../../transforms/line'
-import {getRandomTable} from '../fixtures/legend'
+import {getRandomTable} from '../randomTable'
 
 describe('convertLineSpec', () => {
   it('convertLineSpec', () => {
@@ -15,6 +15,7 @@ describe('convertLineSpec', () => {
     const fillColumnKeys = ['cpu', 'host', 'machine']
     const sampleTable = getRandomTable(
       maxValue,
+      false,
       numberOfRecords,
       recordsPerLine,
       fillColumnKeys
@@ -32,7 +33,8 @@ describe('convertLineSpec', () => {
       STATIC_LEGEND_DEFAULTS,
       lineSpec,
       getColumnFormatter,
-      yColKey
+      yColKey,
+      'overlaid'
     )
 
     expect(result.length).toEqual(fillColumnKeys.length + 1)

--- a/giraffe/src/utils/legend/staticLegend.test.ts
+++ b/giraffe/src/utils/legend/staticLegend.test.ts
@@ -5,28 +5,30 @@ import {lineTransform} from '../../transforms/line'
 import {getRandomTable} from '../randomTable'
 
 describe('convertLineSpec', () => {
-  it('convertLineSpec', () => {
-    const xColKey = '_time'
-    const yColKey = '_value'
-    const getColumnFormatter = () => (x: string) => x
-    const maxValue = 100
-    const numberOfRecords = 20
-    const recordsPerLine = 5
-    const fillColumnKeys = ['cpu', 'host', 'machine']
-    const sampleTable = getRandomTable(
-      maxValue,
-      false,
-      numberOfRecords,
-      recordsPerLine,
-      fillColumnKeys
-    )
+  const xColKey = '_time'
+  const yColKey = '_value'
+  const getColumnFormatter = () => (x: string) => x
+  const maxValue = 100
+  const numberOfRecords = 20
+  const recordsPerLine = 5
+  const fillColumnKeys = ['cpu', 'host', 'machine']
+  const sampleTable = getRandomTable(
+    maxValue,
+    false,
+    numberOfRecords,
+    recordsPerLine,
+    fillColumnKeys
+  )
+
+  it('overlaid line graphs have certain columns', () => {
+    const position = 'overlaid'
     const lineSpec = lineTransform(
       sampleTable,
       xColKey,
       yColKey,
       fillColumnKeys,
       NINETEEN_EIGHTY_FOUR,
-      'overlaid'
+      position
     )
 
     const result = convertLineSpec(
@@ -34,13 +36,46 @@ describe('convertLineSpec', () => {
       lineSpec,
       getColumnFormatter,
       yColKey,
-      'overlaid'
+      position
     )
 
     expect(result.length).toEqual(fillColumnKeys.length + 1)
     result.forEach(legendColumn => {
       expect(
-        [...fillColumnKeys, '_value'].indexOf(legendColumn.key)
+        [...fillColumnKeys, yColKey].indexOf(legendColumn.key)
+      ).toBeGreaterThanOrEqual(0)
+      expect(legendColumn.values.length).toEqual(
+        numberOfRecords / recordsPerLine
+      )
+    })
+  })
+
+  it('stacked line graphs have certain columns', () => {
+    const position = 'stacked'
+    const addtionalColumKeys = ['cumulative', 'lines']
+    const lineSpec = lineTransform(
+      sampleTable,
+      xColKey,
+      yColKey,
+      fillColumnKeys,
+      NINETEEN_EIGHTY_FOUR,
+      position
+    )
+
+    const result = convertLineSpec(
+      STATIC_LEGEND_DEFAULTS,
+      lineSpec,
+      getColumnFormatter,
+      yColKey,
+      position
+    )
+
+    expect(result.length).toEqual(fillColumnKeys.length + 3)
+    result.forEach(legendColumn => {
+      expect(
+        [...fillColumnKeys, ...addtionalColumKeys, `Latest ${yColKey}`].indexOf(
+          legendColumn.name
+        )
       ).toBeGreaterThanOrEqual(0)
       expect(legendColumn.values.length).toEqual(
         numberOfRecords / recordsPerLine

--- a/giraffe/src/utils/legend/staticLegend.ts
+++ b/giraffe/src/utils/legend/staticLegend.ts
@@ -33,7 +33,7 @@ export const convertLineSpec = (
   const domainLabel = valueAxis === 'x' ? DomainLabel.X : DomainLabel.Y
   const sortOrder = getDataSortOrder(
     lineData,
-    Object.values(latestValueIndices[domainLabel]),
+    Object.values(latestValueIndices),
     position,
     domainLabel
   )

--- a/giraffe/src/utils/legend/staticLegend.ts
+++ b/giraffe/src/utils/legend/staticLegend.ts
@@ -26,7 +26,7 @@ export const convertLineSpec = (
   const {valueAxis} = staticLegend
   const valueFormatter = getColumnFormatter(valueColumnKey)
   const mappings = spec?.columnGroupMaps?.fill?.mappings
-  const latestValueIndices = spec?.columnGroupMaps?.latestValueIndices
+  const latestValueIndices = spec?.columnGroupMaps?.latestIndices
   const lineValues = spec.table.getColumn(valueColumnKey)
   const fillIndices = spec.table.getColumn(FILL)
   const lineData: LineData = spec?.lineData
@@ -34,7 +34,7 @@ export const convertLineSpec = (
   const domainLabel = valueAxis === 'x' ? DomainLabel.X : DomainLabel.Y
   const sortOrder = getDataSortOrder(
     lineData,
-    Object.values(latestValueIndices),
+    Object.values(latestValueIndices[domainLabel]),
     position,
     domainLabel
   )

--- a/giraffe/src/utils/legend/staticLegend.ts
+++ b/giraffe/src/utils/legend/staticLegend.ts
@@ -1,35 +1,47 @@
 import {
+  DomainLabel,
   Formatter,
   LegendData,
-  LineLayerSpec,
   LineData,
+  LineLayerSpec,
+  LinePosition,
   StaticLegend,
 } from '../../types'
+import {
+  FILL,
+  LINE_COUNT,
+  STACKED_LINE_CUMULATIVE,
+  VALUE,
+} from '../../constants/columnKeys'
 
-const peek = (arr: number[]): number => {
-  if (Array.isArray(arr) && arr.length >= 1) {
-    return arr[arr.length - 1]
-  }
-  return NaN
-}
+import {getDataSortOrder} from './sort'
 
 export const convertLineSpec = (
   staticLegend: StaticLegend,
   spec: LineLayerSpec,
   getColumnFormatter: (colKey: string) => Formatter,
-  valueColumnKey: string
+  valueColumnKey: string,
+  position: LinePosition
 ): LegendData => {
   const {valueAxis} = staticLegend
   const valueFormatter = getColumnFormatter(valueColumnKey)
   const mappings = spec?.columnGroupMaps?.fill?.mappings
+  const latestValueIndices = spec?.columnGroupMaps?.latestValueIndices
+  const lineValues = spec.table.getColumn(valueColumnKey)
+  const fillIndices = spec.table.getColumn(FILL)
   const lineData: LineData = spec?.lineData
 
-  const colors = Object.values(lineData).map(line => line.fill)
+  const domainLabel = valueAxis === 'x' ? DomainLabel.X : DomainLabel.Y
+  const sortOrder = getDataSortOrder(
+    lineData,
+    Object.values(latestValueIndices),
+    position,
+    domainLabel
+  )
 
-  const propertyName = valueAxis === 'x' ? 'xs' : 'ys'
-
-  const values = Object.values(lineData).map(line => {
-    const latestValue = peek(line[propertyName])
+  const colors = sortOrder.map(index => lineData[`${fillIndices[index]}`].fill)
+  const values = sortOrder.map(index => {
+    const latestValue = lineValues[index]
     if (latestValue === latestValue) {
       return valueFormatter(latestValue)
     }
@@ -49,9 +61,42 @@ export const convertLineSpec = (
     values,
   }
 
-  const legendColumns = columnKeys.map(key => {
-    // TODO: should be using formatter from config
-    const column: string[] = mappings.map(fillColumn => fillColumn[key])
+  const additionalColumns = []
+  if (position === 'stacked') {
+    const stackedDomainValues = spec.stackedDomainValueColumn ?? []
+    additionalColumns.push({
+      key: VALUE,
+      name: STACKED_LINE_CUMULATIVE,
+      type: spec.table.getColumnType(VALUE),
+      colors,
+      values: sortOrder.map(index =>
+        valueFormatter(stackedDomainValues[index])
+      ),
+    })
+
+    const lineCountByGroupId = {}
+    sortOrder
+      .map(index => fillIndices[index])
+      .sort()
+      .forEach((groupId, key) => {
+        lineCountByGroupId[`${groupId}`] = key + 1
+      })
+    additionalColumns.push({
+      key: VALUE,
+      name: LINE_COUNT,
+      type: spec.table.getColumnType(VALUE),
+      colors,
+      values: sortOrder.map(
+        index => lineCountByGroupId[`${fillIndices[index]}`]
+      ),
+    })
+  }
+
+  const fillColumns = columnKeys.map(key => {
+    const column: string[] = mappings.map(fillColumn => {
+      const fillFormatter = getColumnFormatter(key)
+      return fillFormatter(fillColumn[key])
+    })
 
     return {
       key,
@@ -62,5 +107,5 @@ export const convertLineSpec = (
     }
   })
 
-  return [valueColumn, ...legendColumns]
+  return [valueColumn, ...additionalColumns, ...fillColumns]
 }

--- a/giraffe/src/utils/legend/staticLegend.ts
+++ b/giraffe/src/utils/legend/staticLegend.ts
@@ -11,7 +11,6 @@ import {
   FILL,
   LINE_COUNT,
   STACKED_LINE_CUMULATIVE,
-  VALUE,
 } from '../../constants/columnKeys'
 
 import {getDataSortOrder} from './sort'
@@ -65,9 +64,9 @@ export const convertLineSpec = (
   if (position === 'stacked') {
     const stackedDomainValues = spec.stackedDomainValueColumn ?? []
     additionalColumns.push({
-      key: VALUE,
+      key: valueColumnKey,
       name: STACKED_LINE_CUMULATIVE,
-      type: spec.table.getColumnType(VALUE),
+      type: spec.table.getColumnType(valueColumnKey),
       colors,
       values: sortOrder.map(index =>
         valueFormatter(stackedDomainValues[index])
@@ -82,9 +81,9 @@ export const convertLineSpec = (
         lineCountByGroupId[`${groupId}`] = key + 1
       })
     additionalColumns.push({
-      key: VALUE,
+      key: valueColumnKey,
       name: LINE_COUNT,
-      type: spec.table.getColumnType(VALUE),
+      type: spec.table.getColumnType(valueColumnKey),
       colors,
       values: sortOrder.map(
         index => lineCountByGroupId[`${fillIndices[index]}`]

--- a/giraffe/src/utils/legend/tooltip.test.ts
+++ b/giraffe/src/utils/legend/tooltip.test.ts
@@ -12,7 +12,7 @@ import {
   COLUMN_KEY,
   POINT_KEY,
   HOST_KEY,
-} from '../randomTable'
+} from '../fixtures/randomTable'
 import {LayerTypes, LineLayerSpec, ScatterLayerSpec} from '../../types'
 
 describe('getPointsTooltipData', () => {

--- a/giraffe/src/utils/legend/tooltip.test.ts
+++ b/giraffe/src/utils/legend/tooltip.test.ts
@@ -12,7 +12,7 @@ import {
   COLUMN_KEY,
   POINT_KEY,
   HOST_KEY,
-} from '../fixtures/legend'
+} from '../randomTable'
 import {LayerTypes, LineLayerSpec, ScatterLayerSpec} from '../../types'
 
 describe('getPointsTooltipData', () => {

--- a/giraffe/src/utils/legend/tooltip.ts
+++ b/giraffe/src/utils/legend/tooltip.ts
@@ -1,5 +1,4 @@
 import {
-  DomainLabel,
   LineData,
   LinePosition,
   NumericColumnData,
@@ -17,6 +16,7 @@ import {
 } from '../../constants/columnKeys'
 
 import {BandHoverIndices} from '../bandHover'
+import {getDataSortOrder} from './sort'
 
 const isVoid = (x: any) => x === null || x === undefined
 
@@ -28,32 +28,6 @@ const orderDataByValue = (
   const dataMap = {}
   originalOrder.forEach((place, index) => (dataMap[place] = data[index]))
   return nextOrder.map(place => dataMap[place])
-}
-
-const getDataSortOrder = (
-  lineData: LineData,
-  hoveredRowIndices: number[],
-  position: LinePosition
-): number[] => {
-  if (!position || position === 'overlaid') {
-    return hoveredRowIndices
-  }
-
-  const dataMap = {}
-  const measurementValues = Object.keys(lineData).reduce(
-    (accumulator, id) => accumulator.concat(lineData[id][DomainLabel.Y]),
-    []
-  )
-  const sortable = []
-  hoveredRowIndices.forEach(hoveredRowIndex => {
-    if (!dataMap[measurementValues[hoveredRowIndex]]) {
-      dataMap[measurementValues[hoveredRowIndex]] = []
-    }
-    dataMap[measurementValues[hoveredRowIndex]].push(hoveredRowIndex)
-    sortable.push(measurementValues[hoveredRowIndex])
-  })
-  sortable.sort((first, second) => second - first)
-  return sortable.map(measurement => dataMap[measurement].shift())
 }
 
 export const getRangeLabel = (min: number, max: number, formatter): string => {
@@ -109,6 +83,7 @@ export const getPointsTooltipData = (
   const sortOrder = lineData
     ? getDataSortOrder(lineData, hoveredRowIndices, position)
     : hoveredRowIndices
+
   const xColData = table.getColumn(xColKey, 'number')
   const yColData = table.getColumn(yColKey, 'number')
   const groupColData = table.getColumn(groupColKey, 'number')

--- a/giraffe/src/utils/randomTable.ts
+++ b/giraffe/src/utils/randomTable.ts
@@ -1,16 +1,6 @@
-import {newTable} from '../newTable'
-import {LayerTypes} from '../../types'
+import {newTable} from './newTable'
+import {LayerTypes} from '../types'
 import memoizeOne from 'memoize-one'
-
-interface SampleTableOptions {
-  include_negative?: boolean
-  all_negative?: boolean
-  decimalPlaces?: number
-  maxValue?: number
-  numberOfRecords?: number
-  recordsPerLine?: number
-  plotType?: string
-}
 
 const getRandomNumber = (
   max: number,
@@ -28,55 +18,6 @@ export const COLUMN_KEY = 'cpu'
 export const POINT_KEY = 'disk'
 export const HOST_KEY = 'host'
 
-export const createSampleTable = (options: SampleTableOptions) => {
-  const {
-    include_negative = false,
-    all_negative = false,
-    decimalPlaces = 2,
-    maxValue = 100,
-    numberOfRecords = 20,
-    recordsPerLine = 5,
-    plotType = 'line',
-  } = options
-
-  const now = Date.now()
-  const TIME_COL = []
-  const VALUE_COL = []
-  const CPU_COL = []
-  const SYMBOL_COL = []
-  const DISK_COL = []
-  const HOST_COL = []
-
-  for (let i = 0; i < numberOfRecords; i += 1) {
-    let num = getRandomNumber(maxValue, decimalPlaces)
-    if (include_negative) {
-      num = all_negative
-        ? Math.abs(num) * -1
-        : getRandomNumber(maxValue, decimalPlaces, true)
-    }
-    VALUE_COL.push(num)
-    CPU_COL.push(`${COLUMN_KEY}${Math.floor(i / recordsPerLine)}`)
-    TIME_COL.push(now + (i % recordsPerLine) * 1000 * 60)
-    if (plotType === LayerTypes.Scatter) {
-      SYMBOL_COL.push(i % 2)
-      DISK_COL.push(`disk-${i % recordsPerLine}`)
-      HOST_COL.push(`host-${i % 2}`)
-    }
-  }
-  const table = newTable(numberOfRecords)
-    .addColumn('_time', 'dateTime:RFC3339', 'time', TIME_COL)
-    .addColumn('_value', 'system', 'number', VALUE_COL)
-
-  if (plotType === LayerTypes.Scatter) {
-    return table
-      .addColumn(POINT_KEY, 'string', 'string', DISK_COL)
-      .addColumn('__symbol', 'string', 'string', SYMBOL_COL)
-      .addColumn(HOST_KEY, 'string', 'string', HOST_COL)
-  }
-  return table.addColumn(COLUMN_KEY, 'string', 'string', CPU_COL)
-}
-
-const now = Date.now()
 const defaultNumberOfRecords = 80
 const defaultRecordsPerLine = 20
 
@@ -100,6 +41,7 @@ interface RandomFillColumns {
 export const getRandomTable = memoizeOne(
   (
     maxValue: number,
+    includeNegative: boolean,
     numberOfRecords: number = defaultNumberOfRecords,
     recordsPerLine: number = defaultRecordsPerLine,
     fillColumns?: ColumnsArg,
@@ -112,9 +54,10 @@ export const getRandomTable = memoizeOne(
       columnNames: [],
       columnValues: [],
     } as RandomFillColumns
+    const now = Date.now()
 
     for (let i = 0; i < numberOfRecords; i += 1) {
-      valueColumn.push(getRandomNumber(maxValue, 2))
+      valueColumn.push(getRandomNumber(maxValue, 2, includeNegative))
       cpuColumn.push(`cpu${Math.floor(i / recordsPerLine)}`)
       timeColumn.push(now + (i % recordsPerLine) * 1000 * 60)
     }
@@ -173,3 +116,61 @@ export const getRandomTable = memoizeOne(
     return table
   }
 )
+
+export interface SampleTableOptions {
+  include_negative?: boolean
+  all_negative?: boolean
+  decimalPlaces?: number
+  maxValue?: number
+  numberOfRecords?: number
+  recordsPerLine?: number
+  plotType?: string
+}
+
+export const createSampleTable = (options: SampleTableOptions) => {
+  const {
+    include_negative = false,
+    all_negative = false,
+    decimalPlaces = 2,
+    maxValue = 100,
+    numberOfRecords = 20,
+    recordsPerLine = 5,
+    plotType = 'line',
+  } = options
+
+  const now = Date.now()
+  const TIME_COL = []
+  const VALUE_COL = []
+  const CPU_COL = []
+  const SYMBOL_COL = []
+  const DISK_COL = []
+  const HOST_COL = []
+
+  for (let i = 0; i < numberOfRecords; i += 1) {
+    let num = getRandomNumber(maxValue, decimalPlaces)
+    if (include_negative) {
+      num = all_negative
+        ? Math.abs(num) * -1
+        : getRandomNumber(maxValue, decimalPlaces, true)
+    }
+    VALUE_COL.push(num)
+    CPU_COL.push(`${COLUMN_KEY}${Math.floor(i / recordsPerLine)}`)
+    TIME_COL.push(now + (i % recordsPerLine) * 1000 * 60)
+    if (plotType === LayerTypes.Scatter) {
+      SYMBOL_COL.push(i % 2)
+      DISK_COL.push(`disk-${i % recordsPerLine}`)
+      HOST_COL.push(`host-${i % 2}`)
+    }
+  }
+  const table = newTable(numberOfRecords)
+    .addColumn('_time', 'dateTime:RFC3339', 'time', TIME_COL)
+    .addColumn('_value', 'system', 'number', VALUE_COL)
+
+  if (plotType === LayerTypes.Scatter) {
+    return table
+      .addColumn(POINT_KEY, 'string', 'string', DISK_COL)
+      .addColumn('__symbol', 'string', 'string', SYMBOL_COL)
+      .addColumn(HOST_KEY, 'string', 'string', HOST_COL)
+  }
+  return table.addColumn(COLUMN_KEY, 'string', 'string', CPU_COL)
+}

--- a/stories/src/linegraph.stories.tsx
+++ b/stories/src/linegraph.stories.tsx
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react'
 import {withKnobs, number, select, boolean, text} from '@storybook/addon-knobs'
 
 import {Config, Plot, timeFormatter, fromFlux} from '../../giraffe/src'
-import {getRandomTable} from './data/randomTable'
+import {getRandomTable} from '../../giraffe/src/utils/randomTable'
 
 import {
   PlotContainer,
@@ -30,7 +30,7 @@ const maxValue = Math.random() * Math.floor(200)
 storiesOf('Line Graph', module)
   .addDecorator(withKnobs)
   .add('User defined ticks', () => {
-    let table = getRandomTable(maxValue)
+    let table = getRandomTable(maxValue, false)
     const xTickStart = number('xTickStart', new Date().getTime())
     const xTickStep = number('xTickStep', 200_000)
     const xTotalTicks = number('xTotalTicks', 5)

--- a/stories/src/linegraph.stories.tsx
+++ b/stories/src/linegraph.stories.tsx
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react'
 import {withKnobs, number, select, boolean, text} from '@storybook/addon-knobs'
 
 import {Config, Plot, timeFormatter, fromFlux} from '../../giraffe/src'
-import {getRandomTable} from '../../giraffe/src/utils/randomTable'
+import {getRandomTable} from '../../giraffe/src/utils/fixtures/randomTable'
 
 import {
   PlotContainer,

--- a/stories/src/staticLegend.stories.tsx
+++ b/stories/src/staticLegend.stories.tsx
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react'
 import {withKnobs, number, select, boolean, text} from '@storybook/addon-knobs'
 
 import {Config, Plot, timeFormatter} from '../../giraffe/src'
-import {getRandomTable} from '../../giraffe/src/utils/randomTable'
+import {getRandomTable} from '../../giraffe/src/utils/fixtures/randomTable'
 
 import {
   PlotContainer,

--- a/stories/src/staticLegend.stories.tsx
+++ b/stories/src/staticLegend.stories.tsx
@@ -48,9 +48,15 @@ storiesOf('Static Legend', module)
       fixedPlotSize['height'] = fixedHeight
       fixedPlotSize['width'] = fixedWidth
     }
+    const includeNegativeNumbers = boolean('Include negative numbers ?', false)
+    const position = select(
+      'Line Position',
+      {stacked: 'stacked', overlaid: 'overlaid'},
+      'overlaid'
+    )
     const table = getRandomTable(
       maxValue,
-      true,
+      includeNegativeNumbers,
       lines * 20,
       20,
       fillColumnsCount,
@@ -99,11 +105,6 @@ storiesOf('Static Legend', module)
       'YYYY-MM-DD HH:mm:ss ZZ'
     )
     const fill = fillKnob(table, findStringColumns(table))
-    const position = select(
-      'Line Position',
-      {stacked: 'stacked', overlaid: 'overlaid'},
-      'overlaid'
-    )
     const interpolation = interpolationKnob()
     const showAxes = showAxesKnob()
     const lineWidth = number('Line Width', 1)
@@ -192,9 +193,15 @@ storiesOf('Static Legend', module)
       fixedPlotSize['height'] = fixedHeight
       fixedPlotSize['width'] = fixedWidth
     }
+    const includeNegativeNumbers = boolean('Include negative numbers ?', false)
+    const position = select(
+      'Line Position',
+      {stacked: 'stacked', overlaid: 'overlaid'},
+      'overlaid'
+    )
     const table = getRandomTable(
       maxValue,
-      true,
+      includeNegativeNumbers,
       20 * lines,
       20,
       fillColumnNames
@@ -242,11 +249,6 @@ storiesOf('Static Legend', module)
       'YYYY-MM-DD HH:mm:ss ZZ'
     )
     const fill = fillKnob(table, findStringColumns(table))
-    const position = select(
-      'Line Position',
-      {stacked: 'stacked', overlaid: 'overlaid'},
-      'overlaid'
-    )
     const interpolation = interpolationKnob()
     const showAxes = showAxesKnob()
     const lineWidth = number('Line Width', 1)

--- a/stories/src/staticLegend.stories.tsx
+++ b/stories/src/staticLegend.stories.tsx
@@ -3,7 +3,7 @@ import {storiesOf} from '@storybook/react'
 import {withKnobs, number, select, boolean, text} from '@storybook/addon-knobs'
 
 import {Config, Plot, timeFormatter} from '../../giraffe/src'
-import {getRandomTable} from './data/randomTable'
+import {getRandomTable} from '../../giraffe/src/utils/randomTable'
 
 import {
   PlotContainer,
@@ -50,6 +50,7 @@ storiesOf('Static Legend', module)
     }
     const table = getRandomTable(
       maxValue,
+      true,
       lines * 20,
       20,
       fillColumnsCount,
@@ -191,7 +192,13 @@ storiesOf('Static Legend', module)
       fixedPlotSize['height'] = fixedHeight
       fixedPlotSize['width'] = fixedWidth
     }
-    const table = getRandomTable(maxValue, 20 * lines, 20, fillColumnNames)
+    const table = getRandomTable(
+      maxValue,
+      true,
+      20 * lines,
+      20,
+      fillColumnNames
+    )
     const colors = colorSchemeKnob()
     const legendOrientationThreshold = tooltipOrientationThresholdKnob(20)
     const staticLegendOrientationThreshold = number(


### PR DESCRIPTION
Closes #548 

Adds additional columns in the Static Legend when the line graph is a stacked line layer:
<img width="1680" alt="Screen Shot 2021-04-26 at 8 28 53 PM" src="https://user-images.githubusercontent.com/10736577/116180601-0b6b7e80-a6ce-11eb-80bc-0d268ad04225.png">
