### PR TITLE
fix: remove eot, ttf and svg font files for icomoon

### DIFF
--- a/giraffe/src/components/Icon.scss
+++ b/giraffe/src/components/Icon.scss
@@ -7,12 +7,8 @@
 
 @font-face {
   font-family: 'icomoon';
-  src: url('../fonts/icomoon.eot') format('embedded-opentype');
-  src: url('../fonts/icomoon.eot') format('embedded-opentype'),
-    url('../fonts/icomoon.woff2') format('woff2'),
-    url('../fonts/icomoon.ttf') format('truetype'),
-    url('../fonts/icomoon.woff') format('woff'),
-    url('../fonts/icomoon.svg') format('svg');
+  src: url('../fonts/icomoon.woff2') format('woff2'),
+    url('../fonts/icomoon.woff') format('woff');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Attempt to fix: https://github.com/influxdata/ui/issues/2629

Those font files are not relevant for the web. This might be a cause of the `OTS parsing error` and the `font rejected by sanitizer` errors. Locally I was able to get rid of those by removing the incompatible/unnecessary files. 