### PR TITLE
fix: Broken Tooltip

### DIFF
--- a/giraffe/src/utils/useMousePos.ts
+++ b/giraffe/src/utils/useMousePos.ts
@@ -14,7 +14,7 @@ interface UseMousePosProps {
 const mousePositionFromEvent = (e: MouseEvent<HTMLDivElement>) => {
   const {top, left} = e.currentTarget.getBoundingClientRect()
 
-  return {x: e.pageX - left, y: e.pageY - top}
+  return {x: e.clientX - left, y: e.clientY - top}
 }
 
 export const useMousePos = (): [MousePosition, UseMousePosProps] => {
@@ -50,9 +50,7 @@ export const useRefMousePos = (el: Element): MousePosition => {
     }
 
     const onMouseEnter = e => {
-      const {left, top} = el.getBoundingClientRect()
-
-      setState({x: e.pageX - left, y: e.pageY - top})
+      setState({x: e.x, y: e.y})
     }
 
     const onMouseMove = e => {


### PR DESCRIPTION
When a page contained more graphs than the page could fit, the tooltip would disappear if scrolling down/to the right. This fix makes the Tooltip show for all graphs on these type of pages.

Closes #680 