### PR TITLE
fix: update fromFlux to allow result column to be in any position

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -437,11 +437,13 @@ describe('fromFlux', () => {
 #datatype,string,string,string,string
 #default,,,,
 ,a,b,c,d
+,,,,
 
 #group,false,false,true,false
 #datatype,string,string,string,string
 #default,,,,
-,a,b,c,d`
+,a,b,c,d
+,,,,`
 
     const {fluxGroupKeyUnion} = fromFlux(CSV)
 
@@ -452,30 +454,104 @@ describe('fromFlux', () => {
     const CSV = `#group,true,false,false,true
 #datatype,string,string,string,string
 #default,strangeColumnA,,,
-,a,b,c,d
+,result,b,c,d
+,,0,0,0
 
 #group,false,false,true,false
 #datatype,string,string,string,string
 #default,strangeColumnB,,,
-,a,b,c,d`
+,result,b,c,d
+,,0,0,0`
 
     const {resultColumnNames} = fromFlux(CSV)
 
     expect(resultColumnNames).toEqual(['strangeColumnA', 'strangeColumnB'])
   })
 
-  it('handles blank result column names', () => {
-    const CSV = `#group,true,false,false,true
+  it('handles result column in unexpected column position', () => {
+    const DEFAULT_CSV = `#group,true,false,false,true
+#datatype,string,string,string,string
+#default,,resultInUnexpectedPosA,,
+,a,result,c,d
+,0,,0,0
+
+#group,false,false,true,false
+#datatype,string,string,string,string
+#default,,resultInUnexpectedPosB,,
+,a,result,c,d
+,0,,0,0`
+
+    const defaultCSV = fromFlux(DEFAULT_CSV)
+
+    expect(defaultCSV.resultColumnNames).toEqual([
+      'resultInUnexpectedPosA',
+      'resultInUnexpectedPosB',
+    ])
+
+    const ROWS_CSV = `#group,true,false,false,true
 #datatype,string,string,string,string
 #default,,,,
-,a,b,c,d
+,a,result,c,d
+,0,resultInUnexpectedPosA,0,0
 
 #group,false,false,true,false
 #datatype,string,string,string,string
 #default,,,,
-,a,b,c,d`
+,a,result,c,d
+,0,resultInUnexpectedPosB,0,0`
 
-    const {resultColumnNames} = fromFlux(CSV)
+    const rowsCSV = fromFlux(ROWS_CSV)
+
+    expect(rowsCSV.resultColumnNames).toEqual([
+      'resultInUnexpectedPosA',
+      'resultInUnexpectedPosB',
+    ])
+  })
+
+  it('handles blank result column names and empty rows', () => {
+    const BLANK_RESULT_COLUMN_CSV = `#group,true,false,false,true
+#datatype,string,string,string,string
+#default,,,,
+,result,b,c,d
+,,0,0,0
+
+#group,false,false,true,false
+#datatype,string,string,string,string
+#default,,,,
+,result,b,c,d
+,,0,0,0`
+
+    const blankResultColumn = fromFlux(BLANK_RESULT_COLUMN_CSV)
+
+    expect(blankResultColumn.resultColumnNames).toEqual([])
+
+    const EMPTY_ROWS_CSV = `#group,true,false,false,true
+#datatype,string,string,string,string
+#default,strangeColumnA,,,
+,result,b,c,d
+
+#group,false,false,true,false
+#datatype,string,string,string,string
+#default,strangeColumnB,,,
+,result,b,c,d`
+
+    const emptyRows = fromFlux(EMPTY_ROWS_CSV)
+
+    expect(emptyRows.resultColumnNames).toEqual([])
+  })
+
+  it('handles missing result column', () => {
+    const NO_RESULT_CSV = `#group,true,false,false,true
+#datatype,string,string,string,string
+#default,strangeColumnA,,,
+,result,b,c,d
+
+#group,false,false,true,false
+#datatype,string,string,string,string
+#default,strangeColumnB,,,
+,result,b,c,d`
+
+    const {resultColumnNames} = fromFlux(NO_RESULT_CSV)
 
     expect(resultColumnNames).toEqual([])
   })

--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -544,12 +544,14 @@ describe('fromFlux', () => {
     const NO_RESULT_CSV = `#group,true,false,false,true
 #datatype,string,string,string,string
 #default,strangeColumnA,,,
-,result,b,c,d
+,a,b,c,d
+,,,,
 
 #group,false,false,true,false
 #datatype,string,string,string,string
 #default,strangeColumnB,,,
-,result,b,c,d`
+,a,b,c,d
+,,,,`
 
     const {resultColumnNames} = fromFlux(NO_RESULT_CSV)
 

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -2,8 +2,7 @@ import {csvParse, csvParseRows} from 'd3-dsv'
 import {Table, ColumnType, FluxDataType} from '../types'
 import {assert} from './assert'
 import {newTable} from './newTable'
-
-const RESULT_COLUMN_INDEX = 1
+import {RESULT} from '../constants/columnKeys'
 export interface FromFluxResult {
   error?: Error
 
@@ -100,15 +99,6 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
         } else {
           tableTexts.push(line)
         }
-        if (line.startsWith('#default')) {
-          const defaults = line.split(',')
-          if (
-            defaults.length >= RESULT_COLUMN_INDEX + 1 &&
-            defaults[RESULT_COLUMN_INDEX].length
-          ) {
-            resultColumnNames.add(defaults[RESULT_COLUMN_INDEX])
-          }
-        }
       })
 
       tableText = tableTexts.join('\n').trim()
@@ -151,6 +141,13 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
         columnDefault = annotationData.defaultByColumnName[columnName]
 
         for (let i = 0; i < tableData.length; i++) {
+          if (columnName === RESULT) {
+            if (columnDefault.length) {
+              resultColumnNames.add(columnDefault)
+            } else if (tableData[i][columnName].length) {
+              resultColumnNames.add(tableData[i][columnName])
+            }
+          }
           columns[columnKey].data[tableLength + i] = parseValue(
             tableData[i][columnName] || columnDefault,
             columnType

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Part of #726 

According to the [Flux spec](https://github.com/influxdata/flux/blob/master/docs/SPEC.md#csv) the result column is not necessarily guaranteed to be the first column when present.

Update `fromFlux` to guard against an unexpected change to Flux query results that would still be considered within its spec.