### PR TITLE
feat: adjust cross hair visibility by changing it's color

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/constants/index.ts
+++ b/giraffe/src/constants/index.ts
@@ -51,7 +51,7 @@ export const CONFIG_DEFAULTS: Partial<Config> = {
   legendFontBrightColor: '#f6f6f8',
   legendBackgroundColor: '#0f0e15',
   legendBorder: '2px solid #202028',
-  legendCrosshairColor: '#f3f3f3',
+  legendCrosshairColor: 'rgba(255,255,255,0.75)',
   legendColorizeRows: true,
   legendOpacity: 1,
 }

--- a/giraffe/src/constants/index.ts
+++ b/giraffe/src/constants/index.ts
@@ -51,7 +51,7 @@ export const CONFIG_DEFAULTS: Partial<Config> = {
   legendFontBrightColor: '#f6f6f8',
   legendBackgroundColor: '#0f0e15',
   legendBorder: '2px solid #202028',
-  legendCrosshairColor: '#31313d',
+  legendCrosshairColor: '#f3f3f3',
   legendColorizeRows: true,
   legendOpacity: 1,
 }


### PR DESCRIPTION
Closes: #674

We need to change the color of the crosshair line so that the line is more visible. 

<img width="1102" alt="Screen Shot 2021-09-09 at 10 48 17 AM" src="https://user-images.githubusercontent.com/18511823/132737045-8adf5290-252a-469c-b5ae-31d1eec18672.png">