### PR TITLE
WIP: chore: disable eslint warning for missing dependency because it should not be included

### DIFF
--- a/giraffe/src/components/StaticLegendBox.tsx
+++ b/giraffe/src/components/StaticLegendBox.tsx
@@ -61,6 +61,7 @@ export const StaticLegendBox: FunctionComponent<StaticLegendBoxProps> = props =>
   ])
 
   const {style = {}} = staticLegendOverride
+  const {renderEffect} = staticLegendOverride
 
   const {
     legendBackgroundColor: backgroundColor,
@@ -80,7 +81,7 @@ export const StaticLegendBox: FunctionComponent<StaticLegendBoxProps> = props =>
 
   useEffect(() => {
     const {headerTextMetrics, sampleTextMetrics} = getStaticLegendTexMetrics()
-    staticLegendOverride.renderEffect({
+    renderEffect({
       totalHeight: height + top,
       staticLegendHeight: height,
       legendDataLength: legendData.length,
@@ -90,6 +91,10 @@ export const StaticLegendBox: FunctionComponent<StaticLegendBoxProps> = props =>
       headerTextMetrics,
       sampleTextMetrics,
     })
+    /* run this hook only for the height changes because the purpose is to set the height for user
+     * therefore, the dependencies should not include anything that doesn't affect height
+     */
+    // eslint-disable-next-line
   }, [height, legendData, top])
 
   return (


### PR DESCRIPTION
As part of #630 

Disable the eslint warning proactively because we do not need `renderEffect` as a dependency. `renderEffect` is a function given by the consumer to be run inside the hook. The function should not change. It is used only to adjust the height of the static legend automatically. The hook should only run when anything associated with the height changes.

Note: this change is being made to eliminate a warning that would appear only if `eslint-plugin-react-hooks` is installed