### PR TITLE
fix: strings that are numbers still render as strings

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/TableCell.tsx
+++ b/giraffe/src/components/TableCell.tsx
@@ -89,7 +89,8 @@ const getStyle = (props: Props) => {
     isFixed(isFirstColumnFixed, rowIndex, columnIndex) ||
     isTimeData(props) ||
     isTimestamp(dataType) ||
-    isNaN(Number(data))
+    isNaN(Number(data)) ||
+    dataType.includes('string')
   ) {
     return style
   }
@@ -114,6 +115,7 @@ const getClassName = (props: Props): string => {
     columnIndex,
     hoveredRowIndex,
     hoveredColumnIndex,
+    dataType,
   } = props
   const classes = classnames('table-graph-cell', {
     'table-graph-cell__fixed-row': isFixedRow(rowIndex, columnIndex),
@@ -132,7 +134,8 @@ const getClassName = (props: Props): string => {
       columnIndex,
       hoveredColumnIndex
     ),
-    'table-graph-cell__numerical': !isNaN(Number(data)),
+    'table-graph-cell__numerical':
+      !isNaN(Number(data)) && !dataType.includes('string'),
     'table-graph-cell__field-name': isFieldName(
       isVerticalTimeAxis,
       rowIndex,
@@ -183,7 +186,7 @@ export const getContents = (props: Props): string => {
     return defaultTo(getFieldName(props), '').toString()
   }
 
-  if (!isNaN(+data)) {
+  if (!isNaN(+data) && !dataType.includes('string')) {
     // method needs the first arg to be a number to work properly
     return formatStatValue(+data, {decimalPlaces})
   }

--- a/stories/src/data/tableGraph.ts
+++ b/stories/src/data/tableGraph.ts
@@ -1,5 +1,5 @@
 export const tableCSV = `#group,false,false,true,true,false,false,true,true,true,true
-#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
 #default,_result,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
 ,,0,2020-07-01T21:45:43.0968Z,2020-07-01T21:50:43.0968Z,2020-07-01T21:45:50Z,2.2,usage_system,cpu,cpu1,MBP15-TLUONG.local

--- a/stories/src/data/tableGraph.ts
+++ b/stories/src/data/tableGraph.ts
@@ -1,5 +1,5 @@
 export const tableCSV = `#group,false,false,true,true,false,false,true,true,true,true
-#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string
 #default,_result,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
 ,,0,2020-07-01T21:45:43.0968Z,2020-07-01T21:50:43.0968Z,2020-07-01T21:45:50Z,2.2,usage_system,cpu,cpu1,MBP15-TLUONG.local


### PR DESCRIPTION
Closes: https://github.com/influxdata/idpe/issues/10645

Our table was formatting `string` dataType that were numbers, as numbers. This is because we use `isNaN` to make the decision, I added a layer around those checks to check whether the dataType of the flux column is `string` in the first place. 

Screen shots: 

`_value` column dataType `string`

<img width="668" alt="Screen Shot 2021-09-08 at 10 40 45 AM" src="https://user-images.githubusercontent.com/18511823/132558211-1ad2c9a9-75ed-49c4-ad5d-4b3259bbde7c.png">


`_value` column dataType `double`
 
<img width="660" alt="Screen Shot 2021-09-08 at 10 41 11 AM" src="https://user-images.githubusercontent.com/18511823/132558270-79826c28-01be-4138-b4ac-1669401cf8e8.png">
