### PR TITLE
feat: enhance fromFlux utility to include all result column names

### DIFF
--- a/giraffe/README.md
+++ b/giraffe/README.md
@@ -463,7 +463,7 @@ When using the comma separated values (CSV) from the Flux query as the `fluxResp
 
 Giraffe comes with utility functions.
 
-- **fromFlux**: _function(string)._ Takes a Flux CSV, converts it, and returns a `Table` used in the [table property](#data-properties) of the config.
+- **fromFlux**: _function(string)._ Takes a Flux CSV, converts it, and returns an object that includes `Table` used in the [table property](#data-properties) of the config.
 
 - **fromRows**: _function([Object, ...], Object)._ The first argument is an array of objects, each representing a row of data. The optional second argument describes the schema for the data. Returns a `Table` used in the [table property](#data-properties) of the config.
 

--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.23.1",
+  "version": "2.24.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -291,10 +291,12 @@ describe('fromFlux', () => {
         'server_version',
         'cpu',
       ],
+      resultColumnNames: ['_result'],
     }
     const fFlux = fromFlux(resp)
     expect(fFlux).toEqual(expected)
   })
+
   it('can parse a Flux CSV with mismatched schemas', () => {
     const CSV = `#group,false,false,true,true,false,true,true,true,true,true
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
@@ -311,6 +313,8 @@ describe('fromFlux', () => {
 ,,3,2019-02-01T23:38:32.524234Z,2019-02-01T23:39:02.524234Z,2019-02-01T23:38:43Z,fourty,usage_guest,cpu,cpu0,oox4k.local`
 
     const actual = fromFlux(CSV)
+
+    expect(actual.resultColumnNames).toEqual(['_result'])
 
     expect(actual.table.getColumn('result', 'string')).toEqual([
       '_result',
@@ -442,6 +446,38 @@ describe('fromFlux', () => {
     const {fluxGroupKeyUnion} = fromFlux(CSV)
 
     expect(fluxGroupKeyUnion).toEqual(['a', 'c', 'd'])
+  })
+
+  it('returns all result column names', () => {
+    const CSV = `#group,true,false,false,true
+#datatype,string,string,string,string
+#default,strangeColumnA,,,
+,a,b,c,d
+
+#group,false,false,true,false
+#datatype,string,string,string,string
+#default,strangeColumnB,,,
+,a,b,c,d`
+
+    const {resultColumnNames} = fromFlux(CSV)
+
+    expect(resultColumnNames).toEqual(['strangeColumnA', 'strangeColumnB'])
+  })
+
+  it('handles blank result column names', () => {
+    const CSV = `#group,true,false,false,true
+#datatype,string,string,string,string
+#default,,,,
+,a,b,c,d
+
+#group,false,false,true,false
+#datatype,string,string,string,string
+#default,,,,
+,a,b,c,d`
+
+    const {resultColumnNames} = fromFlux(CSV)
+
+    expect(resultColumnNames).toEqual([])
   })
 
   it('parses empty numeric values as null', () => {

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -102,7 +102,10 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
         }
         if (line.startsWith('#default')) {
           const defaults = line.split(',')
-          if (defaults.length >= 2 && defaults[RESULT_COLUMN_INDEX].length) {
+          if (
+            defaults.length >= RESULT_COLUMN_INDEX + 1 &&
+            defaults[RESULT_COLUMN_INDEX].length
+          ) {
             resultColumnNames.add(defaults[RESULT_COLUMN_INDEX])
           }
         }

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.23.1",
+  "version": "2.24.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #726 

Adds a property to hold all of the result column names in the annotated CSV from the results of a Flux query. This allows the `fromFlux` utility to assist the developer in identifying valid result column names, which in turn can simplify user interface validation of visualization configuration options and properties.