### PR TITLE
feat: export createGroupIDColumn

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.10.7",
+  "version": "2.11.0",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/index.ts
+++ b/giraffe/src/index.ts
@@ -20,6 +20,7 @@ export {getLatestValues} from './utils/getLatestValues'
 export {formatStatValue} from './utils/formatStatValue'
 
 // Transforms
+export {createGroupIDColumn} from './transforms'
 export {lineTransform} from './transforms/line'
 
 // Constants


### PR DESCRIPTION
Exports `createGroupIDColumn` to allow consuming apps to create the proper order for the `fill` property