### PR TITLE
chore: migrate sass division

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/components/DapperScrollbars.scss
+++ b/giraffe/src/components/DapperScrollbars.scss
@@ -31,20 +31,20 @@ $g13-mist: #bec2cc;
 .cf-dapper-scrollbars--track-x {
   height: $dapper-scrollbars--size !important;
   width: calc(100% - #{$dapper-scrollbars--size}) !important;
-  bottom: $dapper-scrollbars--size / 2 !important;
-  left: $dapper-scrollbars--size / 2 !important;
+  bottom: $dapper-scrollbars--size * 0.5 !important;
+  left: $dapper-scrollbars--size * 0.5 !important;
 }
 
 .cf-dapper-scrollbars--track-y {
   width: $dapper-scrollbars--size !important;
   height: calc(100% - #{$dapper-scrollbars--size}) !important;
-  right: $dapper-scrollbars--size / 2 !important;
-  top: $dapper-scrollbars--size / 2 !important;
+  right: $dapper-scrollbars--size * 0.5 !important;
+  top: $dapper-scrollbars--size * 0.5 !important;
 }
 
 .cf-dapper-scrollbars--thumb-x,
 .cf-dapper-scrollbars--thumb-y {
-  border-radius: $dapper-scrollbars--size / 2 !important;
+  border-radius: $dapper-scrollbars--size * 0.5 !important;
 }
 
 .cf-dapper-scrollbars--thumb-x {

--- a/giraffe/src/components/Input.scss
+++ b/giraffe/src/components/Input.scss
@@ -144,7 +144,7 @@
   }
 
   .cf-input-icon {
-    left: ($height / 2) + 2px;
+    left: ($height * 0.5) + 2px;
   }
 
   .cf-input-pseudo {

--- a/giraffe/src/components/TableGraphs.scss
+++ b/giraffe/src/components/TableGraphs.scss
@@ -159,7 +159,7 @@ $table-light-graph--text-highlight: #383846;
   -o-user-select: text !important;
   -webkit-user-select: text !important;
   background-color: $table-graph--cell;
-  border: (2px / 2) solid $table-graph--border;
+  border: (2px * 0.5) solid $table-graph--border;
   box-sizing: border-box;
   color: $table-graph--text-color;
   font-size: $table-graph--font;

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Migrate away from using slash for division in Sass