### PR TITLE
fix: valign the table header cell

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.18.4",
+  "version": "2.18.5",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/src/components/SimpleTable/Table/TableHeaderCell.tsx
+++ b/giraffe/src/components/SimpleTable/Table/TableHeaderCell.tsx
@@ -27,7 +27,7 @@ export const TableHeaderCell = forwardRef<
     <th
       data-testid={testID}
       ref={ref}
-      style={{textAlign: 'left', verticalAlign: 'middle'}}
+      style={{textAlign: 'left', verticalAlign: 'top'}}
       colSpan={1}
       className={tableHeaderCellClass}
     >


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/2035

Just a simple css change to align the table headers better. We cant yet close the UI#2035 issue yet because there are two version of simple table, one giraffe's (behind the `useGiraffeGraphs` flag) and he other is in UI. 

<img width="751" alt="Screen Shot 2021-09-10 at 12 08 31 PM" src="https://user-images.githubusercontent.com/18511823/132904868-c230ffdf-bd83-45e8-83f4-5b4f1c23b866.png">
