### PR TITLE
fix: enable multi line annotation tooltips

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -126,11 +126,15 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
       <div style={tooltipCaretStyle} />
       <div style={tooltipCaretFillStyle} />
 
-      {multiLines.map(line => {
+      {multiLines.map((line, index) => {
         if (!line || line === '' || line.trim() === '') {
           return <br />
         }
-        return <div style={textContainerStyle}>{line}</div>
+        return (
+          <div key={`annoLine-${index}`} style={textContainerStyle}>
+            {line}
+          </div>
+        )
       })}
       <div style={textContainerStyle}>{data.description}</div>
     </div>,

--- a/giraffe/src/components/AnnotationTooltip.tsx
+++ b/giraffe/src/components/AnnotationTooltip.tsx
@@ -104,6 +104,8 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
     overflowWrap: 'break-word',
   }
 
+  const multiLines = data.title.split('\n')
+
   return createPortal(
     <div
       className="giraffe-annotation-tooltip"
@@ -123,7 +125,13 @@ export const AnnotationTooltip: FunctionComponent<Props> = props => {
     >
       <div style={tooltipCaretStyle} />
       <div style={tooltipCaretFillStyle} />
-      <div style={textContainerStyle}>{data.title}</div>
+
+      {multiLines.map(line => {
+        if (!line || line === '' || line.trim() === '') {
+          return <br />
+        }
+        return <div style={textContainerStyle}>{line}</div>
+      })}
       <div style={textContainerStyle}>{data.description}</div>
     </div>,
     annotationTooltipElement


### PR DESCRIPTION
to support ui#1124
https://app.zenhub.com/workspaces/applicationdumplings-60a80d872533670017a6b107/issues/influxdata/ui/1124

divides up the annotation text using the newline ('/n') string.