### PR TITLE
feat: drawing range annotations

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -24,7 +24,6 @@ const ANNOTATION_OVERLAY_DEFAULT_STYLE = {
 
 export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props => {
   const {config, spec, width, height, hoverX, hoverY, xScale, yScale} = props
-  console.log('ack! 45a: width?', width, hoverX, hoverY)
   const lineWidth = config.lineWidth || 2
   const annotationsPositions = useMemo(
     () => getAnnotationsPositions(spec.annotationData, xScale, yScale),
@@ -36,8 +35,6 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
   if (config.hoverDimension === 'x' || config.hoverDimension === 'y') {
     hoverDimension = config.hoverDimension
   }
-
-  //console.log('in annotation layer, got positions:', annotationsPositions)
 
   const hoverMargin = config.hoverMargin
     ? config.hoverMargin
@@ -85,7 +82,6 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
             startValue={annotationData.startValue}
             stopValue={annotationData.stopValue}
             color={annotationData.color}
-            secondaryColor={annotationData.secondaryColor}
             strokeWidth={lineWidth}
             pin={annotationData.pin}
             id={annotationData.id}
@@ -98,7 +94,6 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
             startValue={annotationData.startValue}
             stopValue={annotationData.stopValue}
             color={annotationData.color}
-            secondaryColor={annotationData.secondaryColor}
             strokeWidth={lineWidth}
             pin={annotationData.pin}
             id={annotationData.id}

--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -24,6 +24,7 @@ const ANNOTATION_OVERLAY_DEFAULT_STYLE = {
 
 export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props => {
   const {config, spec, width, height, hoverX, hoverY, xScale, yScale} = props
+  console.log('ack! 45a: width?', width, hoverX, hoverY)
   const lineWidth = config.lineWidth || 2
   const annotationsPositions = useMemo(
     () => getAnnotationsPositions(spec.annotationData, xScale, yScale),
@@ -35,6 +36,8 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
   if (config.hoverDimension === 'x' || config.hoverDimension === 'y') {
     hoverDimension = config.hoverDimension
   }
+
+  //console.log('in annotation layer, got positions:', annotationsPositions)
 
   const hoverMargin = config.hoverMargin
     ? config.hoverMargin
@@ -82,6 +85,7 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
             startValue={annotationData.startValue}
             stopValue={annotationData.stopValue}
             color={annotationData.color}
+            secondaryColor={annotationData.secondaryColor}
             strokeWidth={lineWidth}
             pin={annotationData.pin}
             id={annotationData.id}
@@ -94,6 +98,7 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
             startValue={annotationData.startValue}
             stopValue={annotationData.stopValue}
             color={annotationData.color}
+            secondaryColor={annotationData.secondaryColor}
             strokeWidth={lineWidth}
             pin={annotationData.pin}
             id={annotationData.id}

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -6,6 +6,7 @@ import styles from './AnnotationLine.scss'
 interface AnnotationLineProps {
   dimension: AnnotationDimension
   color: string
+  secondaryColor?: string
   strokeWidth: number
   startValue: number
   stopValue: number
@@ -20,13 +21,23 @@ const PIN_TRIANGLE_HEIGHT = 8
 const PIN_TRIANGLE_WIDTH = 6
 
 export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
-  const {dimension, color, strokeWidth, startValue, length, pin} = props
+  const {
+    dimension,
+    color,
+    secondaryColor,
+    strokeWidth,
+    startValue,
+    stopValue,
+    length,
+    pin,
+  } = props
 
   // This prevents blurry sub-pixel rendering as well as clipped lines
   // If the line is at the edge of the canvas the stroke will be half obscured
   // because the stroke is centered on the line. Giving a minimum value
   // prevents the line from being clipped
   const clampedStart = Math.max(1, Math.round(startValue))
+  const clampedEnd = Math.max(1, Math.round(stopValue))
 
   if (dimension === 'y') {
     return (
@@ -69,59 +80,111 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
     )
   }
 
-  return (
-    // a separate line layer on the annotation line is required on top,
-    // because the dashed line doesnt allow for a continuous click-able target
-    // this top layer has an opacity of 0 so is not visible.
-    <>
-      <line
-        x1={clampedStart}
-        x2={clampedStart}
-        y1="0"
-        y2={length}
-        stroke={color}
-        strokeOpacity={0}
-        strokeWidth={strokeWidth}
-        id={props.id}
-        className={`${styles['giraffe-annotation-hover']} giraffe-annotation-line`}
-      />
-      <line
-        x1={clampedStart}
-        x2={clampedStart}
-        y1="0"
-        y2={length}
-        stroke={color}
-        strokeWidth={strokeWidth}
-        id={props.id}
-        className={`${styles['giraffe-annotation-hover']} giraffe-annotation-line`}
-        strokeDasharray={'4'}
-      />
-      {pin === 'circle' &&
-        createElement('circle', {
+  // dimension is x:
+  const xProps = {
+    x1: clampedStart,
+    x2: clampedStart,
+    y1: '0',
+    y2: length,
+    stroke: color,
+    strokeWidth,
+    id: props.id,
+    className: `${styles['giraffe-annotation-hover']} giraffe-annotation-line`,
+  }
+
+  // this is the rectangle that goes on top of a range annotation
+  const makeRangeRectangle = () => {
+    return createElement('polygon', {
+      points: `${clampedStart}, 0
+          ${clampedEnd}, 0
+          ${clampedEnd}, ${PIN_TRIANGLE_HEIGHT}
+          ${clampedStart}, ${PIN_TRIANGLE_HEIGHT}`,
+      fill: secondaryColor,
+      id: props.id,
+    })
+  }
+
+  // this is the overlay that goes over the whole range; with 10% opacity
+  const makeRangeOverlay = () => {
+    return createElement('polygon', {
+      points: `${clampedStart}, ${length}
+          ${clampedEnd}, ${length}
+          ${clampedEnd}, ${PIN_TRIANGLE_HEIGHT}
+          ${clampedStart}, ${PIN_TRIANGLE_HEIGHT}`,
+      fill: secondaryColor,
+      id: props.id,
+      opacity: 0.1,
+    })
+  }
+
+  const makePin = (pinType?: string, timeSignature?: number) => {
+    if (!timeSignature) {
+      timeSignature = clampedStart
+    }
+    if (!pinType) {
+      pinType = pin
+    }
+
+    switch (pinType) {
+      case 'circle':
+        return createElement('circle', {
           r: PIN_CIRCLE_RADIUS,
           fill: color,
-          cx: clampedStart,
+          cx: timeSignature,
           cy: PIN_CIRCLE_RADIUS,
-        })}
-      {pin === 'start' &&
-        createElement('polygon', {
-          points: `${clampedStart - PIN_TRIANGLE_WIDTH}, 0
-          ${clampedStart + PIN_TRIANGLE_WIDTH}, 0
-          ${clampedStart}, ${PIN_TRIANGLE_HEIGHT}`,
+        })
+      case 'start':
+        return createElement('polygon', {
+          points: `${timeSignature - PIN_TRIANGLE_WIDTH}, 0
+          ${timeSignature + PIN_TRIANGLE_WIDTH}, 0
+          ${timeSignature}, ${PIN_TRIANGLE_HEIGHT}`,
           fill: color,
           style: {cursor: 'pointer'},
           id: props.id,
           className: 'giraffe-annotation-click-target',
-        })}
-      {pin === 'stop' &&
-        createElement('polygon', {
-          points: `${clampedStart}, 0 ${clampedStart -
+        })
+      case 'stop':
+        return createElement('polygon', {
+          points: `${timeSignature}, 0 ${timeSignature -
             PIN_TRIANGLE_WIDTH}, ${PIN_TRIANGLE_HEIGHT /
-            2} ${clampedStart}, ${PIN_TRIANGLE_HEIGHT}`,
+            2} ${timeSignature}, ${PIN_TRIANGLE_HEIGHT}`,
           fill: color,
-        })}
-    </>
-  )
+        })
+      default:
+        return null
+    }
+  }
+  if (clampedStart === clampedEnd) {
+    return (
+      // a separate line layer on the annotation line is required on top,
+      // because the dashed line doesnt allow for a continuous click-able target
+      // this top layer has an opacity of 0 so is not visible.
+      <>
+        <line {...xProps} strokeOpacity={0} />
+        <line {...xProps} strokeDasharray={'4'} />
+        {makePin()}
+      </>
+    )
+  } else {
+    // they are different, need two lines here
+    const x2Props = {
+      ...xProps,
+      x1: clampedEnd,
+      x2: clampedEnd,
+    }
+    return (
+      <>
+        <line {...xProps} strokeOpacity={0} />
+        <line {...xProps} strokeDasharray={'4'} />
+        <line {...x2Props} strokeOpacity={0} />
+        <line {...x2Props} strokeDasharray={'4'} />
+        {makeRangeOverlay()}
+        {makeRangeRectangle()}
+        {makePin()}
+        {makePin('start', clampedEnd)}
+      </>
+    )
+  }
 }
 
 export default AnnotationLine

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -125,7 +125,7 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
   }
 
   // this is the overlay that goes over the whole range; with 10% opacity
-  // do not make this click to edit, b/c then cannot have overlapping point annotations
+  // making this click to edit will make overlapping point annotations impossible
   const makeRangeOverlay = () => {
     return createElement('polygon', {
       points: `${clampedStart}, ${length}
@@ -137,10 +137,7 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
     })
   }
 
-  const makePin = (pinType?: string, timeSignature?: number) => {
-    if (!timeSignature) {
-      timeSignature = clampedStart
-    }
+  const makePin = (pinType?: string) => {
     if (!pinType) {
       pinType = pin
     }
@@ -150,14 +147,14 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
         return createElement('circle', {
           r: PIN_CIRCLE_RADIUS,
           fill: color,
-          cx: timeSignature,
+          cx: clampedStart,
           cy: PIN_CIRCLE_RADIUS,
         })
       case 'start':
         return createElement('polygon', {
-          points: `${timeSignature - PIN_TRIANGLE_WIDTH}, 0
-          ${timeSignature + PIN_TRIANGLE_WIDTH}, 0
-          ${timeSignature}, ${PIN_TRIANGLE_HEIGHT}`,
+          points: `${clampedStart - PIN_TRIANGLE_WIDTH}, 0
+          ${clampedStart + PIN_TRIANGLE_WIDTH}, 0
+          ${clampedStart}, ${PIN_TRIANGLE_HEIGHT}`,
           fill: color,
           style: {cursor: 'pointer'},
           id: props.id,
@@ -165,9 +162,9 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
         })
       case 'stop':
         return createElement('polygon', {
-          points: `${timeSignature}, 0 ${timeSignature -
+          points: `${clampedStart}, 0 ${clampedStart -
             PIN_TRIANGLE_WIDTH}, ${PIN_TRIANGLE_HEIGHT /
-            2} ${timeSignature}, ${PIN_TRIANGLE_HEIGHT}`,
+            2} ${clampedStart}, ${PIN_TRIANGLE_HEIGHT}`,
           fill: color,
         })
       default:
@@ -198,24 +195,24 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
         {makePin()}
       </>
     )
-  } else {
-    // they are different (range annotation) , need two lines here
-    const x2Props = {
-      ...xProps,
-      x1: clampedEnd,
-      x2: clampedEnd,
-    }
-    return (
-      <>
-        <line {...xProps} strokeOpacity={0} />
-        <line {...xProps} strokeDasharray={'4'} />
-        <line {...x2Props} strokeOpacity={0} />
-        <line {...x2Props} strokeDasharray={'4'} />
-        {makeRangeOverlay()}
-        {makeRangeRectangle()}
-      </>
-    )
   }
+
+  // they are different (range annotation) , need two lines here
+  const x2Props = {
+    ...xProps,
+    x1: clampedEnd,
+    x2: clampedEnd,
+  }
+  return (
+    <>
+      <line {...xProps} strokeOpacity={0} />
+      <line {...xProps} strokeDasharray={'4'} />
+      <line {...x2Props} strokeOpacity={0} />
+      <line {...x2Props} strokeDasharray={'4'} />
+      {makeRangeOverlay()}
+      {makeRangeRectangle()}
+    </>
+  )
 }
 
 export default AnnotationLine

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -6,7 +6,6 @@ import styles from './AnnotationLine.scss'
 interface AnnotationLineProps {
   dimension: AnnotationDimension
   color: string
-  secondaryColor?: string
   strokeWidth: number
   startValue: number
   stopValue: number
@@ -17,14 +16,41 @@ interface AnnotationLineProps {
 
 // These could become configurable values
 const PIN_CIRCLE_RADIUS = 4
-const PIN_TRIANGLE_HEIGHT = 8
-const PIN_TRIANGLE_WIDTH = 6
+const PIN_TRIANGLE_HEIGHT = 11
+const PIN_TRIANGLE_WIDTH = 9
+const RANGE_HEIGHT = 9
 
+/**
+ *  This class draws the annotation itself.  Another handles the tooltip. (AnnotationTooltip)
+ *
+ *  If the annotation is a 'y' annotation, then this class *only* draws a point annotation
+ *  (a single dotted line) (at the start value) with an optional pin on the right.
+ *
+ *  If it the annotation is an 'x' annotation, if the startTime === stopTime
+ *  then this class draws a single dotted line, with an optional pin at the top
+ *
+ *  If startTime < stopTime
+ *  then this draws a line at the start, another at the end, with a 'hat' over it that is
+ *  entirely clickable; along with an overlay with 10% opacity that is NOT clickable.
+ *
+ *  The overlay is not clickable to allow overlapping point annotations.
+ *  If there are two overlapping range annotations (or any type of annotation, range or point)
+ *  then the annotation that was drawn last is clickable.  (they stack).  They are drawn in the order that
+ *  the annotations are created; not in their time order.
+ *
+ *  To make any element of the annotation line clickable, then that element needs to have the 'props.id' assigned to its id,
+ *  and (nice to have, but not required for clicking, but this shows the user that it
+ *  is clickable (affordance)), the style should get changed;
+ *
+ *  add to the 'createElement' object:
+ *
+ *  style: {cursor: 'pointer'}
+ *
+ * */
 export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
   const {
     dimension,
     color,
-    secondaryColor,
     strokeWidth,
     startValue,
     stopValue,
@@ -81,38 +107,32 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
   }
 
   // dimension is x:
-  const xProps = {
-    x1: clampedStart,
-    x2: clampedStart,
-    y1: '0',
-    y2: length,
-    stroke: color,
-    strokeWidth,
-    id: props.id,
-    className: `${styles['giraffe-annotation-hover']} giraffe-annotation-line`,
-  }
 
   // this is the rectangle that goes on top of a range annotation
+  // make it *all* click to edit
   const makeRangeRectangle = () => {
+    const pixelMargin = 1
+
     return createElement('polygon', {
-      points: `${clampedStart}, 0
-          ${clampedEnd}, 0
-          ${clampedEnd}, ${PIN_TRIANGLE_HEIGHT}
-          ${clampedStart}, ${PIN_TRIANGLE_HEIGHT}`,
-      fill: secondaryColor,
+      points: `${clampedStart - pixelMargin}, 0
+          ${clampedEnd + pixelMargin}, 0
+          ${clampedEnd + pixelMargin}, ${RANGE_HEIGHT}
+          ${clampedStart - pixelMargin}, ${RANGE_HEIGHT}`,
+      fill: color,
       id: props.id,
+      style: {cursor: 'pointer'},
     })
   }
 
   // this is the overlay that goes over the whole range; with 10% opacity
+  // do not make this click to edit, b/c then cannot have overlapping point annotations
   const makeRangeOverlay = () => {
     return createElement('polygon', {
       points: `${clampedStart}, ${length}
           ${clampedEnd}, ${length}
-          ${clampedEnd}, ${PIN_TRIANGLE_HEIGHT}
-          ${clampedStart}, ${PIN_TRIANGLE_HEIGHT}`,
-      fill: secondaryColor,
-      id: props.id,
+          ${clampedEnd}, ${RANGE_HEIGHT}
+          ${clampedStart}, ${RANGE_HEIGHT}`,
+      fill: color,
       opacity: 0.1,
     })
   }
@@ -154,7 +174,20 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
         return null
     }
   }
+
+  const xProps = {
+    x1: clampedStart,
+    x2: clampedStart,
+    y1: '0',
+    y2: length,
+    stroke: color,
+    strokeWidth,
+    id: props.id,
+    className: `${styles['giraffe-annotation-hover']} giraffe-annotation-line`,
+  }
+
   if (clampedStart === clampedEnd) {
+    // point annotation:
     return (
       // a separate line layer on the annotation line is required on top,
       // because the dashed line doesnt allow for a continuous click-able target
@@ -166,7 +199,7 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
       </>
     )
   } else {
-    // they are different, need two lines here
+    // they are different (range annotation) , need two lines here
     const x2Props = {
       ...xProps,
       x1: clampedEnd,
@@ -180,8 +213,6 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
         <line {...x2Props} strokeDasharray={'4'} />
         {makeRangeOverlay()}
         {makeRangeRectangle()}
-        {makePin()}
-        {makePin('start', clampedEnd)}
       </>
     )
   }

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -24,14 +24,18 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
     legendFont: font,
     legendFontColor: fontColor,
   } = config
-  const {dimension, startValue} = data || {}
+
+  const {dimension, startValue, stopValue} = data || {}
 
   // move this 15 pixels up to get out of the way of the annotation click target
   const yAxisTooltipOffset = -15
 
+  // setting position to be the average between start and stop;
+  // if it is a ranged annotation then it will appear in the middle,
+  // if it is a point annotation then the math is a no-op.
   const position = {
-    x: dimension === 'x' ? startValue : width,
-    y: dimension === 'y' ? startValue : yAxisTooltipOffset,
+    x: dimension === 'x' ? (startValue + stopValue) / 2 : width,
+    y: dimension === 'y' ? (startValue + stopValue) / 2 : yAxisTooltipOffset,
   } as TooltipPosition
 
   const clampedXOffset = Math.round(

--- a/giraffe/src/components/Brush.tsx
+++ b/giraffe/src/components/Brush.tsx
@@ -54,7 +54,7 @@ export const Brush: FunctionComponent<Props> = ({
       // doing brush now
       callback([p0, p1])
     } else {
-      if (event.mouseState === 'mouseUpHappened') {
+      if (event.mouseActionState === 'mouseUpHappened') {
         // a mouseUpHappened, so this is the equivalent of an 'onClick'
         // because brushing (dragging across an area) has not happened
         onClick(event?.mouseEvent)

--- a/giraffe/src/components/Brush.tsx
+++ b/giraffe/src/components/Brush.tsx
@@ -13,7 +13,7 @@ interface Props {
   height: number
   onXBrushEnd: (xRange: number[]) => void
   onYBrushEnd: (yRange: number[]) => void
-  onMouseUpEnd?: (mouseEvent: React.MouseEvent) => void
+  onClick?: (mouseEvent: React.MouseEvent) => void
 }
 
 export const Brush: FunctionComponent<Props> = ({
@@ -22,13 +22,12 @@ export const Brush: FunctionComponent<Props> = ({
   height,
   onXBrushEnd,
   onYBrushEnd,
-  onMouseUpEnd,
+  onClick,
 }) => {
   const isBrushing = event && event.direction
 
   useLayoutEffect(() => {
     if (event?.type !== 'dragend') {
-      //console.log('the event (not dragend).....(ack-42-1)', event)
       return
     }
 
@@ -52,18 +51,14 @@ export const Brush: FunctionComponent<Props> = ({
       if (p1 - p0 < MIN_SELECTION_SIZE) {
         return
       }
-      //console.log('brushing now!!!')
+      // doing brush now
       callback([p0, p1])
     } else {
       if (event.mouseState === 'mouseUpHappened') {
         // a mouseUpHappened, so this is the equivalent of an 'onClick'
         // because brushing (dragging across an area) has not happened
-        //console.log('DD-1 for reals!')
-        onMouseUpEnd(event?.mouseEvent)
+        onClick(event?.mouseEvent)
       }
-      // else {
-      //   //console.log('EE-1 ......phantom click.  DO NOTHING')
-      // }
     }
   }, [event?.type])
 

--- a/giraffe/src/components/Brush.tsx
+++ b/giraffe/src/components/Brush.tsx
@@ -4,6 +4,7 @@ import {useLayoutEffect, FunctionComponent, CSSProperties} from 'react'
 
 import {DragEvent} from '../utils/useDragEvent'
 import {getRectDimensions} from '../utils/brush'
+import {InteractionHandlerArguments} from "../types";
 
 const MIN_SELECTION_SIZE = 5 // pixels
 
@@ -13,6 +14,7 @@ interface Props {
   height: number
   onXBrushEnd: (xRange: number[]) => void
   onYBrushEnd: (yRange: number[]) => void
+  onMouseUpEnd?: (plotInteraction: InteractionHandlerArguments) => void
 }
 
 export const Brush: FunctionComponent<Props> = ({
@@ -25,9 +27,21 @@ export const Brush: FunctionComponent<Props> = ({
   const isBrushing = event && event.direction
 
   useLayoutEffect(() => {
+
+    if(event?.type === 'dragend') {
+      if (isBrushing){
+        console.log('brushing now!!!');
+      } else {
+        console.log("not brushing, but over.... (call onMouseUpEnd here)")
+        //want to elicit an onMouseUpEnd callback here
+      }
+    }
+
     if (!isBrushing || event.type !== 'dragend') {
       return
     }
+
+    console.log("got to main action! (woohoo!) ACK")
 
     let p0
     let p1
@@ -50,7 +64,7 @@ export const Brush: FunctionComponent<Props> = ({
     }
 
     callback([p0, p1])
-  })
+  }, [event?.type])
 
   if (!isBrushing || event.type === 'dragend') {
     return null

--- a/giraffe/src/components/Brush.tsx
+++ b/giraffe/src/components/Brush.tsx
@@ -13,7 +13,7 @@ interface Props {
   height: number
   onXBrushEnd: (xRange: number[]) => void
   onYBrushEnd: (yRange: number[]) => void
-  onMouseUpEnd?: () => void
+  onMouseUpEnd?: (mouseEvent: React.MouseEvent) => void
 }
 
 export const Brush: FunctionComponent<Props> = ({
@@ -28,17 +28,17 @@ export const Brush: FunctionComponent<Props> = ({
 
   // debounce a function WITHOUT ARGS
   // rolling our own, not using lodash b/c lodash is large and not included in giraffe
-  function debounce(func, timeout = 300) {
-    let timer
-    return () => {
-      clearTimeout(timer)
-      timer = setTimeout(() => {
-        func()
-      }, timeout)
-    }
-  }
+  // function debounce(func, timeout = 300) {
+  //   let timer
+  //   return () => {
+  //     clearTimeout(timer)
+  //     timer = setTimeout(() => {
+  //       func()
+  //     }, timeout)
+  //   }
+  // }
 
-  const debouncedOnMouseUpEnd = debounce(onMouseUpEnd)
+  //const debouncedOnMouseUpEnd = debounce(onMouseUpEnd)
 
   useLayoutEffect(() => {
     if (event?.type !== 'dragend') {
@@ -72,14 +72,11 @@ export const Brush: FunctionComponent<Props> = ({
       console.log('brushing now!!!')
       callback([p0, p1])
     } else {
-      console.log('not brushing, but over.... (call onMouseUpEnd here)')
-      console.log('in progress???', event.mouseState)
-      if (event.mouseState === 'mouseDownHappened') {
+      if (event.mouseState === 'mouseUpHappened') {
+        // a mouseUpHappened, so this is the equivalent of an 'onClick'
+        // because brushing (dragging across an area) has not happened
         console.log('DD-1 for reals!')
-        //want to elicit an onMouseUpEnd callback here
-
-        //TODO:  remove debounce.  pairing up mouse downs with ups removes the need for one.
-        debouncedOnMouseUpEnd()
+        onMouseUpEnd(event?.mouseEvent)
       } else {
         console.log('EE-1 ......phantom click.  DO NOTHING')
       }

--- a/giraffe/src/components/Brush.tsx
+++ b/giraffe/src/components/Brush.tsx
@@ -26,30 +26,13 @@ export const Brush: FunctionComponent<Props> = ({
 }) => {
   const isBrushing = event && event.direction
 
-  // debounce a function WITHOUT ARGS
-  // rolling our own, not using lodash b/c lodash is large and not included in giraffe
-  // function debounce(func, timeout = 300) {
-  //   let timer
-  //   return () => {
-  //     clearTimeout(timer)
-  //     timer = setTimeout(() => {
-  //       func()
-  //     }, timeout)
-  //   }
-  // }
-
-  //const debouncedOnMouseUpEnd = debounce(onMouseUpEnd)
-
   useLayoutEffect(() => {
     if (event?.type !== 'dragend') {
-      console.log('the event (not dragend).....(ack-42-1)', event)
+      //console.log('the event (not dragend).....(ack-42-1)', event)
       return
     }
 
-    console.log('the event (dragEnd! :).....(ack-42)', event)
-
     if (isBrushing) {
-      console.log('got to main action! (woohoo!) ACK')
       let callback
       let p0
       let p1
@@ -69,17 +52,18 @@ export const Brush: FunctionComponent<Props> = ({
       if (p1 - p0 < MIN_SELECTION_SIZE) {
         return
       }
-      console.log('brushing now!!!')
+      //console.log('brushing now!!!')
       callback([p0, p1])
     } else {
       if (event.mouseState === 'mouseUpHappened') {
         // a mouseUpHappened, so this is the equivalent of an 'onClick'
         // because brushing (dragging across an area) has not happened
-        console.log('DD-1 for reals!')
+        //console.log('DD-1 for reals!')
         onMouseUpEnd(event?.mouseEvent)
-      } else {
-        console.log('EE-1 ......phantom click.  DO NOTHING')
       }
+      // else {
+      //   //console.log('EE-1 ......phantom click.  DO NOTHING')
+      // }
     }
   }, [event?.type])
 

--- a/giraffe/src/components/SizedPlot.test.tsx
+++ b/giraffe/src/components/SizedPlot.test.tsx
@@ -102,9 +102,11 @@ describe('the SizedPlot', () => {
             )}
           </MockComponent>
         )
-        // when the user (for real) does a single click, then a mouse up happens.
-        // choose mouse up because the single click listener wasn't triggering except on
-        // double clicks
+
+        // we now do the single-click via the dragging listener,
+        // and pair mouseUps with mouseDowns;
+        // so doing a mousedown then a mouse Up to simulate a single click
+        fireEvent.mouseDown(screen.getByTestId('giraffe-inner-plot'))
         fireEvent.mouseUp(screen.getByTestId('giraffe-inner-plot'))
 
         expect(resetSpy).not.toHaveBeenCalled()

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -83,25 +83,12 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
 
   const defaultSpec = env.getSpec(0)
 
-  // get me the x value (which might be a timestamp) of a particular
-  // point on the x axis
-  const getValueX = (point, snapToDataPoint = true) => {
-    //get the actual value of the point given:
-    const actual = env.xScale.invert(point)
+  const getNearestDataPoint = graphPoint => {
+    // this gets the actual value of the point given:
+    // (the x value of a particular point on the x axis)
+    const valueX = env.xScale.invert(graphPoint)
 
-    // eventually:
-    //check the plot type. if it is not enabled for annotations,
-    // just return what we have now.
-    // if it is enabled, then keep going to get the closest
-    // data point
-
-    if (snapToDataPoint) {
-      return getNearestTimeStamp(actual)
-    }
-    return actual
-  }
-
-  const getNearestTimeStamp = valueX => {
+    // now find the nearest data point:
     let nearest = NaN
     if (valueX && defaultSpec?.type === SpecTypes.Line) {
       const timestamps = defaultSpec?.lineData[0]?.xs ?? []
@@ -112,8 +99,8 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
 
   // need them both (need the actual value for hovering)
   // so expanding it out
-  const valueX = getValueX(hoverEvent.x, false)
-  const clampedValueX = getNearestTimeStamp(valueX)
+  const valueX = env.xScale.invert(hoverEvent.x)
+  const clampedValueX = getNearestDataPoint(hoverEvent.x)
 
   const plotInteraction: InteractionHandlerArguments = {
     clampedValueX,
@@ -131,8 +118,8 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
   const handleXBrushEnd = useCallback(
     (xRange: number[]) => {
       if (userConfig?.interactionHandlers?.onXBrush) {
-        const beginning = getValueX(xRange[0], true)
-        const end = getValueX(xRange[1], true)
+        const beginning = getNearestDataPoint(xRange[0])
+        const end = getNearestDataPoint(xRange[1])
         userConfig.interactionHandlers.onXBrush(beginning, end)
       } else {
         env.xDomain = rangeToDomain(xRange, env.xScale, env.innerWidth)

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -60,13 +60,7 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
   const hoverX = dragEvent ? null : hoverEvent.x
   const hoverY = dragEvent ? null : hoverEvent.y
 
-  const handleXBrushEnd = useCallback(
-    (xRange: number[]) => {
-      env.xDomain = rangeToDomain(xRange, env.xScale, env.innerWidth)
-      forceUpdate()
-    },
-    [env.xScale, env.innerWidth, forceUpdate]
-  )
+
 
   const handleYBrushEnd = useCallback(
     (yRange: number[]) => {
@@ -116,6 +110,19 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
     },
   }
 
+  const handleXBrushEnd = useCallback(
+      (xRange: number[]) => {
+        console.log('in handleXBrushEnd; range??', xRange)
+        console.log('plot interaction??', plotInteraction)
+
+        env.xDomain = rangeToDomain(xRange, env.xScale, env.innerWidth)
+
+        console.log("new env domain???", env.xDomain)
+        forceUpdate()
+      },
+      [env.xScale, env.innerWidth, forceUpdate]
+  )
+
   const noOp = () => {}
   const singleClick = config.interactionHandlers?.singleClick
     ? event => {
@@ -153,6 +160,7 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
   // they are:  hover:  mouseEnter, mousemove, mouseleave
   //            drag target: mouseDown
   // and every time there is a single click, the mouse goes up.  so using that instead.
+//console.log("switched to single click..... ACK")
 
   return (
     <div

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -82,7 +82,6 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
   }, [env])
 
   const defaultSpec = env.getSpec(0)
-  //console.log('got the default spec: ', defaultSpec)
 
   // get me the x value (which might be a timestamp) of a particular
   // point on the x axis
@@ -131,18 +130,12 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
 
   const handleXBrushEnd = useCallback(
     (xRange: number[]) => {
-      console.log('in handleXBrushEnd; range??', xRange)
-      console.log('plot interaction??', plotInteraction)
-
       if (userConfig?.interactionHandlers?.onXBrush) {
-        console.log('in my xbrush!!! ack 44a')
         const beginning = getValueX(xRange[0], true)
         const end = getValueX(xRange[1], true)
-
         userConfig.interactionHandlers.onXBrush(beginning, end)
       } else {
         env.xDomain = rangeToDomain(xRange, env.xScale, env.innerWidth)
-        console.log('(normal zooming) new env domain???', env.xDomain)
         forceUpdate()
       }
     },
@@ -160,26 +153,12 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
         ) {
           return
         }
-
-        console.log(
-          '(ACK!!! 53) in singleclick, using plot interaction:',
-          plotInteraction
-        )
         userConfig.interactionHandlers.singleClick(plotInteraction)
       }
     : noOp
 
   if (userConfig.interactionHandlers?.hover) {
     userConfig.interactionHandlers.hover(plotInteraction)
-  }
-
-  const handleOnMouseUpEnd = event => {
-    console.log(
-      '22-UPDATED  here in on handle on mouse up end-ACK-updated; ',
-      clampedValueX,
-      plotInteraction
-    )
-    singleClick(event)
   }
 
   const fullsizeStyle: CSSProperties = {
@@ -190,12 +169,13 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
     bottom: 0,
   }
 
-  // for single clicking; using mouseup, since the onClick only gets through
-  // with a double click; and the hover and drag target does not use a mouse up;
-  // they are:  hover:  mouseEnter, mousemove, mouseleave
-  //            drag target: mouseDown
-  // and every time there is a single click, the mouse goes up.  so using that instead.
-  //console.log("switched to single click..... ACK")
+  // for single clicking:
+  // the brush element we are using uses a dragListener that consumes the
+  // 'onMouseDown'; thus the 'onClick' does not trigger.
+  // the Drag listener keeps track of the difference between a drag and a single click,
+  // and calls our 'singleClick' method when a single click happens.
+  // see useDragEvents.ts (the DragEvent in particular)
+  // in the src/util directory for more details.
 
   return (
     <div
@@ -363,7 +343,7 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
           height={env.innerHeight}
           onXBrushEnd={handleXBrushEnd}
           onYBrushEnd={handleYBrushEnd}
-          onMouseUpEnd={handleOnMouseUpEnd}
+          onClick={singleClick}
         />
       </div>
     </div>

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -108,10 +108,6 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
     },
   }
 
-  const handleOnMouseUpEnd = () => {
-    console.log('here in on handle on mouse up end; ', clampedValueX)
-  }
-
   const handleXBrushEnd = useCallback(
     (xRange: number[]) => {
       console.log('in handleXBrushEnd; range??', xRange)
@@ -149,8 +145,13 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
     config.interactionHandlers.hover(plotInteraction)
   }
 
-  const callbacks = {
-    singleClick,
+  const handleOnMouseUpEnd = event => {
+    console.log(
+      '22-UPDATED  here in on handle on mouse up end-ACK-updated; ',
+      clampedValueX,
+      plotInteraction
+    )
+    singleClick(event)
   }
 
   const fullsizeStyle: CSSProperties = {
@@ -192,7 +193,6 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
           left: `${margins.left}px`,
           cursor: `${userConfig.cursor || 'crosshair'}`,
         }}
-        onMouseUp={callbacks.singleClick}
         onDoubleClick={memoizedResetDomains}
         {...hoverTargetProps}
         {...dragTargetProps}

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -60,8 +60,6 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
   const hoverX = dragEvent ? null : hoverEvent.x
   const hoverY = dragEvent ? null : hoverEvent.y
 
-
-
   const handleYBrushEnd = useCallback(
     (yRange: number[]) => {
       env.yDomain = rangeToDomain(yRange, env.yScale, env.innerHeight).reverse()
@@ -110,17 +108,21 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
     },
   }
 
+  const handleOnMouseUpEnd = () => {
+    console.log('here in on handle on mouse up end; ', clampedValueX)
+  }
+
   const handleXBrushEnd = useCallback(
-      (xRange: number[]) => {
-        console.log('in handleXBrushEnd; range??', xRange)
-        console.log('plot interaction??', plotInteraction)
+    (xRange: number[]) => {
+      console.log('in handleXBrushEnd; range??', xRange)
+      console.log('plot interaction??', plotInteraction)
 
-        env.xDomain = rangeToDomain(xRange, env.xScale, env.innerWidth)
+      env.xDomain = rangeToDomain(xRange, env.xScale, env.innerWidth)
 
-        console.log("new env domain???", env.xDomain)
-        forceUpdate()
-      },
-      [env.xScale, env.innerWidth, forceUpdate]
+      console.log('new env domain???', env.xDomain)
+      forceUpdate()
+    },
+    [env.xScale, env.innerWidth, forceUpdate]
   )
 
   const noOp = () => {}
@@ -135,6 +137,10 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
           return
         }
 
+        console.log(
+          '(ACK!!! 53) in singleclick, using plot interaction:',
+          plotInteraction
+        )
         config.interactionHandlers.singleClick(plotInteraction)
       }
     : noOp
@@ -160,7 +166,7 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
   // they are:  hover:  mouseEnter, mousemove, mouseleave
   //            drag target: mouseDown
   // and every time there is a single click, the mouse goes up.  so using that instead.
-//console.log("switched to single click..... ACK")
+  //console.log("switched to single click..... ACK")
 
   return (
     <div
@@ -329,6 +335,7 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
           height={env.innerHeight}
           onXBrushEnd={handleXBrushEnd}
           onYBrushEnd={handleYBrushEnd}
+          onMouseUpEnd={handleOnMouseUpEnd}
         />
       </div>
     </div>

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -882,7 +882,6 @@ export interface AnnotationMark {
   title: string
   description: string
   color: string
-  secondaryColor?: string
   startValue: number
   stopValue: number
   dimension: AnnotationDimension

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -144,6 +144,7 @@ export interface InteractionHandlers {
   doubleClick?: (plotInteraction: InteractionHandlerArguments) => void
   singleClick?: (plotInteraction: InteractionHandlerArguments) => void
   hover?: (plotInteraction: InteractionHandlerArguments) => void
+  onXBrush?: (beginning: number | string, end: number | string) => void
 }
 
 export enum FormatterType {
@@ -881,6 +882,7 @@ export interface AnnotationMark {
   title: string
   description: string
   color: string
+  secondaryColor?: string
   startValue: number
   stopValue: number
   dimension: AnnotationDimension

--- a/giraffe/src/utils/annotationData.ts
+++ b/giraffe/src/utils/annotationData.ts
@@ -9,7 +9,6 @@ export const getAnnotationsPositions = (
   const annotationMarks: AnnotationMark[] = []
 
   annotationData.forEach(annotation => {
-    console.log('got an annotation to make a position from....', annotation)
     annotationMarks.push({
       ...annotation,
       pin: annotation.pin || 'none',

--- a/giraffe/src/utils/annotationData.ts
+++ b/giraffe/src/utils/annotationData.ts
@@ -9,6 +9,7 @@ export const getAnnotationsPositions = (
   const annotationMarks: AnnotationMark[] = []
 
   annotationData.forEach(annotation => {
+    console.log('got an annotation to make a position from....', annotation)
     annotationMarks.push({
       ...annotation,
       pin: annotation.pin || 'none',
@@ -25,6 +26,7 @@ export const getAnnotationsPositions = (
   return annotationMarks
 }
 
+// is the mouse within the start/stop area ? (using the margin)
 const isWithinHoverableArea = (
   startValue: number,
   stopValue: number,

--- a/giraffe/src/utils/useDragEvent.ts
+++ b/giraffe/src/utils/useDragEvent.ts
@@ -77,11 +77,10 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
   const onMouseDown = useCallback(
     (mouseDownEvent: React.MouseEvent<Element, MouseEvent>) => {
       mouseDownEvent.stopPropagation()
-      console.log('43a-1 CHANGED')
 
-      console.log(
-        'AA-1 in drag event......(on mouse down...was in frustration land....)'
-      )
+      // console.log(
+      //   'AA-1 in drag event......(on mouse down...was in frustration land....)'
+      // )
 
       const el = mouseDownEvent.currentTarget
 
@@ -94,7 +93,7 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
       const onMouseMove = mouseMoveEvent => {
         const [x, y] = getXYCoords(mouseMoveEvent)
 
-        console.log('BB-1 in on mouse move (drag event) ack-42a')
+        //console.log('BB-1 in on mouse move (drag event) ack-42a')
 
         const {initialX, initialY} = dragEventRef.current
         let {direction} = dragEventRef.current
@@ -125,7 +124,7 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
         document.removeEventListener('mousemove', onMouseMove)
         document.removeEventListener('mousemove', onMouseUp)
 
-        console.log('CC-1 in on mouse up (drag event)')
+        //console.log('CC-1 in on mouse up (drag event)')
         const [x, y] = getXYCoords(mouseUpEvent)
 
         let mouseState = null

--- a/giraffe/src/utils/useDragEvent.ts
+++ b/giraffe/src/utils/useDragEvent.ts
@@ -13,12 +13,12 @@ const MIN_DRAG_DELTA = 3
  * We can compensate for that by having a listener for 'onMouseUpEnd' for the consumer of this event (see Brush)
  *
  * But in order to differentiate between a drag and a click, we need to pair up the mouseDowns with the MouseUps and
- * only allow 'legal' mouseUps with the mouseState.
+ * only allow 'legal' mouseUps with the mouseActionState.
  *
  * A 'mouseUp' is only legal if it can be paired with a previous "mouseDown".
  *
  * If a 'mouseUp' happens after another 'mouseUp' (without a "mouseDown" in between)
- * then it is not legal and the 'mouseState' will be null.
+ * then it is not legal and the 'mouseActionState' will be null.
  *
  * The consumer (Brush, in this example) keeps track of whether or not the drag happens.
  *
@@ -35,16 +35,16 @@ const MIN_DRAG_DELTA = 3
  * Most of the time, there are additional onMouseUpEvents after that. (we will call them phantom mouseUps)
  *
  * We only want the first onMouseUp event to be legal.
- * So we check that the previous 'mouseState' was a mouseDownEvent ('mouseDownHappened'), and if so set the mouse state to a 'mouseUpHappened'.
+ * So we check that the previous 'mouseActionState' was a mouseDownEvent ('mouseDownHappened'), and if so set the mouse state to a 'mouseUpHappened'.
  *
  * When the next mouseUp Event happens (without a proper, previous matching mouseDown Event),
- * then mouseState will be set to null.
+ * then mouseActionState will be set to null.
  *
- * When the singleclick happens, it will check if the mouseState says 'mouseDownHappened'; if so; then it is a legal
- * mouseUp; and the mouseState will be set to 'mouseUpHappened'.  If the mouse state is *anything* other then ''mouseDownHappened', then
- * the mouseState is set to null.
+ * When the singleclick happens, it will check if the mouseActionState says 'mouseDownHappened'; if so; then it is a legal
+ * mouseUp; and the mouseActionState will be set to 'mouseUpHappened'.  If the mouse state is *anything* other then ''mouseDownHappened', then
+ * the mouseActionState is set to null.
  *
- * The consumer checks the mouseState, and only fires the event if the mouseState is 'mouseUpHappened'
+ * The consumer checks the mouseActionState, and only fires the event if the mouseActionState is 'mouseUpHappened'
  *
  * And thus we have some history and can pair mouse ups with mouse downs and assure that phantom clicks
  * do not cause wonky behavior.
@@ -62,7 +62,7 @@ export interface DragEvent {
   direction: 'x' | 'y' | null
   x: number
   y: number
-  mouseState: 'mouseUpHappened' | 'mouseDownHappened' | null
+  mouseActionState: 'mouseUpHappened' | 'mouseDownHappened' | null
   mouseEvent?: React.MouseEvent
 }
 
@@ -120,16 +120,16 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
 
         const [x, y] = getXYCoords(mouseUpEvent)
 
-        let mouseState = null
+        let mouseActionState = null
 
-        if (dragEventRef?.current?.mouseState === 'mouseDownHappened') {
-          mouseState = 'mouseUpHappened'
+        if (dragEventRef?.current?.mouseActionState === 'mouseDownHappened') {
+          mouseActionState = 'mouseUpHappened'
         }
 
         dragEventRef.current = {
           ...dragEventRef.current,
           type: 'dragend',
-          mouseState,
+          mouseActionState,
           x,
           y,
           mouseEvent: mouseUpEvent,
@@ -150,7 +150,7 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
         x,
         y,
         direction: null,
-        mouseState: 'mouseDownHappened',
+        mouseActionState: 'mouseDownHappened',
       }
 
       forceUpdate()

--- a/giraffe/src/utils/useDragEvent.ts
+++ b/giraffe/src/utils/useDragEvent.ts
@@ -7,51 +7,51 @@ import {useForceUpdate} from './useForceUpdate'
 const MIN_DRAG_DELTA = 3
 
 /**
- * Because dragging and mouse clicks are non trivial, this implementation of DragEvent consumes the mouseDown event
+ * Because dragging and mouse clicks are non trivial, this implementation of DragEvent consumes the mouseDown event;
  * which means that 'onClick' doesn't work for anything that uses these events.
  *
  * We can compensate for that by having a listener for 'onMouseUpEnd' for the consumer of this event (see Brush)
  *
- * but in order to differentiate between a drag and a click, we need to pair up the mouseDowns with the MouseUps and
+ * But in order to differentiate between a drag and a click, we need to pair up the mouseDowns with the MouseUps and
  * only allow 'legal' mouseUps with the mouseState.
  *
- * a 'mouseUp' is only legal if it can be paired with a previous "mouseDown".
+ * A 'mouseUp' is only legal if it can be paired with a previous "mouseDown".
  *
- * if a 'mouseUp' happens after another 'mouseUp' (without a "mouseDown" in between)
+ * If a 'mouseUp' happens after another 'mouseUp' (without a "mouseDown" in between)
  * then it is not legal and the 'mouseState' will be null.
  *
- * the consumer (Brush, in this example) keeps track of whether or not the drag happens.
+ * The consumer (Brush, in this example) keeps track of whether or not the drag happens.
  *
  * We need differentiation because:
  *
- * the issue is that when the drag is over, both the onBrushEnd (x or y) and then the
+ * The issue is that when the drag is over, both the onBrushEnd (x or y) and then the
  * onMouseUpEnd handlers get triggered; because of multiple mouseUp events.
  *
- * we want one or the other, not both. (a response to a range drag or to a single click)
+ * We want one or the other, not both. (a response to a range drag or to a single click)
  *
  * Each time there is a drag, there is ONE mouseDownEvent, then mousemove events, then one MouseUp Event that
  * triggers the onBrushEnd.
  *
- * most of the time, there are additional onMouseUpEvents after that. (i will call them phantom mouseUps)
+ * Most of the time, there are additional onMouseUpEvents after that. (we will call them phantom mouseUps)
  *
- * we only want the first onMouseUp event to be legal.
- * so we check that the previous 'mouseState' was a mouseDownEvent ('mouseDownHappened'), and if so set the mouse state to a 'mouseUpHappened'.
+ * We only want the first onMouseUp event to be legal.
+ * So we check that the previous 'mouseState' was a mouseDownEvent ('mouseDownHappened'), and if so set the mouse state to a 'mouseUpHappened'.
  *
  * When the next mouseUp Event happens (without a proper, previous matching mouseDown Event),
- * then mouseState will be set to null
+ * then mouseState will be set to null.
  *
  * When the singleclick happens, it will check if the mouseState says 'mouseDownHappened'; if so; then it is a legal
- * mouseUp; and the mouseState will be set to 'mouseUpHappened'.  if the mouse state is *anything* other then ''mouseDownHappened', then
+ * mouseUp; and the mouseState will be set to 'mouseUpHappened'.  If the mouse state is *anything* other then ''mouseDownHappened', then
  * the mouseState is set to null.
  *
- * the consumer checks the mousestate, and only fires the event if the mousestate is 'mouseUpHappened'
+ * The consumer checks the mouseState, and only fires the event if the mouseState is 'mouseUpHappened'
  *
- * and thus we have some history and can pair mouse ups with mouse downs and assure that phantom clicks
+ * And thus we have some history and can pair mouse ups with mouse downs and assure that phantom clicks
  * do not cause wonky behavior.
  *
- * removing the phantom clicks entirely is a MUCH harder problem; because this is a clicker used by people with events.
+ * Removing the phantom clicks entirely is a MUCH harder problem; because this is a clicker used by people with events.
  *
- * we are putting the mouseEvent into the event so that the consumer for the 'onMouseUpEnd' can use it, since that consumer
+ * We are putting the mouseEvent into the event so that the consumer for the 'onMouseUpEnd' can use it, since that consumer
  * is a mouseListener and needs the mouseEvent information.
  */
 
@@ -78,10 +78,6 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
     (mouseDownEvent: React.MouseEvent<Element, MouseEvent>) => {
       mouseDownEvent.stopPropagation()
 
-      // console.log(
-      //   'AA-1 in drag event......(on mouse down...was in frustration land....)'
-      // )
-
       const el = mouseDownEvent.currentTarget
 
       const getXYCoords = baseEvent => {
@@ -92,8 +88,6 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
 
       const onMouseMove = mouseMoveEvent => {
         const [x, y] = getXYCoords(mouseMoveEvent)
-
-        //console.log('BB-1 in on mouse move (drag event) ack-42a')
 
         const {initialX, initialY} = dragEventRef.current
         let {direction} = dragEventRef.current
@@ -124,7 +118,6 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
         document.removeEventListener('mousemove', onMouseMove)
         document.removeEventListener('mousemove', onMouseUp)
 
-        //console.log('CC-1 in on mouse up (drag event)')
         const [x, y] = getXYCoords(mouseUpEvent)
 
         let mouseState = null

--- a/giraffe/src/utils/useDragEvent.ts
+++ b/giraffe/src/utils/useDragEvent.ts
@@ -6,6 +6,50 @@ import {useForceUpdate} from './useForceUpdate'
 // action is a vertical or horizontal drag
 const MIN_DRAG_DELTA = 3
 
+/**
+ * Because dragging and mouse clicks are non trivial, this implementation of DragEvent consumes the mouseDown event
+ * which means that 'onClick' doesn't work for anything that uses these events.
+ *
+ * We can compensate for that by having a listener for 'onMouseUpEnd' for the consumer of this event (see Brush)
+ *
+ * but in order to differentiate between a drag and a click, we need to pair up the mouseDowns with the MouseUps and
+ * state which one is 'legal' with the mouseState.
+ *
+ * a 'mouseDown' is only legal if before it a "mouseUp" happened.
+ *
+ * if a 'mouseDown' happens after another 'mouseDown' (without a "mouseUp" in between)
+ * then it is not legal and the 'mouseState' will be null.
+ *
+ * the consumer (Brush, in this example) keeps track of whether or not the drag happens.
+ *
+ *
+ * We need differentiation because:
+ *
+ * the issue is that when the drag is over, both the onBrushEnd (x or y) and then the
+ * onMouseUpEnd handlers get triggered.
+ *
+ * we want one or the other, not both. (a response to a range drag or to a single click)
+ *
+ * Each time there is a drag, there is ONE mouseDownEvent, then mousemove events, then one MouseUp Event that
+ * triggers the onBrushEnd.
+ *
+ * most of the time, there are additional onMouseUpEvents after that. (i will call them phantom mouseUps)
+ *
+ * we only want the first onMouseUp event to be legal.
+ * so we check that the previous 'mouseState' was a mouseDownEvent, and if so set the mouse state to a mouseUpHappened.
+ *
+ * when the next mouseUp Event happens (without a proper mouseUp Event), then mouseState will be set to null
+ *
+ * when the singleclick happens, it will check if the mouseState says 'mouseDownHappened'; if so; then it is a legal
+ * mouseDown with a corresponding mouseUpHappened.
+ * if the mouseState is null, then it is a phantom click; so nothing will happen.
+ *
+ * and thus we have some history and can pair mouse ups with mouse downs and assure that phantom clicks
+ * do not cause wonky behavior.
+ *
+ * removing the phantom clicks entirely is a MUCH harder problem; because this is a clicker used by people with events.
+ */
+
 export interface DragEvent {
   type: 'drag' | 'dragend'
   initialX: number
@@ -13,6 +57,7 @@ export interface DragEvent {
   direction: 'x' | 'y' | null
   x: number
   y: number
+  mouseState: 'mouseUpHappened' | 'mouseDownHappened' | null
 }
 
 interface UseDragEventProps {
@@ -26,8 +71,10 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
   const onMouseDown = useCallback(
     (mouseDownEvent: React.MouseEvent<Element, MouseEvent>) => {
       mouseDownEvent.stopPropagation()
-        
-        console.log('in drag event......(on mouse down...was in frustration land....)')
+
+      console.log(
+        'AA-1 in drag event......(on mouse down...was in frustration land....)'
+      )
 
       const el = mouseDownEvent.currentTarget
 
@@ -40,7 +87,7 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
       const onMouseMove = mouseMoveEvent => {
         const [x, y] = getXYCoords(mouseMoveEvent)
 
-          console.log('in mouse mouse (drag event)');
+        console.log('BB-1 in on mouse move (drag event) ack-42a')
 
         const {initialX, initialY} = dragEventRef.current
         let {direction} = dragEventRef.current
@@ -48,11 +95,17 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
         if (!direction) {
           const dx = Math.abs(x - initialX)
           const dy = Math.abs(y - initialY)
+          console.log('moving......dx & dy', dx, dy)
 
           if (dx >= dy && dx > MIN_DRAG_DELTA) {
             direction = 'x'
+            console.log('direction set to x')
           } else if (dy > MIN_DRAG_DELTA) {
             direction = 'y'
+            console.log('direction set to y')
+          } else {
+            //not really moving....set to notMoving! (none)
+            console.log('no direction here....(none) ack-42!')
           }
         }
 
@@ -71,12 +124,19 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
         document.removeEventListener('mousemove', onMouseMove)
         document.removeEventListener('mousemove', onMouseUp)
 
-         console.log("in on mouse up (drag event)")
+        console.log('CC-1 in on mouse up (drag event)')
         const [x, y] = getXYCoords(mouseUpEvent)
+
+        let mouseState = null
+
+        if (dragEventRef?.current?.mouseState === 'mouseUpHappened') {
+          mouseState = 'mouseDownHappened'
+        }
 
         dragEventRef.current = {
           ...dragEventRef.current,
           type: 'dragend',
+          mouseState,
           x,
           y,
         }
@@ -96,6 +156,7 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
         x,
         y,
         direction: null,
+        mouseState: 'mouseUpHappened',
       }
 
       forceUpdate()

--- a/giraffe/src/utils/useDragEvent.ts
+++ b/giraffe/src/utils/useDragEvent.ts
@@ -26,6 +26,8 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
   const onMouseDown = useCallback(
     (mouseDownEvent: React.MouseEvent<Element, MouseEvent>) => {
       mouseDownEvent.stopPropagation()
+        
+        console.log('in drag event......(on mouse down...was in frustration land....)')
 
       const el = mouseDownEvent.currentTarget
 
@@ -37,6 +39,8 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
 
       const onMouseMove = mouseMoveEvent => {
         const [x, y] = getXYCoords(mouseMoveEvent)
+
+          console.log('in mouse mouse (drag event)');
 
         const {initialX, initialY} = dragEventRef.current
         let {direction} = dragEventRef.current
@@ -67,6 +71,7 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
         document.removeEventListener('mousemove', onMouseMove)
         document.removeEventListener('mousemove', onMouseUp)
 
+         console.log("in on mouse up (drag event)")
         const [x, y] = getXYCoords(mouseUpEvent)
 
         dragEventRef.current = {

--- a/stories/src/annotation.stories.tsx
+++ b/stories/src/annotation.stories.tsx
@@ -436,10 +436,6 @@ storiesOf('Annotations', module)
     const table = annotationsTable
     const includeLineLayer = boolean('Line Layer', true)
     const annotationColor = text('Annotation color string', 'green')
-    const annotationSecondaryColor = text(
-      'Annotation color string',
-      'lightgreen'
-    )
     const annotationDimension = select(
       'Annotation Dimension',
       {
@@ -541,7 +537,6 @@ storiesOf('Annotations', module)
         title: `Hi ${i}`,
         description: `start/value is ${startVal}`,
         color: annotationColor,
-        secondaryColor: annotationSecondaryColor,
         dimension: annotationDimension,
         startValue: Number(startVal),
         stopValue: Number(endVal),

--- a/stories/src/annotation.stories.tsx
+++ b/stories/src/annotation.stories.tsx
@@ -211,7 +211,7 @@ storiesOf('Annotations', module)
     const doubleClickHandler = plotInteraction => {
       // eslint-disable-next-line
       console.log(
-        'This double click function is overrdien! Returned arguments:',
+        'This double click function is overridden! Returned arguments:',
         plotInteraction
       )
     }
@@ -465,9 +465,6 @@ storiesOf('Annotations', module)
 
     const endTime = text('_endTime', String(Date.now() + 1000 * 60 * 6))
 
-    console.log('startTime:', currentTime)
-    console.log('endTime: ', endTime)
-
     const columnKey = annotationDimension === 'y' ? y : x
 
     const annotationsInput =
@@ -526,7 +523,6 @@ storiesOf('Annotations', module)
     )
 
     const numAnnotations = annotationsInput[0].length
-    console.log('num annotations??', numAnnotations)
 
     const annotationLayerData = []
 
@@ -543,8 +539,6 @@ storiesOf('Annotations', module)
         pin: pinType,
       })
     }
-
-    console.log('annotation layer data: ', annotationLayerData)
 
     const layers = [
       {

--- a/stories/src/annotation.stories.tsx
+++ b/stories/src/annotation.stories.tsx
@@ -436,6 +436,10 @@ storiesOf('Annotations', module)
     const table = annotationsTable
     const includeLineLayer = boolean('Line Layer', true)
     const annotationColor = text('Annotation color string', 'green')
+    const annotationSecondaryColor = text(
+      'Annotation color string',
+      'lightgreen'
+    )
     const annotationDimension = select(
       'Annotation Dimension',
       {
@@ -448,15 +452,32 @@ storiesOf('Annotations', module)
     const x = xKnob(table)
     const y = yKnob(table)
     const currentValue = text(
-      '_value',
+      '_startValue',
       x === VALUE
         ? String(table.getColumn(x, 'number')[0])
         : String(table.getColumn(y, 'number')[0])
     )
-    const currentTime = text('_time', String(Date.now() + 1000 * 60 * 6))
+
+    const endValue = text(
+      '_endValue',
+      x === VALUE
+        ? String(table.getColumn(x, 'number')[0])
+        : String(table.getColumn(y, 'number')[0])
+    )
+
+    const currentTime = text('_startTime', String(Date.now() + 1000 * 60 * 6))
+
+    const endTime = text('_endTime', String(Date.now() + 1000 * 60 * 6))
+
+    console.log('startTime:', currentTime)
+    console.log('endTime: ', endTime)
 
     const columnKey = annotationDimension === 'y' ? y : x
-    const annotationsInput = columnKey === TIME ? currentTime : currentValue
+
+    const annotationsInput =
+      columnKey === TIME
+        ? [currentTime.split(), endTime.split()]
+        : [currentValue.split(), endValue.split()]
 
     const tickFont = tickFontKnob()
     const valueAxisLabel = text('Value Axis Label', 'foo')
@@ -464,6 +485,12 @@ storiesOf('Annotations', module)
     const xScale = xScaleKnob()
     const yScale = yScaleKnob()
     const timeZone = timeZoneKnob('America/Los_Angeles')
+
+    const pinType = select(
+      'pin',
+      {start: 'start', stop: 'stop', none: 'none', circle: 'circle'},
+      'start'
+    )
     const timeFormat = select(
       'Time Format',
       {
@@ -502,19 +529,34 @@ storiesOf('Annotations', module)
       'auto'
     )
 
+    const numAnnotations = annotationsInput[0].length
+    console.log('num annotations??', numAnnotations)
+
+    const annotationLayerData = []
+
+    for (let i = 0; i < numAnnotations; i++) {
+      const startVal = annotationsInput[0][i]
+      const endVal = annotationsInput[1][i]
+      annotationLayerData.push({
+        title: `Hi ${i}`,
+        description: `start/value is ${startVal}`,
+        color: annotationColor,
+        secondaryColor: annotationSecondaryColor,
+        dimension: annotationDimension,
+        startValue: Number(startVal),
+        stopValue: Number(endVal),
+        pin: pinType,
+      })
+    }
+
+    console.log('annotation layer data: ', annotationLayerData)
+
     const layers = [
       {
         type: 'annotation',
         x,
         y,
-        annotations: annotationsInput.split(',').map((valueString: string) => ({
-          title: 'Hi',
-          description: `value is ${valueString}`,
-          color: annotationColor,
-          dimension: annotationDimension,
-          startValue: Number(valueString),
-          stopValue: Number(valueString),
-        })),
+        annotations: annotationLayerData,
         fill,
         hoverDimension,
         hoverMargin: annotationHoverMargin,


### PR DESCRIPTION
for giraffe#585

this PR is all about drawing annotations.

users of this library (ui, in our case) has its own listeners for graph interaction to add annotations

added a new interaction handler; so that when brushing on the x axis, a callback other than zoom can be invoked

also: differentiating now properly between drags and single clicks.