### PR TITLE
chore: update the story by using a string knob to handle undefined input

### DIFF
--- a/stories/src/linegraph.stories.tsx
+++ b/stories/src/linegraph.stories.tsx
@@ -34,8 +34,10 @@ storiesOf('Line Graph', module)
     const fillColumnsCount = number('Number of fill columns', 5)
     const fillColumnNameLength = number('Length of fill column names', 4)
 
-    const fixedWidth = number('Fixed Width', -1)
-    const fixedHeight = number('Fixed Height', -1)
+    const fixedWidthText = text('Fixed Width', '')
+    const fixedHeightText = text('Fixed Height', '')
+    const fixedWidth = !fixedWidthText ? -1 : Number(fixedWidthText)
+    const fixedHeight = !fixedHeightText ? -1 : Number(fixedHeightText)
 
     const fixedPlotSize = {}
     if (fixedHeight > 0 && fixedWidth > 0) {

--- a/stories/src/linegraph.stories.tsx
+++ b/stories/src/linegraph.stories.tsx
@@ -165,8 +165,10 @@ storiesOf('Line Graph', module)
     const xTickStart = number('xTickStart', new Date().getTime())
     const xTickStep = number('xTickStep', 200_000)
     const xTotalTicks = number('xTotalTicks', 5)
-    const yTickStart = number('yTickStart', NaN)
-    const yTickStep = number('yTickStep', NaN)
+    const yTickStartText = text('yTickStart', '')
+    const yTickStepText = text('yTickStep', '')
+    const yTickStart = !yTickStartText ? null : Number(yTickStartText)
+    const yTickStep = !yTickStepText ? null : Number(yTickStepText)
     const yTotalTicks = number('yTotalTicks', 8)
     const timeFormat = select(
       'Time Format',


### PR DESCRIPTION
There is a console error in the browser if we use `NaN` but the knob requires 2 arguments of the number type.

We can work around all of this by using a text knob and then interpreting the input from the text knob into the proper config property to be passed into the `<Plot>`