### PR TITLE
feat: allow long column names in legends and tooltips

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/components/LegendStyles.ts
+++ b/giraffe/src/components/LegendStyles.ts
@@ -9,7 +9,6 @@ import {
 } from '../constants'
 
 const legendColumnGap = '12px'
-const legendColumnMaxWidth = '200px'
 const legendTablePadding = '4px'
 
 const legendColumnOrder = (name: string): number | undefined => {
@@ -180,9 +179,6 @@ const tooltipColumnValueStyle = (
 
   if (switchToVertical) {
     return {
-      maxWidth: legendColumnMaxWidth,
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
       color,
       display: 'table-cell',
@@ -193,9 +189,6 @@ const tooltipColumnValueStyle = (
   }
 
   return {
-    maxWidth: legendColumnMaxWidth,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     fontWeight: 600,
     lineHeight: '1.125em',
@@ -219,9 +212,6 @@ const staticLegendColumnValueStyle = (
 
   if (switchToVertical) {
     return {
-      maxWidth: legendColumnMaxWidth,
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
       color,
       display: 'table-cell',
@@ -232,9 +222,6 @@ const staticLegendColumnValueStyle = (
   }
 
   return {
-    maxWidth: legendColumnMaxWidth,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     fontWeight: 600,
     padding: `${STATIC_LEGEND_LINE_SPACING_RATIO}em`,

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #719 

Allows long column names.

In cases where the columns are so many and the names are so long, which may obscure some of the later columns, the user has access to mitigations including orientation and a static legend with scrolling.

<img width="1680" alt="Screen Shot 2022-01-04 at 3 59 54 PM" src="https://user-images.githubusercontent.com/10736577/148140484-e53f6696-d44c-435f-89e0-fb1f96065ddf.png">
