### PR TITLE
fix: this is what broke everything

### DIFF
--- a/giraffe/src/utils/lineData.ts
+++ b/giraffe/src/utils/lineData.ts
@@ -41,8 +41,8 @@ export const simplifyLineData = (
 
   for (const [k, {xs, ys, fill}] of Object.entries(lineData)) {
     const [simplifedXs, simplifiedYs] = simplify(
-      xs.map(x => xScale(x)),
-      ys.map(y => yScale(y)),
+      xs.map(x => xScale(x || 0)),
+      ys.map(y => yScale(y || 0)),
       0.5
     )
 


### PR DESCRIPTION
fix: force coercion of falsy values to 0

guards against https://github.com/d3/d3-scale/releases/tag/v3.2.4

Issue: on april 28th 2021, we found an issue when we upgraded multiple giraffe libraries. This resulted in our graphs intermittently coming back empty/blank. This was because we had originally believed the null values would return 0, as d3-scale did originally. But by upgrading this broke and we were receiving NaN values. These values made it so our graphs could not be displayed properly but only broke on graphs with undefined values. 