### PR TITLE
fix: move useLayoutEffect into component to resolve lint error

### DIFF
--- a/giraffe/src/components/geo/CircleMarkerLayer.tsx
+++ b/giraffe/src/components/geo/CircleMarkerLayer.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {createRef, FunctionComponent, useLayoutEffect} from 'react'
+import React, {createRef, FunctionComponent} from 'react'
 import {CircleMarker} from 'react-leaflet'
 
 // Utils
@@ -8,7 +8,6 @@ import {
   getColor,
   normalizeValue,
 } from './dimensionCalculations'
-import {defineToolTipEffect} from './processing/toolTips'
 import {formatCircleMarkerRowInfo} from '../../utils/geo'
 
 // Types
@@ -79,12 +78,9 @@ export const CircleMarkerLayer: FunctionComponent<Props> = props => {
   const tooltip = (
     <GeoTooltip
       stylingConfig={stylingConfig}
-      onCreate={setTooltip => {
-        useLayoutEffect(defineToolTipEffect(tooltips, setTooltip), [
-          properties,
-          table,
-        ])
-      }}
+      properties={properties}
+      table={table}
+      tooltips={tooltips}
     />
   )
   return (

--- a/giraffe/src/components/geo/GeoTooltip.tsx
+++ b/giraffe/src/components/geo/GeoTooltip.tsx
@@ -1,17 +1,28 @@
-import {FunctionComponent, useState} from 'react'
+import {FunctionComponent, useLayoutEffect, useState} from 'react'
 import React from 'react'
-import {Config} from '../../types'
 import {Tooltip} from '../Tooltip'
 
+// Utils
+import {defineToolTipEffect} from './processing/toolTips'
+
+// Types
+import {Config} from '../../types'
+import {GeoTable} from './processing/GeoTable'
+import {GeoCircleViewLayer, GeoPointMapViewLayer} from '../../types/geo'
 interface Props {
   stylingConfig: Partial<Config>
-  onCreate
+  properties: GeoPointMapViewLayer | GeoCircleViewLayer
+  table: GeoTable
+  tooltips: Array<{markerRef; rowInfo}>
 }
 
 export const GeoTooltip: FunctionComponent<Props> = props => {
-  const {stylingConfig, onCreate} = props
+  const {stylingConfig, properties, table, tooltips} = props
   const [tooltipData, setTooltipData] = useState(null)
-  onCreate(setTooltipData)
+  useLayoutEffect(defineToolTipEffect(tooltips, setTooltipData), [
+    properties,
+    table,
+  ])
 
   return (
     <>

--- a/giraffe/src/components/geo/PointMapLayer.tsx
+++ b/giraffe/src/components/geo/PointMapLayer.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {useEffect, useState} from 'react'
-import {FunctionComponent, useLayoutEffect} from 'react'
+import {FunctionComponent} from 'react'
 import {Marker} from 'react-leaflet'
 import MarkerClusterGroup from 'react-leaflet-markercluster'
 import 'react-leaflet-markercluster/dist/styles.min.css'
@@ -8,7 +8,6 @@ import 'react-leaflet-markercluster/dist/styles.min.css'
 // Utils
 import {getColor} from './dimensionCalculations'
 import {SVGIcon} from './SVGIcon'
-import {defineToolTipEffect} from './processing/toolTips'
 import {GeoTooltip} from './GeoTooltip'
 
 import {
@@ -67,12 +66,9 @@ export const PointMapLayer: FunctionComponent<Props> = props => {
   const tooltip = (
     <GeoTooltip
       stylingConfig={stylingConfig}
-      onCreate={setTooltip => {
-        useLayoutEffect(defineToolTipEffect(tooltips, setTooltip), [
-          properties,
-          table,
-        ])
-      }}
+      properties={properties}
+      table={table}
+      tooltips={tooltips}
     />
   )
   const [visible, setVisible] = useState(true)


### PR DESCRIPTION
Part of #630 

Resolves lint errors for
``` 
/giraffe/src/components/geo/CircleMarkerLayer.tsx
83:9 warning React Hook useLayoutEffect received a function whose dependencies are unknown. Pass an inline function instead react-hooks/exhaustive-deps
83:9 error React Hook "useLayoutEffect" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function react-hooks/rules-of-hooks

 /giraffe/src/components/geo/PointMapLayer.tsx
71:9 warning React Hook useLayoutEffect received a function whose dependencies are unknown. Pass an inline function instead react-hooks/exhaustive-deps
71:9 error React Hook "useLayoutEffect" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function react-hooks/rules-of-hooks
```