### PR TITLE
fix: remove absolute positioning in static legend for easier styling

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.15.3",
+  "version": "2.15.4",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/StaticLegendBox.tsx
+++ b/giraffe/src/components/StaticLegendBox.tsx
@@ -100,18 +100,13 @@ export const StaticLegendBox: FunctionComponent<StaticLegendBoxProps> = props =>
         ...style,
         backgroundColor,
         border,
-        bottom: 0,
         boxSizing: 'border-box',
         color: fontBrightColor,
         cursor: staticLegendOverride.cursor,
         font,
         height: `${height}px`,
-        left: 0,
         opacity,
         overflow: 'auto',
-        position: 'absolute',
-        right: 0,
-        top: `${top}px`,
         width: `${width}px`,
       }}
       data-testid="giraffe-static-legend"

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.15.0",
+  "version": "2.15.4",
   "license": "MIT",
   "scripts": {
     "lint": "eslint '{src,../giraffe/src}/**/*.{ts,tsx}'",


### PR DESCRIPTION
In support of https://github.com/influxdata/ui/issues/1749

By removing the absolute position in static legend, consuming apps have a much easier time styling the static legend and its parent elements to handle overflow, such as with scrollbars. Everything still looks the same with these changes.

<img width="1680" alt="Screen Shot 2021-06-22 at 3 27 46 PM" src="https://user-images.githubusercontent.com/10736577/123007871-c0d54e00-d36e-11eb-949b-faf269ad3b3d.png">

<img width="1680" alt="Screen Shot 2021-06-22 at 3 27 53 PM" src="https://user-images.githubusercontent.com/10736577/123007879-c6329880-d36e-11eb-8b3a-b05c56d1db5a.png">
