### PR TITLE
chore: remove duplicate rule for css in webpack config

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.18.6",
+  "version": "2.18.7",
   "main": "dist/index.js",
   "module": "src/index.js",
   "license": "MIT",

--- a/giraffe/webpack.common.config.js
+++ b/giraffe/webpack.common.config.js
@@ -56,11 +56,6 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        exclude: /leaflet\.css/,
-        use: [{loader: 'style-loader'}, {loader: 'css-loader'}],
-      },
-      {
-        test: /leaflet\.css/,
         use: [{loader: 'style-loader'}, 'css-loader'],
       },
       {

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.18.6",
+  "version": "2.18.7",
   "license": "MIT",
   "scripts": {
     "lint": "eslint '{src,../giraffe/src}/**/*.{ts,tsx}'",


### PR DESCRIPTION
Clean up. Sanity check looks good. Maps are loading in storybook with styles.

<img width="1680" alt="Screen Shot 2021-10-12 at 5 15 09 PM" src="https://user-images.githubusercontent.com/10736577/137045851-1f2371bc-5682-4399-8200-0d983024286f.png">
