### PR TITLE
fix: update native geo table to use s2 column

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.15.8",
+  "version": "2.15.9",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/geo/processing/NativeGeoTable.ts
+++ b/giraffe/src/components/geo/processing/NativeGeoTable.ts
@@ -21,6 +21,7 @@ export class NativeGeoTable implements GeoTable {
   coordinateEncoding: CoordinateEncoding
   table: Table
   maxRows: number
+  s2Column: string
   latLonColumns: LatLonColumns
 
   constructor(
@@ -32,6 +33,7 @@ export class NativeGeoTable implements GeoTable {
     this.coordinateEncoding = getDataEncoding(table, latLonColumns, s2Column)
     this.table = table
     this.maxRows = maxRows
+    this.s2Column = s2Column
     this.latLonColumns = latLonColumns
   }
 
@@ -50,7 +52,7 @@ export class NativeGeoTable implements GeoTable {
   }
 
   getS2CellID(index: number): string {
-    const column = this.table.getColumn(GEO_HASH_COLUMN)
+    const column = this.table.getColumn(this.s2Column || GEO_HASH_COLUMN)
     if (!column) {
       return null
     }

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.15.8",
+  "version": "2.15.9",
   "license": "MIT",
   "scripts": {
     "lint": "eslint '{src,../giraffe/src}/**/*.{ts,tsx}'",

--- a/stories/src/geo.stories.tsx
+++ b/stories/src/geo.stories.tsx
@@ -169,7 +169,7 @@ geo.add('Map Markers Custom CSV', () => {
     lattitudeSelection = lattitudeKnob(table)
     longitudeSelection = longitudeKnob(table)
   } else {
-    s2GeoHash = s2GeoHashKnob(table, 's2_cell_id')
+    s2GeoHash = s2GeoHashKnob(table, {key: 'tag', column: 's2_cell_id'})
   }
 
   const config: Config = {
@@ -184,7 +184,7 @@ geo.add('Map Markers Custom CSV', () => {
         allowPanAndZoom,
         detectCoordinateFields: false,
         useS2CellID,
-        s2Column: s2GeoHash,
+        s2Column: s2GeoHash.column,
         latLonColumns: {lat: lattitudeSelection, lon: longitudeSelection},
         layers: [
           {

--- a/stories/src/helpers.tsx
+++ b/stories/src/helpers.tsx
@@ -243,6 +243,6 @@ export const longitudeKnob = (table: Table, initial?: Record<string, any>) => {
   )
 }
 
-export const s2GeoHashKnob = (table: Table, initial?: string) => {
+export const s2GeoHashKnob = (table: Table, initial?: any) => {
   return select('S2 Geo Hash:', findTags(table), initial || '_value')
 }


### PR DESCRIPTION
Turns out there was a hardcoded value being used for using `s2_cell_id` to get lat/lon coordinates. I updated NativeGeoTable to use the selected s2Column