### PR TITLE
feat: activate linting for React hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended",
+    "plugin:react-hooks/recommended",
     "prettier/react",
     "prettier/@typescript-eslint"
   ],
@@ -49,7 +50,8 @@
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/prefer-interface": "off",
     "@typescript-eslint/camelcase": "off",
-    "@typescript-eslint/no-unused-vars": ["error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
       {"varsIgnorePattern": "^_", "argsIgnorePattern": "^_"}
     ],
     "react/jsx-no-target-blank": "off",

--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",
@@ -71,6 +71,7 @@
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.17.0",
+    "eslint-plugin-react-hooks": "^4.0.5",
     "file-loader": "^6.1.1",
     "he": "1.2.0",
     "intl-dateformat": "^0.1.1",

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "license": "MIT",
   "scripts": {
     "lint": "eslint '{src,../giraffe/src}/**/*.{ts,tsx}'",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6180,6 +6180,11 @@ eslint-plugin-prettier@^3.1.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^4.0.5:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
+
 eslint-plugin-react@^7.12.4:
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz#bc13fd7101de67996ea51b33873cd9dc2b7e5758"


### PR DESCRIPTION
Closes #630 

All React hooks lint errors have been addressed. Let's put the linter in place to let developers know when a hook is not used with best practices in mind.