### PR TITLE
feat: add style prop to PlotContainer

### DIFF
--- a/stories/src/annotation.stories.tsx
+++ b/stories/src/annotation.stories.tsx
@@ -139,7 +139,13 @@ storiesOf('Annotations', module)
       layers,
     }
     return (
-      <PlotContainer>
+      <PlotContainer
+        style={{
+          width: 'calc(100vw - 100px)',
+          height: 'calc(100vh - 125px)',
+          margin: '75px 50px 50px 50px',
+        }}
+      >
         <Plot config={config} />
       </PlotContainer>
     )
@@ -274,7 +280,13 @@ storiesOf('Annotations', module)
       interactionHandlers,
     }
     return (
-      <PlotContainer>
+      <PlotContainer
+        style={{
+          width: 'calc(100vw - 100px)',
+          height: 'calc(100vh - 125px)',
+          margin: '75px 50px 50px 50px',
+        }}
+      >
         <Plot config={config} />
       </PlotContainer>
     )
@@ -409,7 +421,13 @@ storiesOf('Annotations', module)
       layers,
     }
     return (
-      <PlotContainer>
+      <PlotContainer
+        style={{
+          width: 'calc(100vw - 100px)',
+          height: 'calc(100vh - 125px)',
+          margin: '75px 50px 50px 50px',
+        }}
+      >
         <Plot config={config} />
       </PlotContainer>
     )
@@ -536,7 +554,13 @@ storiesOf('Annotations', module)
       layers,
     }
     return (
-      <PlotContainer>
+      <PlotContainer
+        style={{
+          width: 'calc(100vw - 100px)',
+          height: 'calc(100vh - 125px)',
+          margin: '75px 50px 50px 50px',
+        }}
+      >
         <Plot config={config} />
       </PlotContainer>
     )

--- a/stories/src/helpers.tsx
+++ b/stories/src/helpers.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, {CSSProperties, FC} from 'react'
 import {select, text, boolean, number} from '@storybook/addon-knobs'
 
 import {Table} from '../../giraffe/src'
@@ -7,17 +7,21 @@ import {cpuTable} from './data/mosaicTable'
 
 import * as giraffe from '../../giraffe/src'
 
-export const PlotContainer = ({children}) => (
-  <div
-    style={{
-      width: 'calc(100vw - 100px)',
-      height: 'calc(100vh - 125px)',
-      margin: '75px 50px 50px 50px',
-    }}
-  >
-    {children}
-  </div>
-)
+export interface PlotContainerProps {
+  style?: CSSProperties
+}
+
+export const PlotContainer: FC<PlotContainerProps> = props => {
+  const {style = {}, children} = props
+
+  const defaultPlotStyle = {
+    width: 'calc(100vw - 100px)',
+    height: 'calc(100vh - 125px)',
+    margin: '50px',
+  }
+
+  return <div style={{...defaultPlotStyle, ...style}}>{children}</div>
+}
 
 export const multiSelect = (
   label: string,


### PR DESCRIPTION
Closes #532 

Adds a `style` prop to `PlotContainer` to allow for specifying CSS Properties such as margin for the `PlotContainer`