### PR TITLE
fix: move early return after all hooks

### DIFF
--- a/giraffe/src/components/Geo.tsx
+++ b/giraffe/src/components/Geo.tsx
@@ -39,11 +39,11 @@ const Geo: FunctionComponent<Props> = props => {
   } = props
   const {layers, tileServerConfiguration} = props
   const {tileServerUrl, bingKey} = tileServerConfiguration
-  const mapRef = React.createRef()
+  const mapRef = React.createRef<any>()
 
   useEffect(() => {
     if (width && height) {
-      ;(mapRef.current as any).leafletElement._onResize()
+      mapRef.current?.leafletElement._onResize()
     }
   }, [width, height])
 

--- a/giraffe/src/components/Geo.tsx
+++ b/giraffe/src/components/Geo.tsx
@@ -42,7 +42,9 @@ const Geo: FunctionComponent<Props> = props => {
   const mapRef = React.createRef()
 
   useEffect(() => {
-    ;(mapRef.current as any).leafletElement._onResize()
+    if (width && height) {
+      ;(mapRef.current as any).leafletElement._onResize()
+    }
   }, [width, height])
 
   const {table, detectCoordinateFields} = props

--- a/giraffe/src/components/Geo.tsx
+++ b/giraffe/src/components/Geo.tsx
@@ -24,18 +24,18 @@ interface Props extends Partial<GeoLayerConfig> {
 }
 
 const Geo: FunctionComponent<Props> = props => {
-  const {width, height} = props
-
   const {
-    lat,
-    lon,
-    zoom,
-    mapStyle,
-    stylingConfig,
     allowPanAndZoom,
-    useS2CellID,
+    height,
+    lat,
     latLonColumns,
+    lon,
+    mapStyle,
     s2Column,
+    stylingConfig,
+    useS2CellID,
+    width,
+    zoom,
   } = props
   const {layers, tileServerConfiguration} = props
   const {tileServerUrl, bingKey} = tileServerConfiguration

--- a/giraffe/src/components/Geo.tsx
+++ b/giraffe/src/components/Geo.tsx
@@ -25,9 +25,7 @@ interface Props extends Partial<GeoLayerConfig> {
 
 const Geo: FunctionComponent<Props> = props => {
   const {width, height} = props
-  if (width === 0 || height === 0) {
-    return null
-  }
+
   const {
     lat,
     lon,
@@ -70,6 +68,10 @@ const Geo: FunctionComponent<Props> = props => {
     )
     setPreprocessedTable(newTable)
   }, [table, detectCoordinateFields])
+
+  if (width === 0 || height === 0) {
+    return null
+  }
 
   const onViewportChange = (viewport: {center?: number[]; zoom?: number}) => {
     const {onViewportChange} = props


### PR DESCRIPTION
Part of #630 

Resolves the lint error for
```
/giraffe/src/components/Geo.tsx
46:3 error React Hook "useEffect" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return? react-hooks/rules-of-hooks
51:53 error React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return? react-hooks/rules-of-hooks
63:3 error React Hook "useEffect" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return? react-hooks/rules-of-hooks
```