### PR TITLE
fix: use correct file extension for "module" path

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "main": "dist/index.js",
-  "module": "src/index.js",
+  "module": "src/index.ts",
   "license": "MIT",
   "scripts": {
     "build": "rm -rf dist && NODE_ENV=production webpack --config webpack.prod.config.js",

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "license": "MIT",
   "scripts": {
     "lint": "eslint '{src,../giraffe/src}/**/*.{ts,tsx}'",


### PR DESCRIPTION
Closes #682 

Giraffe does not have `src/index.js`. It does have `src/index.ts`. Let's use that. 😄 