### PR TITLE
fix: use correct dependencies for renderEffect to prevent infinite re…

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.15.5",
+  "version": "2.15.6",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/StaticLegendBox.tsx
+++ b/giraffe/src/components/StaticLegendBox.tsx
@@ -90,7 +90,7 @@ export const StaticLegendBox: FunctionComponent<StaticLegendBoxProps> = props =>
       headerTextMetrics,
       sampleTextMetrics,
     })
-  }, [legendData, staticLegendOverride])
+  }, [height, legendData, top])
 
   return (
     <div

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.15.5",
+  "version": "2.15.6",
   "license": "MIT",
   "scripts": {
     "lint": "eslint '{src,../giraffe/src}/**/*.{ts,tsx}'",


### PR DESCRIPTION
Addresses https://github.com/influxdata/ui/issues/1803

By changing the dependencies to depend on only heights, renderEffect will not fire again if the consumer has not yet had a chance to update the heights. This prevents infinite re-render.

Here is the fix in a custom artifact running in the UI:

https://user-images.githubusercontent.com/10736577/123363485-81059680-d527-11eb-8948-9b1f7a9ce67d.mp4

