### PR TITLE
fix: add null check in PlotEnv

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/utils/PlotEnv.ts
+++ b/giraffe/src/utils/PlotEnv.ts
@@ -467,7 +467,7 @@ export class PlotEnv {
     }
 
     const derivedColumnType = this.config.layers
-      .map((_, i) => this.getSpec(i).table)
+      .map((_, i) => this.getSpec(i)?.table)
       .filter(table => !!table)
       .map(table => table.getColumnType(columnKey))
       .find(k => !!k)


### PR DESCRIPTION
Not all layers will create a spec, such as `RawFluxDataTable`, `Gauge`, `Geo`, `Custom`, `SingleStat`, and `Table`.
See https://github.com/influxdata/giraffe/blob/master/giraffe/src/utils/PlotEnv.ts#L375-L381

As such, guard against accessing a property on null.