### PR TITLE
chore: refactor spec types to set

### DIFF
--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -76,7 +76,8 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
     forceUpdate()
   }
 
-  // spec types applicable to annotations
+  // spec types applicable to annotations.
+  // add to this set as new plot types are added.
   const annotationSpecTypes = new Set<string>()
   annotationSpecTypes.add(SpecTypes.Line)
   annotationSpecTypes.add(SpecTypes.Band)
@@ -93,17 +94,15 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
     // (the x value of a particular point on the x axis)
     const valueX = env.xScale.invert(graphPoint)
 
-    // NOTE:  every time a new plot type is added to annotations,
-    // need to add the type below in the 'if' statement clause
-
     // now find the nearest data point:
     let nearest = NaN
     if (
       valueX &&
+      defaultSpec &&
       'lineData' in defaultSpec &&
       annotationSpecTypes.has(defaultSpec.type)
     ) {
-      const timestamps = defaultSpec?.lineData[0]?.xs ?? []
+      const timestamps = defaultSpec.lineData[0]?.xs ?? []
       nearest = nearestTimestamp(timestamps, valueX)
     }
     return nearest

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -76,6 +76,11 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
     forceUpdate()
   }
 
+  // spec types applicable to annotations
+  const annotationSpecTypes = new Set<string>()
+  annotationSpecTypes.add(SpecTypes.Line)
+  annotationSpecTypes.add(SpecTypes.Band)
+
   const memoizedResetDomains = useCallback(() => {
     env.resetDomains()
     forceUpdate()
@@ -95,8 +100,8 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
     let nearest = NaN
     if (
       valueX &&
-      (defaultSpec?.type === SpecTypes.Line ||
-        defaultSpec?.type === SpecTypes.Band)
+      'lineData' in defaultSpec &&
+      annotationSpecTypes.has(defaultSpec.type)
     ) {
       const timestamps = defaultSpec?.lineData[0]?.xs ?? []
       nearest = nearestTimestamp(timestamps, valueX)


### PR DESCRIPTION
1) refactors the allowed annotation spec types to a set that can be easily expanded
2) requires that defaultType includes property `lineData` before enabling annotations
3) ensures that defaultType exists