### PR TITLE
feat: disable the hover layers for line and band when legendHide is truthy to avoid confusing the user

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/BandLayer.tsx
+++ b/giraffe/src/components/BandLayer.tsx
@@ -30,6 +30,7 @@ export const BandLayer: FunctionComponent<Props> = props => {
     height,
     hoverX,
     hoverY,
+    legendHide,
     spec,
     width,
     xScale,
@@ -119,7 +120,8 @@ export const BandLayer: FunctionComponent<Props> = props => {
     )
   )
 
-  const hasHoverData = hoverRowIndices && hoverRowIndices.length > 0
+  const hasHoverData =
+    hoverRowIndices && hoverRowIndices.length > 0 && !legendHide
 
   return (
     <>

--- a/giraffe/src/components/LineLayer.tsx
+++ b/giraffe/src/components/LineLayer.tsx
@@ -18,12 +18,13 @@ export const LineLayer: FunctionComponent<Props> = props => {
   const {
     config,
     spec,
-    width,
     height,
+    width,
     xScale,
     yScale,
     hoverX,
     hoverY,
+    legendHide,
     canvasRef,
   } = props
   const {position} = config
@@ -78,7 +79,8 @@ export const LineLayer: FunctionComponent<Props> = props => {
     height
   )
 
-  const hasHoverData = hoverRowIndices && hoverRowIndices.length > 0
+  const hasHoverData =
+    hoverRowIndices && hoverRowIndices.length > 0 && !legendHide
 
   return (
     <>

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -69,7 +69,7 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
   )
 
   const {margins, config} = env
-  const {width, height, showAxes} = config
+  const {width, height, legendHide, showAxes} = config
 
   const resetDomains = env => {
     env.resetDomains()
@@ -197,7 +197,9 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
           right: `${margins.right}px`,
           bottom: `${margins.bottom}px`,
           left: `${margins.left}px`,
-          cursor: `${userConfig.cursor || 'crosshair'}`,
+          cursor: `${userConfig.cursor ||
+            (!legendHide && 'crosshair') ||
+            'auto'}`,
         }}
         onDoubleClick={memoizedResetDomains}
         {...hoverTargetProps}
@@ -256,6 +258,7 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
             const sharedProps = {
               hoverX,
               hoverY,
+              legendHide,
               plotConfig: config,
               xScale: env.xScale,
               yScale: env.yScale,

--- a/giraffe/src/types/index.ts
+++ b/giraffe/src/types/index.ts
@@ -689,17 +689,18 @@ export interface RectLayerSpec {
 }
 
 export interface LayerProps {
-  xScale: Scale<number, number>
-  yScale: Scale<number, number>
-  width: number
-  height: number
-  spec: LayerSpec
+  columnFormatter: (colKey: string) => (x: any) => string
+  yColumnType: ColumnType
   config: LayerConfig
   plotConfig: SizedConfig
-  yColumnType: ColumnType
-  columnFormatter: (colKey: string) => (x: any) => string
+  spec: LayerSpec
   hoverX: number | null
   hoverY: number | null
+  legendHide: boolean
+  height: number
+  width: number
+  xScale: Scale<number, number>
+  yScale: Scale<number, number>
 }
 
 export interface Scale<D = any, R = any> {

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.12.1",
+  "version": "2.13.1",
   "license": "MIT",
   "scripts": {
     "lint": "eslint '{src,../giraffe/src}/**/*.{ts,tsx}'",

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.10.7",
+  "version": "2.12.1",
   "license": "MIT",
   "scripts": {
     "lint": "eslint '{src,../giraffe/src}/**/*.{ts,tsx}'",


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/1456

To avoid confusing the user and leading them to thinking there's a bug, the hover layer should be disabled when `legendHide` is truthy.

When disabled, the cursor is now 'auto' (not a crosshair), and there is no guide wire. 

https://user-images.githubusercontent.com/10736577/120868518-13c69d00-c549-11eb-82a0-05dca0750fd4.mp4

