### PR TITLE
feat: update Static Legend interface

### DIFF
--- a/giraffe/README.md
+++ b/giraffe/README.md
@@ -431,6 +431,8 @@ When using the comma separated values (CSV) from the Flux query as the `fluxResp
   - **opacity**: _number. Optional. Defaults to 1.0 when excluded._ The [_CSS opacity_](https://developer.mozilla.org/en-US/docs/Web/CSS/opacity) of the static legend.
 
   - **orientationThreshold**: _number. Optional. Defaults to undefined when excluded._ The number of columns in the legend that will determine the direction of columns in the legend. When _undefined_ or when the total number of columns is less than or equal to it, the columns in the tooltip will display horizontally. When the total number of columns is greater, the columns will display vertically.
+
+  - **style**: _Object. Optional._ An object containing the key-value pairs used for inline styling the class `.giraffe-static-legend` by using the [style property](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style). Primarily used for adjusting `margin` and `padding`. May be used to add additional styling to Static Legend, but does not affect: **backgroundColor**, **border**, **cursor**, **font**, **fontBrightColor**, **fontColor**, and **opacity**. 
   
   - **valueAxis**: _string. Optional. Defaults to 'y' when not included.  Valid values are either 'x' or 'y'.  This is to set where the 'values' that are displayed in the tooltip come from (which axis, x or y)
 

--- a/giraffe/README.md
+++ b/giraffe/README.md
@@ -432,7 +432,7 @@ When using the comma separated values (CSV) from the Flux query as the `fluxResp
 
   - **orientationThreshold**: _number. Optional. Defaults to undefined when excluded._ The number of columns in the legend that will determine the direction of columns in the legend. When _undefined_ or when the total number of columns is less than or equal to it, the columns in the tooltip will display horizontally. When the total number of columns is greater, the columns will display vertically.
 
-  - **style**: _Object. Optional._ An object containing the key-value pairs used for inline styling the class `.giraffe-static-legend` by using the [style property](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style). Primarily used for adjusting `margin` and `padding`. May be used to add additional styling to Static Legend, but does not affect: **backgroundColor**, **border**, **cursor**, **font**, **fontBrightColor**, **fontColor**, and **opacity**. 
+  - **style**: _Object. Optional._ An object containing the key-value pairs used for inline styling the class `.giraffe-static-legend` by using the [style property](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style). Primarily used for adjusting `margin` and `padding`. May be used to add additional styling to Static Legend, but does not affect the following styles: `backgroundColor`, `border`, `bottom`, `color`, `cursor`, `font`, `height`, `left`, `opacity`, `overflow`, `position`, `right`, `top`, `width`.
   
   - **valueAxis**: _string. Optional. Defaults to 'y' when not included.  Valid values are either 'x' or 'y'.  This is to set where the 'values' that are displayed in the tooltip come from (which axis, x or y)
 

--- a/giraffe/src/components/StaticLegendBox.tsx
+++ b/giraffe/src/components/StaticLegendBox.tsx
@@ -77,6 +77,7 @@ export const StaticLegendBox: FunctionComponent<StaticLegendBoxProps> = props =>
     <div
       className="giraffe-static-legend"
       style={{
+        padding: 10, // overridable, must be at the top
         ...style,
         backgroundColor,
         border,
@@ -86,8 +87,8 @@ export const StaticLegendBox: FunctionComponent<StaticLegendBoxProps> = props =>
         font,
         height: `${height}px`,
         left: 0,
+        opacity: staticLegendOverride.opacity,
         overflow: 'auto',
-        padding: 10,
         position: 'absolute',
         right: 0,
         top: `${top}px`,

--- a/giraffe/src/components/StaticLegendBox.tsx
+++ b/giraffe/src/components/StaticLegendBox.tsx
@@ -50,6 +50,8 @@ export const StaticLegendBox: FunctionComponent<StaticLegendBoxProps> = props =>
     staticLegend: staticLegendOverride,
   } = overrideLegendConfig(config, staticLegend)
 
+  const {style = {}} = staticLegendOverride
+
   const layerConfig = configOverride.layers[staticLegendOverride.layer]
   const valueColumnKey = layerConfig[staticLegendOverride.valueAxis]
 
@@ -75,6 +77,7 @@ export const StaticLegendBox: FunctionComponent<StaticLegendBoxProps> = props =>
     <div
       className="giraffe-static-legend"
       style={{
+        ...style,
         backgroundColor,
         border,
         bottom: 0,

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -124,6 +124,7 @@ export interface StaticLegend {
   message?: string
   opacity?: number
   orientationThreshold?: number
+  style?: CSSProperties // no correspinding legend property, unique to static legend
   valueAxis?: 'x' | 'y' // no corresponding legend property, unique to static legend
   widthRatio?: number // no corresponding legend property, unique to static legend
 }


### PR DESCRIPTION
In support of https://github.com/influxdata/ui/issues/806

- A consuming app may need to adjust `margin` and `padding` around the Static Legend Box, allow this.
- Other styles can be added without further interface changes.
- Does not affect commonly-used strategically-important styles previously defined in the interface.