### PR TITLE
fix: annotations much easier to click on

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/AnnotationLayer.tsx
+++ b/giraffe/src/components/AnnotationLayer.tsx
@@ -16,6 +16,7 @@ import {AnnotationLine} from './AnnotationLine'
 export interface AnnotationLayerProps extends LayerProps {
   spec: AnnotationLayerSpec
   config: AnnotationLayerConfig
+  onHover: (forceHide: boolean) => void
 }
 
 const ANNOTATION_OVERLAY_DEFAULT_STYLE = {
@@ -23,7 +24,17 @@ const ANNOTATION_OVERLAY_DEFAULT_STYLE = {
 } as CSSProperties
 
 export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props => {
-  const {config, spec, width, height, hoverX, hoverY, xScale, yScale} = props
+  const {
+    config,
+    spec,
+    width,
+    height,
+    hoverX,
+    hoverY,
+    xScale,
+    yScale,
+    onHover,
+  } = props
   const lineWidth = config.lineWidth || 2
   const annotationsPositions = useMemo(
     () => getAnnotationsPositions(spec.annotationData, xScale, yScale),
@@ -97,6 +108,7 @@ export const AnnotationLayer: FunctionComponent<AnnotationLayerProps> = props =>
             strokeWidth={lineWidth}
             pin={annotationData.pin}
             id={annotationData.id}
+            onHover={onHover}
           />
         )
       )}

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -75,6 +75,8 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
   const clampedStart = Math.max(1, Math.round(startValue))
   const clampedEnd = Math.max(1, Math.round(stopValue))
 
+  console.log('ack ack cak 776a')
+
   if (dimension === 'y') {
     return (
       <>
@@ -116,14 +118,6 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
     )
   }
 
-  // dimension is x:
-  const handleMouseEnter = () => {
-    onHover(true)
-  }
-
-  const handleMouseLeave = () => {
-    onHover(false)
-  }
   /**
    * This is the rectangle or 'hat' that goes on top of a range annotation.
    * The entire hat is click to edit for the annotation.
@@ -136,9 +130,6 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
   const makeRangeRectangle = () => {
     const pixelMargin = 1
 
-    // cannot just directly reference the handleMouseEnter/Leave functions;
-    // that doesn't work (it gets called immediately).
-    // so need the arrow function when using createElement
     return createElement('polygon', {
       points: `${clampedStart - pixelMargin}, 0
           ${clampedEnd + pixelMargin}, 0
@@ -148,10 +139,10 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
       id: props.id,
       style: {cursor: 'pointer', opacity: '60%'},
       onMouseEnter: () => {
-        handleMouseEnter()
+        onHover(true)
       },
       onMouseLeave: () => {
-        handleMouseLeave()
+        onHover(false)
       },
     })
   }
@@ -192,10 +183,10 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
           id: props.id,
           className: 'giraffe-annotation-click-target',
           onMouseEnter: () => {
-            handleMouseEnter()
+            onHover(true)
           },
           onMouseLeave: () => {
-            handleMouseLeave()
+            onHover(false)
           },
         })
       case 'stop':

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -75,8 +75,6 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
   const clampedStart = Math.max(1, Math.round(startValue))
   const clampedEnd = Math.max(1, Math.round(stopValue))
 
-  console.log('ack ack cak 776a')
-
   if (dimension === 'y') {
     return (
       <>

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -65,7 +65,7 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
     stopValue,
     length,
     pin,
-    onHover= () => {},
+    onHover = () => {},
   } = props
 
   // This prevents blurry sub-pixel rendering as well as clipped lines

--- a/giraffe/src/components/AnnotationLine.tsx
+++ b/giraffe/src/components/AnnotationLine.tsx
@@ -12,6 +12,7 @@ interface AnnotationLineProps {
   length: number
   pin: AnnotationPinType
   id: string
+  onHover?: (forceHide: boolean) => void
 }
 
 // These could become configurable values
@@ -46,6 +47,14 @@ const RANGE_HEIGHT = 9
  *
  *  style: {cursor: 'pointer'}
  *
+ *  the 'onHover' method is for firing when the user is hovering over
+ *  a clickable area.  it sends a 'true' when the user entered a clickable area
+ *  and a 'false' when it leaves.  This is so if there is a hover legend showing,
+ *  then it will be hidden while on the clickable area.
+ *
+ *  adding the 'onHover' to the tops of the annotations that are clickable:
+ *  the range rectangle and the 'start' pin for vertical annotation lines.
+ *
  * */
 export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
   const {
@@ -56,6 +65,7 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
     stopValue,
     length,
     pin,
+    onHover= () => {},
   } = props
 
   // This prevents blurry sub-pixel rendering as well as clipped lines
@@ -107,7 +117,13 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
   }
 
   // dimension is x:
+  const handleMouseEnter = () => {
+    onHover(true)
+  }
 
+  const handleMouseLeave = () => {
+    onHover(false)
+  }
   /**
    * This is the rectangle or 'hat' that goes on top of a range annotation.
    * The entire hat is click to edit for the annotation.
@@ -120,6 +136,9 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
   const makeRangeRectangle = () => {
     const pixelMargin = 1
 
+    // cannot just directly reference the handleMouseEnter/Leave functions;
+    // that doesn't work (it gets called immediately).
+    // so need the arrow function when using createElement
     return createElement('polygon', {
       points: `${clampedStart - pixelMargin}, 0
           ${clampedEnd + pixelMargin}, 0
@@ -128,6 +147,12 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
       fill: color,
       id: props.id,
       style: {cursor: 'pointer', opacity: '60%'},
+      onMouseEnter: () => {
+        handleMouseEnter()
+      },
+      onMouseLeave: () => {
+        handleMouseLeave()
+      },
     })
   }
 
@@ -166,6 +191,12 @@ export const AnnotationLine: FunctionComponent<AnnotationLineProps> = props => {
           style: {cursor: 'pointer'},
           id: props.id,
           className: 'giraffe-annotation-click-target',
+          onMouseEnter: () => {
+            handleMouseEnter()
+          },
+          onMouseLeave: () => {
+            handleMouseLeave()
+          },
         })
       case 'stop':
         return createElement('polygon', {

--- a/giraffe/src/components/SizedPlot.tsx
+++ b/giraffe/src/components/SizedPlot.tsx
@@ -3,6 +3,7 @@ import React, {
   FunctionComponent,
   RefObject,
   useCallback,
+  useState,
 } from 'react'
 
 import {Axes} from './Axes'
@@ -59,6 +60,17 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
   const [dragEvent, dragTargetProps] = useDragEvent()
   const hoverX = dragEvent ? null : hoverEvent.x
   const hoverY = dragEvent ? null : hoverEvent.y
+
+  const [forceHoverLegendHide, setForceHoverLegendHide] = useState(false)
+
+  const hideLegend = hideMe => {
+    if (legendHide) {
+      return
+      // it is already hiding, nothing else to do
+      // optimization to reduce unecessary re-renderings
+    }
+    setForceHoverLegendHide(hideMe)
+  }
 
   const handleYBrushEnd = useCallback(
     (yRange: number[]) => {
@@ -258,7 +270,7 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
             const sharedProps = {
               hoverX,
               hoverY,
-              legendHide,
+              legendHide: legendHide || forceHoverLegendHide,
               plotConfig: config,
               xScale: env.xScale,
               yScale: env.yScale,
@@ -276,6 +288,7 @@ export const SizedPlot: FunctionComponent<SizedPlotProps> = ({
                     {...sharedProps}
                     spec={spec}
                     config={layerConfig as AnnotationLayerConfig}
+                    onHover={hideLegend}
                   />
                 )
               case SpecTypes.Line:

--- a/stories/src/annotation.stories.tsx
+++ b/stories/src/annotation.stories.tsx
@@ -68,6 +68,7 @@ storiesOf('Annotations', module)
     const legendFont = legendFontKnob()
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
     const legendColorizeRows = tooltipColorizeRowsKnob()
+    const legendHide = boolean('Hide Hover Legend', false)
 
     const xTotalTicks = number('X Total Ticks', 8)
     const yTotalTicks = number('Y Total Ticks', 10)
@@ -131,6 +132,7 @@ storiesOf('Annotations', module)
       xScale,
       yScale,
       legendFont,
+      legendHide,
       legendOrientationThreshold,
       legendColorizeRows,
       tickFont,
@@ -505,6 +507,7 @@ storiesOf('Annotations', module)
     const legendFont = legendFontKnob()
     const legendOrientationThreshold = tooltipOrientationThresholdKnob()
     const legendColorizeRows = tooltipColorizeRowsKnob()
+    const legendHide = boolean('Hide Hover Legend', false)
 
     const xTotalTicks = number('X Total Ticks', 8)
     const yTotalTicks = number('Y Total Ticks', 10)
@@ -577,6 +580,7 @@ storiesOf('Annotations', module)
       xScale,
       yScale,
       legendFont,
+      legendHide,
       legendOrientationThreshold,
       legendColorizeRows,
       tickFont,


### PR DESCRIPTION
easier clicking now that the hover legend is hidden when the mouse is on a clickable annotation top (either the range 'hat' or the point 'diamond')

if the legend is already hidden then this is a no-op.  nothing happens.  (because there is nothing to hide)

for ui#1119