### PR TITLE
fix: add optional chaining to protect against null from getSpec

### DIFF
--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -93,9 +93,11 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
 
   const valueX = env.xScale.invert(hoverEvent.x)
   let clampedValueX = NaN
+
   if (
     valueX &&
-    (defaultSpec.type === SpecTypes.Band || defaultSpec.type === SpecTypes.Line)
+    (defaultSpec?.type === SpecTypes.Band ||
+      defaultSpec?.type === SpecTypes.Line)
   ) {
     const timestamps = defaultSpec?.lineData[0]?.xs ?? []
     clampedValueX = nearestTimestamp(timestamps, valueX)


### PR DESCRIPTION
The recent re-organization of the `Plot` and `SizedPlot` with new components added in between has brought to light that we must be very careful with changes, as this is the entry point into the heart of the code.

`env.getSpec` can actually return `null` even though it may not happen everywhere. It's still better to guard against this.