### PR TITLE
fix: remove unnecessary wrapped function to resolve lint error

### DIFF
--- a/giraffe/src/components/MultiGrid.tsx
+++ b/giraffe/src/components/MultiGrid.tsx
@@ -598,7 +598,7 @@ export const MultiGrid = forwardRef<MultiGridInputHandles, PropsMultiGrid>(
     useImperativeHandle(ref, () => {
       return {
         recomputeGridSize: () => recomputeGridSize(state, props),
-        forceUpdate: () => useForceUpdate(),
+        forceUpdate: useForceUpdate,
       }
     })
 


### PR DESCRIPTION
Part of #630 

Resolves the lint error for
```/giraffe/src/components/MultiGrid.tsx
601:28 error React Hook "useForceUpdate" is called in function "forceUpdate" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter react-hooks/rules-of-hooks```