### PR TITLE
fix: use dist/index.js instead of src/index.ts to resolve dependencies

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.19.2",
+  "version": "2.20.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.19.2",
+  "version": "2.20.0",
   "license": "MIT",
   "scripts": {
     "lint": "eslint '{src,../giraffe/src}/**/*.{ts,tsx}'",


### PR DESCRIPTION
As part of #682 

Using `src/index.ts` for `module` will break our UI which uses Webpack, which tries to resolve `module` before `main` similar to Vite. The `src/index.ts` file then tries to import the other dependencies which UI does not have.

Let's use `dist/index.js` for both of them. The bundled `dist/index.js` has all of the necessary code.