### PR TITLE
chore: Remove unnecessary styles in Pagination.scss, SimpleTableGraph.scss, and Table.scss 

### DIFF
--- a/giraffe/src/components/SimpleTable/PaginationNav/Pagination.scss
+++ b/giraffe/src/components/SimpleTable/PaginationNav/Pagination.scss
@@ -1,6 +1,5 @@
 
 $g5-pepper: #383846;
-$g14-chromium: #c6cad3;
 
 $cf-form-md-height: 38px;
 
@@ -10,7 +9,6 @@ $cf-form-md-height: 38px;
 */
 
 $cf-pagination--border-color: $g5-pepper;
-$cf-pagination--direction-icon: $g14-chromium;
 
 .cf-pagination,
 .cf-pagination--container {

--- a/giraffe/src/components/SimpleTable/PaginationNav/Pagination.scss
+++ b/giraffe/src/components/SimpleTable/PaginationNav/Pagination.scss
@@ -1,14 +1,8 @@
 
-$g5-pepper: #383846;
-
-$cf-form-md-height: 38px;
-
 /*
   pagination
   ------------------------------------------------------------------------------
 */
-
-$cf-pagination--border-color: $g5-pepper;
 
 .cf-pagination,
 .cf-pagination--container {
@@ -28,11 +22,11 @@ $cf-pagination--border-color: $g5-pepper;
   position: relative;
   &:after {
     content: '';
-    background-color: $cf-pagination--border-color;
+    background-color: #383846;
     z-index: 1;
     width: 100%;
     position: absolute;
-    height: floor($cf-form-md-height * 0.1);
+    height: 3px;
     left: 0;
     bottom: 0;
   }

--- a/giraffe/src/components/SimpleTable/SimpleTableGraph.scss
+++ b/giraffe/src/components/SimpleTable/SimpleTableGraph.scss
@@ -1,12 +1,4 @@
 
-$cf-marg-b: 8px;
-
-$g6-smoke: #434453;
-$g9-mountain: #757888;
-$g13-mist: #bec2cc;
-
-$cf-font-weight--medium: 500;
-
 .visualization--simple-table {
   width: 100%;
   height: 100%;
@@ -16,7 +8,7 @@ $cf-font-weight--medium: 500;
   user-select: text;
 
   .cf-table {
-    border: 2px solid $g6-smoke;
+    border: 2px solid #434453;
     margin-bottom: 10px;
     width: 100%;
   }
@@ -31,7 +23,7 @@ $cf-font-weight--medium: 500;
     display: block;
     font-size: 10px;
     text-transform: uppercase;
-    color: $g9-mountain;
+    color: #757888;
     font-weight: 500;
 
     &:first-of-type {
@@ -54,8 +46,8 @@ $cf-font-weight--medium: 500;
 
 .visualization--simple-table--paging-label {
   display: inline-block;
-  margin-right: $cf-marg-b;
-  color: $g13-mist;
-  font-weight: $cf-font-weight--medium;
+  margin-right: 8px;
+  color: #bec2cc;
+  font-weight: 500;
   width: 189px;
 }

--- a/giraffe/src/components/SimpleTable/SimpleTableGraph.scss
+++ b/giraffe/src/components/SimpleTable/SimpleTableGraph.scss
@@ -1,9 +1,6 @@
 
-$cf-border: 2px;
 $cf-marg-b: 8px;
 
-$g2-kevlar: #202028;
-$g3-castle: #292933;
 $g6-smoke: #434453;
 $g9-mountain: #757888;
 $g13-mist: #bec2cc;

--- a/giraffe/src/components/SimpleTable/Table/Table.scss
+++ b/giraffe/src/components/SimpleTable/Table/Table.scss
@@ -5,24 +5,6 @@ $g6-smoke: #434453;
 $g11-sidewalk: #999dab;
 $g15-platinum: #d4d7dd;
 $g17-whisper: #eeeff2;
-$g20-white: #ffffff;
-
-$c-sapphire: #0b3a8d;
-$c-ocean: #066fc5;
-$c-pool: #00a3ff;
-$c-void: #5c10a0;
-$c-amethyst: #8e1fc3;
-$c-star: #be2ee4;
-$c-emerald: #006f49;
-$c-viridian: #009f5f;
-$c-rainforest: #34bb55;
-$c-tiger: #f48d38;
-$c-pineapple: #ffb94a;
-$c-thunder: #ffd255;
-$c-ruby: #bf3d5e;
-$c-fire: #dc4e58;
-$c-dreamsicle: #ff8564;
-
 
 $cf-font-weight--medium: 500;
 $cf-font-weight--bold: 700;
@@ -213,20 +195,4 @@ $table-row-background: $g3-castle;
     background-color: $backgroundHover;
     color: $text;
   }
-}
-
-.cf-table--row__primary {
-  @include tableColorModifier($c-sapphire, mix($c-ocean, $c-sapphire, 50%), $c-ocean, $c-pool, $g20-white);
-}
-.cf-table--row__secondary {
-  @include tableColorModifier($c-void, mix($c-amethyst, $c-void, 50%), $c-amethyst, $c-star, $g20-white);
-}
-.cf-table--row__success {
-  @include tableColorModifier($c-emerald, mix($c-viridian, $c-emerald, 50%), $c-viridian, $c-rainforest, $g20-white);
-}
-.cf-table--row__warning {
-  @include tableColorModifier($c-tiger, mix($c-pineapple, $c-tiger, 50%), $c-pineapple, $c-thunder, $g3-castle);
-}
-.cf-table--row__danger {
-  @include tableColorModifier($c-ruby, mix($c-fire, $c-ruby, 50%), $c-fire, $c-dreamsicle, $g20-white);
 }

--- a/giraffe/src/components/SimpleTable/Table/Table.scss
+++ b/giraffe/src/components/SimpleTable/Table/Table.scss
@@ -125,15 +125,11 @@ $table-row-background: #292933;
   ------------------------------------------------------------------------------
 */
 
-@mixin tableFontModifier($fontSize) {
+.cf-table__font-sm {
   .cf-table--cell,
   .cf-table--header-cell {
-    font-size: $fontSize;
+    font-size: 13px;
   }
-}
-
-.cf-table__font-sm {
-  @include tableFontModifier(13px);
 }
 
 /*
@@ -156,31 +152,4 @@ $table-row-background: #292933;
 
 .cf-table__highlight .cf-table--body .cf-table--row:hover .cf-table--cell {
   color: #eeeff2;
-}
-
-/*
-  Row Color Modifiers
-  ------------------------------------------------------------------------------
-*/
-
-@mixin tableColorModifier($background, $backgroundAlt, $backgroundHover, $border, $text) {
-  .cf-table .cf-table--body & .cf-table--cell,
-  .cf-table .cf-table--body & .cf-table--header-cell,
-  .cf-table .cf-table--header & .cf-table--cell,
-  .cf-table .cf-table--header & .cf-table--header-cell {
-    background-color: $background;
-    border-color: $border;
-    color: rgba($text, 0.8);
-  }
-
-  .cf-table__striped .cf-table--body &:nth-child(odd) .cf-table--cell,
-  .cf-table__striped .cf-table--body &:nth-child(odd) .cf-table--header-cell {
-    background-color: $backgroundAlt;
-  }
-
-  .cf-table__highlight .cf-table--body &:hover .cf-table--cell,
-  .cf-table__highlight .cf-table--body &:hover .cf-table--header-cell {
-    background-color: $backgroundHover;
-    color: $text;
-  }
 }

--- a/giraffe/src/components/SimpleTable/Table/Table.scss
+++ b/giraffe/src/components/SimpleTable/Table/Table.scss
@@ -1,21 +1,9 @@
 
-$g3-castle: #292933;
-$g4-onyx: #31313d;
-$g6-smoke: #434453;
-$g11-sidewalk: #999dab;
-$g15-platinum: #d4d7dd;
-$g17-whisper: #eeeff2;
-
-$cf-font-weight--medium: 500;
-$cf-font-weight--bold: 700;
-
 $cf-border: 2px;
 
-$cf-form-sm-font: 13px;
-
-$table-border--primary: $g6-smoke;
-$table-border--secondary: $g4-onyx;
-$table-row-background: $g3-castle;
+$table-border--primary: #434453;
+$table-border--secondary: #31313d;
+$table-row-background: #292933;
 
 /*
   Table
@@ -27,14 +15,14 @@ $table-row-background: $g3-castle;
 }
 
 .cf-table--cell {
-  color: $g11-sidewalk;
+  color: #999dab;
   transition: background-color 0.25s ease, color 0.25s ease;
-  font-weight: $cf-font-weight--medium;  
+  font-weight: 500;  
 }
 
 .cf-table--header-cell {
-  color: $g15-platinum;
-  font-weight: $cf-font-weight--bold;  
+  color: #d4d7dd;
+  font-weight: 700;  
 }
 
 .cf-table--row {
@@ -145,7 +133,7 @@ $table-row-background: $g3-castle;
 }
 
 .cf-table__font-sm {
-  @include tableFontModifier($cf-form-sm-font);
+  @include tableFontModifier(13px);
 }
 
 /*
@@ -167,7 +155,7 @@ $table-row-background: $g3-castle;
 }
 
 .cf-table__highlight .cf-table--body .cf-table--row:hover .cf-table--cell {
-  color: $g17-whisper;
+  color: #eeeff2;
 }
 
 /*


### PR DESCRIPTION
Closes: #646

3 groups of styles were removed:
- Unused colors and component sizes
- Variables that were only used once. Uses of the variables were directly replaced with the value.
- Mixins because they were either unused or their use was an extra step.