### PR TITLE
Fix/maps pivoted tooltips

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/geo/processing/NativeGeoTable.ts
+++ b/giraffe/src/components/geo/processing/NativeGeoTable.ts
@@ -8,10 +8,14 @@ import {
   GEO_HASH_COLUMN,
   LAT_COLUMN,
   LON_COLUMN,
+  START_COLUMN,
+  STOP_COLUMN,
   TABLE_COLUMN,
+  TIME_COLUMN,
 } from './tableProcessing'
-import {getLatLonMixin, getTimeStringMixin} from './mixins'
+import {getLatLonMixin} from './mixins'
 import {LatLonColumns} from '../../../types/geo'
+import {timestampToString} from '../../../utils/geo'
 
 export class NativeGeoTable implements GeoTable {
   coordinateEncoding: CoordinateEncoding
@@ -95,7 +99,23 @@ export class NativeGeoTable implements GeoTable {
 
   getLatLon = getLatLonMixin.bind(this)
 
-  getTimeString = getTimeStringMixin.bind(this)
+  getTimeString(index: number): string {
+    const timeValue = this.getValue(index, TIME_COLUMN)
+    if (timeValue) {
+      return timestampToString(timeValue)
+    }
+    const startValue = this.getValue(index, START_COLUMN)
+    const stopValue = this.getValue(index, STOP_COLUMN)
+    if (startValue && stopValue) {
+      return `${timestampToString(startValue)} - ${timestampToString(
+        stopValue
+      )}`
+    }
+    const value = startValue || stopValue
+    if (value) {
+      return timestampToString(value)
+    }
+  }
 }
 
 const getDataEncoding = (

--- a/giraffe/src/components/geo/processing/mixins.ts
+++ b/giraffe/src/components/geo/processing/mixins.ts
@@ -2,7 +2,6 @@ import {S2} from 's2-geometry'
 import {HEX_DIGIT_NUM} from '../../../utils/geo'
 import {CoordinateEncoding} from './GeoTable'
 import {Coordinates} from './GeoTable'
-import {START_COLUMN, STOP_COLUMN, TIME_COLUMN} from './tableProcessing'
 
 export const getLatLonMixin = function(index: number): Coordinates {
   if (this.coordinateEncoding === CoordinateEncoding.FIELDS) {
@@ -26,24 +25,6 @@ export const getLatLonMixin = function(index: number): Coordinates {
     lat: latLng.lat,
   }
 }
-
-export const getTimeStringMixin = function(index: number): string {
-  const timeValue = this.getValue(index, TIME_COLUMN)
-  if (timeValue) {
-    return timestampToString(timeValue)
-  }
-  const startValue = this.getValue(index, START_COLUMN)
-  const stopValue = this.getValue(index, STOP_COLUMN)
-  if (startValue && stopValue) {
-    return `${timestampToString(startValue)} - ${timestampToString(stopValue)}`
-  }
-  const value = startValue || stopValue
-  if (value) {
-    return timestampToString(value)
-  }
-}
-
-const timestampToString = timeValue => new Date(timeValue).toLocaleString()
 
 const precisionTrimming = precisionTrimmingTable => {
   for (let i = 1; i < 17; i++) {

--- a/giraffe/src/utils/geo.ts
+++ b/giraffe/src/utils/geo.ts
@@ -29,6 +29,9 @@ export const getMinZoom = (width: number): number => {
   return Math.ceil(Math.log2(width / 256) * ZOOM_FRACTION) / ZOOM_FRACTION
 }
 
+export const timestampToString = timeValue =>
+  new Date(timeValue).toLocaleString()
+
 export const getRowLimit = (layers: GeoViewLayer[]) => {
   return Math.min.apply(
     null,
@@ -139,7 +142,9 @@ export const formatPointLayerRowInfo = (
           colorValue,
           colorDimension
         )
-        result.push(fillInfo)
+        if (fillInfo) {
+          result.push(fillInfo)
+        }
       }
     })
   }


### PR DESCRIPTION
The `PivotedGeoTable` doesn't show tooltips as it doesn't hold the table tags/fields data in the abstract properties. I have added the property to store the table into this abstract class and updated `getValue` function to search for the correct fields/tags.