### PR TITLE
refactor: remove conditional hooks usage for useTooltipElement

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.15.7",
+  "version": "2.15.8",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -7,7 +7,7 @@ import {
   ANNOTATION_TOOLTIP_CONTAINER_NAME,
   ANNOTATION_DEFAULT_MAX_WIDTH,
 } from '../constants'
-import {useTooltipElement} from '../utils/legend/useTooltipElement'
+import {useAnnotationTooltipElement} from '../utils/legend/useTooltipElement'
 
 interface Props {
   boundingReference: DOMRect
@@ -46,7 +46,7 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
     boundingReference ? boundingReference.y : position.y
   )
 
-  const annotationTooltipElement = useTooltipElement(
+  const annotationTooltipElement = useAnnotationTooltipElement(
     ANNOTATION_TOOLTIP_CONTAINER_NAME,
     {
       xOffset: clampedXOffset,

--- a/giraffe/src/components/Tooltip.tsx
+++ b/giraffe/src/components/Tooltip.tsx
@@ -4,7 +4,7 @@ import {createPortal} from 'react-dom'
 
 import {LegendData, Config} from '../types'
 import {Legend} from './Legend'
-import {useTooltipElement} from '../utils/legend/useTooltipElement'
+import {useLegendElement} from '../utils/legend/useTooltipElement'
 import {TOOLTIP_MAXIMUM_OPACITY, TOOLTIP_MINIMUM_OPACITY} from '../constants'
 
 interface Props {
@@ -22,7 +22,7 @@ export const Tooltip: FunctionComponent<Props> = ({data, config}) => {
     legendHide: isHidden,
     legendOpacity,
   } = config
-  const tooltipElement = useTooltipElement('giraffe-tooltip-container')
+  const tooltipElement = useLegendElement('giraffe-tooltip-container')
 
   const tooltipOpacity = useMemo(() => {
     if (

--- a/giraffe/src/utils/legend/useTooltipElement.ts
+++ b/giraffe/src/utils/legend/useTooltipElement.ts
@@ -1,7 +1,6 @@
 import {useRef, useEffect} from 'react'
 
 import {AnnotationTooltipOptions} from '../../types'
-import {ANNOTATION_TOOLTIP_CONTAINER_NAME} from '../../constants'
 import {useTooltipStyle, useAnnotationStyle} from './useTooltipStyle'
 
 /*
@@ -14,9 +13,29 @@ import {useTooltipStyle, useAnnotationStyle} from './useTooltipStyle'
   The returned node is intended to be used with `React.createPortal`. It is
   appended to the end of the document to circumvent z-index issues.
 */
-export const useTooltipElement = (
+export const useLegendElement = (className: string) => {
+  const ref = useRef<HTMLDivElement>(null)
+
+  if (ref.current === null) {
+    ref.current = document.createElement('div')
+    ref.current.classList.add(className)
+
+    document.body.appendChild(ref.current)
+  }
+
+  useEffect(() => () => document.body.removeChild(ref.current), [])
+
+  useTooltipStyle(ref.current)
+
+  return ref.current
+}
+
+/*
+  Similar to useLegendElement but for Annotation tooltips
+*/
+export const useAnnotationTooltipElement = (
   className: string,
-  options?: AnnotationTooltipOptions
+  options: AnnotationTooltipOptions
 ) => {
   const ref = useRef<HTMLDivElement>(null)
 
@@ -29,11 +48,7 @@ export const useTooltipElement = (
 
   useEffect(() => () => document.body.removeChild(ref.current), [])
 
-  if (className == ANNOTATION_TOOLTIP_CONTAINER_NAME) {
-    useAnnotationStyle(ref.current, options)
-  } else {
-    useTooltipStyle(ref.current)
-  }
+  useAnnotationStyle(ref.current, options)
 
   return ref.current
 }

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.15.7",
+  "version": "2.15.8",
   "license": "MIT",
   "scripts": {
     "lint": "eslint '{src,../giraffe/src}/**/*.{ts,tsx}'",


### PR DESCRIPTION
Part of #630 

- refactors a conditional usage of hooks into separate hooks with no change in behavior

- Addresses 2 errors:
```
/giraffe/src/utils/legend/useTooltipElement.ts
  33:5  error  React Hook "useAnnotationStyle" is called conditionally. React Hooks must be called in the exact same order in every component render  react-hooks/rules-of-hooks
  35:5  error  React Hook "useTooltipStyle" is called conditionally. React Hooks must be called in the exact same order in every component render     react-hooks/rules-of-hooks
```


<img width="1680" alt="Screen Shot 2021-06-30 at 6 10 11 PM" src="https://user-images.githubusercontent.com/10736577/124050350-455b4880-d9cf-11eb-91a2-8b7a1275611f.png">

