### PR TITLE
fix: use Intl.NumberFormat to properly format in the user's locale

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/utils/formatStatValue.ts
+++ b/giraffe/src/utils/formatStatValue.ts
@@ -34,18 +34,13 @@ export const formatStatValue = (
 
   digits = Math.min(digits, MAX_DECIMAL_PLACES)
 
+  const formatter = Intl.NumberFormat(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  })
+
   if (isNumber(value)) {
-    const [wholeNumber, fractionalNumber] = Number(value)
-      .toFixed(digits)
-      .split('.')
-
-    localeFormattedValue = Number(wholeNumber).toLocaleString(undefined, {
-      maximumFractionDigits: MAX_DECIMAL_PLACES,
-    })
-
-    if (fractionalNumber) {
-      localeFormattedValue += `.${fractionalNumber}`
-    }
+    localeFormattedValue = formatter.format(Number(value))
   } else if (isString(value)) {
     localeFormattedValue = value
   } else {

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/3519

- Existing logic for number formatting is trying too hard and failing to account for all locales.
- Use `Intl.NumberFormat` to do all the heavy lifting.
- Dead on accurate due the presence of unit tests in `giraffe/src/utils/formatStatValue.test.ts`