### PR TITLE
chore: v2.18.3

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.18.2",
+  "version": "2.18.3",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",


### PR DESCRIPTION
Not sure what happened [here](https://github.com/influxdata/giraffe/pull/673/files#diff-d7304a1c6249c5809204275173f61db450795e4a8f4be6a532b3c84d4a71a182R3), it showed a diff so I thought the bump was successful but we already have `v2.18.2`. 

This bumps the version to `2.18.3`