### PR TITLE
fix: remove conditional usage of useRef hook

### DIFF
--- a/giraffe/src/components/Plot.tsx
+++ b/giraffe/src/components/Plot.tsx
@@ -10,12 +10,20 @@ interface PlotProps {
   layerCanvasRef?: RefObject<HTMLCanvasElement>
 }
 
-export const Plot: FunctionComponent<PlotProps> = ({
-  children,
-  config,
-  axesCanvasRef = useRef<HTMLCanvasElement>(null),
-  layerCanvasRef = useRef<HTMLCanvasElement>(null),
-}) => {
+export const Plot: FunctionComponent<PlotProps> = props => {
+  const {children, config} = props
+
+  let axesCanvasRef = useRef<HTMLCanvasElement>(null)
+  let layerCanvasRef = useRef<HTMLCanvasElement>(null)
+
+  if (props.axesCanvasRef) {
+    axesCanvasRef = props.axesCanvasRef
+  }
+
+  if (props.layerCanvasRef) {
+    layerCanvasRef = props.layerCanvasRef
+  }
+
   if (config.width && config.height) {
     return (
       <div className="giraffe-fixedsizer" style={{position: 'relative'}}>


### PR DESCRIPTION
Part of #630 

Resolves the lint error for

```
/giraffe/src/components/Plot.tsx
16:19 error React Hook "useRef" is called conditionally. React Hooks must be called in the exact same order in every component render react-hooks/rules-of-hooks
17:20 error React Hook "useRef" is called conditionally. React Hooks must be called in the exact same order in every component render react-hooks/rules-of-hooks
```