### PR TITLE
feat: add scrollbars to the static legend

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/Legend.tsx
+++ b/giraffe/src/components/Legend.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, {CSSProperties} from 'react'
 import {FunctionComponent} from 'react'
 
 import {LegendData, Config} from '../types'
@@ -7,9 +7,14 @@ import {generateLegendStyles, LegendPillsStyles} from './LegendStyles'
 interface Props {
   data: LegendData
   config: Config
+  isScrollable?: boolean
 }
 
-export const Legend: FunctionComponent<Props> = ({data, config}) => {
+export const Legend: FunctionComponent<Props> = ({
+  data,
+  config,
+  isScrollable = false,
+}) => {
   const {
     width,
     height,
@@ -43,6 +48,7 @@ export const Legend: FunctionComponent<Props> = ({data, config}) => {
   const maxLength = switchToVertical ? width : height
 
   const styles = generateLegendStyles(
+    isScrollable,
     columns,
     switchToVertical,
     colorizeRows,
@@ -76,9 +82,9 @@ interface LegendColumnProps {
   name: string
   maxLength: number
   values: string[]
-  columnStyle: React.CSSProperties
-  columnHeaderStyle: React.CSSProperties
-  columnValueStyles: React.CSSProperties[]
+  columnStyle: CSSProperties
+  columnHeaderStyle: CSSProperties
+  columnValueStyles: CSSProperties[]
 }
 
 const LegendColumn: FunctionComponent<LegendColumnProps> = ({

--- a/giraffe/src/components/LegendStyles.ts
+++ b/giraffe/src/components/LegendStyles.ts
@@ -3,6 +3,7 @@ import {LegendData, ColumnType} from '../types'
 
 // Style Constants
 const legendColumnGap = '12px'
+const legendColumnPadding = '15px'
 const legendColumnMaxWidth = '200px'
 const legendTablePadding = '4px'
 
@@ -36,6 +37,7 @@ export interface LegendStyles {
 }
 
 export const generateLegendStyles = (
+  isScrollable: boolean,
   legendData: LegendData,
   switchToVertical: boolean,
   colorizeRows: boolean,
@@ -47,6 +49,7 @@ export const generateLegendStyles = (
   const table = legendTableStyle(switchToVertical)
   const columns = legendData.map((column, i) =>
     legendColumnStyle(
+      isScrollable,
       column.name,
       i,
       column.type,
@@ -93,8 +96,9 @@ const legendTableStyle = (switchToVertical: boolean): CSSProperties => {
 }
 
 const legendColumnStyle = (
+  isScrollableColumn: boolean,
   name: string,
-  i: number,
+  index: number,
   type: ColumnType,
   switchToVertical: boolean,
   columnCount: number
@@ -106,13 +110,21 @@ const legendColumnStyle = (
     }
   }
 
-  return {
+  const columnStyle: CSSProperties = {
     display: 'flex',
     order: legendColumnOrder(name),
     flexDirection: 'column',
-    marginRight: i === columnCount ? 0 : legendColumnGap,
+    marginRight: index === columnCount ? 0 : legendColumnGap,
     textAlign: type === 'number' ? 'right' : 'left',
   }
+
+  if (isScrollableColumn) {
+    columnStyle.paddingBottom = legendColumnPadding
+    if (index === columnCount) {
+      columnStyle.paddingRight = legendColumnPadding
+    }
+  }
+  return columnStyle
 }
 
 const legendColumnHeaderStyle = (
@@ -124,12 +136,14 @@ const legendColumnHeaderStyle = (
       color: fontColor,
       display: 'table-cell',
       margin: legendTablePadding,
+      whiteSpace: 'nowrap',
     }
   }
 
   return {
     marginBottom: legendTablePadding,
     color: fontColor,
+    whiteSpace: 'nowrap',
   }
 }
 

--- a/giraffe/src/components/StaticLegendBox.tsx
+++ b/giraffe/src/components/StaticLegendBox.tsx
@@ -8,6 +8,7 @@ import {
 } from '../types'
 import {CONFIG_DEFAULTS, STATIC_LEGEND_DEFAULTS} from '../constants/index'
 import {Legend} from './Legend'
+import {DapperScrollbars} from './DapperScrollbars'
 import {getLegendData} from '../utils/legend/staticLegend'
 
 interface StaticLegendBoxProps extends StaticLegend {
@@ -77,6 +78,7 @@ export const StaticLegendBox: FunctionComponent<StaticLegendBoxProps> = props =>
         backgroundColor,
         border,
         bottom: 0,
+        boxSizing: 'border-box',
         color: fontBrightColor,
         cursor: staticLegendOverride.cursor,
         font,
@@ -91,7 +93,9 @@ export const StaticLegendBox: FunctionComponent<StaticLegendBoxProps> = props =>
       }}
       data-testid="giraffe-static-legend"
     >
-      <Legend data={legendData} config={configOverride} />
+      <DapperScrollbars removeTracksWhenNotUsed={true} autoHide={true}>
+        <Legend data={legendData} config={configOverride} isScrollable={true} />
+      </DapperScrollbars>
     </div>
   )
 }


### PR DESCRIPTION
Closes #574 

- Adds `DapperScrollbars` to the Static Legend when its content is too big to fit in the available space
- Does **_not_** allow a config-specified scrollbars element (this is too much scope)

<img width="1680" alt="Screen Shot 2021-05-11 at 6 04 28 PM" src="https://user-images.githubusercontent.com/10736577/117903290-1c96bc80-b284-11eb-992e-9e29a3b9235a.png">
