### PR TITLE
chore: update eslint-plugin-react-hooks

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -71,7 +71,7 @@
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.17.0",
-    "eslint-plugin-react-hooks": "^4.0.5",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "file-loader": "^6.1.1",
     "he": "1.2.0",
     "intl-dateformat": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6180,7 +6180,7 @@ eslint-plugin-prettier@^3.1.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react-hooks@^4.0.5:
+eslint-plugin-react-hooks@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
   integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==


### PR DESCRIPTION
Matches a change in UI made by https://github.com/influxdata/ui/pull/2443

Strangely, Giraffe's yarn.lock is already using the higher version. This makes it official in the package.json