### PR TITLE
chore: bring back config.js as preview.js to prevent vertical scrollbar

### DIFF
--- a/stories/.storybook/preview.js
+++ b/stories/.storybook/preview.js
@@ -1,0 +1,5 @@
+import {addParameters} from '@storybook/react'
+
+addParameters({
+  layout: 'fullscreen',
+})


### PR DESCRIPTION
We do need this file but it should be named `preview.js`. It prevents the unsightly vertical scrollbar in storybook