### PR TITLE
fix: changed unused event removal for mousemove; use mouseup

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.15.6",
+  "version": "2.15.7",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/utils/useDragEvent.ts
+++ b/giraffe/src/utils/useDragEvent.ts
@@ -119,7 +119,7 @@ export const useDragEvent = (): [DragEvent | null, UseDragEventProps] => {
 
       const onMouseUp = mouseUpEvent => {
         document.removeEventListener('mousemove', onMouseMove)
-        document.removeEventListener('mousemove', onMouseUp)
+        document.removeEventListener('mouseup', onMouseUp)
 
         const [x, y] = getXYCoords(mouseUpEvent)
 

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.15.6",
+  "version": "2.15.7",
   "license": "MIT",
   "scripts": {
     "lint": "eslint '{src,../giraffe/src}/**/*.{ts,tsx}'",


### PR DESCRIPTION
Closes #628

I think this is a longstanding memory leak. It looks like it was mistakenly added in this [two year old PR.](https://github.com/influxdata/giraffe/commit/80822c79190a07aae3495077842a6a1b15e291c8#diff-795c398b1510d545f8ae5cdee91c58b3b66886f987c1fea1bb2855d50bf190e4R82) Looks like a bad copy/paste job to me.

### Testing instructions:

To reproduce the bug in UI:
1. Create a graph in a cell in a dashboard
1. Do something in the graph that causes one of the callback functions in SizedPlot to fire. e.g.: Drag to resize, add an annotation, etc.
1. Navigate away from the graph. I usually go to Explore
1. Click Boards. The error should fire.

To test the fix:
1. `yarn start`
2. `npm pack`
3. from ui: `yarn cache clean && yarn add $path_to_packed_file` (it's important to clear your cache)
4. repeat the steps above