### PR TITLE
fix: ensure Band's mainColumnName cannot be reused for lower and upper

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.24.1",
+  "version": "2.24.2",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/components/BandHoverLayer.tsx
+++ b/giraffe/src/components/BandHoverLayer.tsx
@@ -36,11 +36,17 @@ export const BandHoverLayer: FunctionComponent<Props> = ({
     y: yColKey,
     fill: fillColKeys,
     lineWidth,
-    lowerColumnName = '',
     mainColumnName: rowColumnName,
     shadeOpacity,
-    upperColumnName = '',
   } = config
+
+  let {upperColumnName, lowerColumnName} = config
+  if (!upperColumnName || upperColumnName === rowColumnName) {
+    upperColumnName = ''
+  }
+  if (!lowerColumnName || lowerColumnName === rowColumnName) {
+    lowerColumnName = ''
+  }
 
   const xColData = spec.table.getColumn(xColKey, 'number')
   const yColData = spec.table.getColumn(yColKey, 'number')

--- a/giraffe/src/components/BandHoverLayer.tsx
+++ b/giraffe/src/components/BandHoverLayer.tsx
@@ -36,17 +36,11 @@ export const BandHoverLayer: FunctionComponent<Props> = ({
     y: yColKey,
     fill: fillColKeys,
     lineWidth,
+    lowerColumnName,
     mainColumnName: rowColumnName,
     shadeOpacity,
+    upperColumnName,
   } = config
-
-  let {upperColumnName, lowerColumnName} = config
-  if (!upperColumnName || upperColumnName === rowColumnName) {
-    upperColumnName = ''
-  }
-  if (!lowerColumnName || lowerColumnName === rowColumnName) {
-    lowerColumnName = ''
-  }
 
   const xColData = spec.table.getColumn(xColKey, 'number')
   const yColData = spec.table.getColumn(yColKey, 'number')

--- a/giraffe/src/components/BandLayer.tsx
+++ b/giraffe/src/components/BandLayer.tsx
@@ -37,15 +37,11 @@ export const BandLayer: FunctionComponent<Props> = props => {
     yScale,
   } = props
 
-  const {mainColumnName: rowColumnName} = config
-
-  let {upperColumnName, lowerColumnName} = config
-  if (!upperColumnName || upperColumnName === rowColumnName) {
-    upperColumnName = ''
-  }
-  if (!lowerColumnName || lowerColumnName === rowColumnName) {
-    lowerColumnName = ''
-  }
+  const {
+    lowerColumnName,
+    mainColumnName: rowColumnName,
+    upperColumnName,
+  } = config
 
   const simplifiedLineData = useMemo(
     () =>

--- a/giraffe/src/components/BandLayer.tsx
+++ b/giraffe/src/components/BandLayer.tsx
@@ -37,11 +37,15 @@ export const BandLayer: FunctionComponent<Props> = props => {
     yScale,
   } = props
 
-  const {
-    lowerColumnName = '',
-    mainColumnName: rowColumnName,
-    upperColumnName = '',
-  } = config
+  const {mainColumnName: rowColumnName} = config
+
+  let {upperColumnName, lowerColumnName} = config
+  if (!upperColumnName || upperColumnName === rowColumnName) {
+    upperColumnName = ''
+  }
+  if (!lowerColumnName || lowerColumnName === rowColumnName) {
+    lowerColumnName = ''
+  }
 
   const simplifiedLineData = useMemo(
     () =>

--- a/giraffe/src/components/PlotResizer.tsx
+++ b/giraffe/src/components/PlotResizer.tsx
@@ -4,6 +4,7 @@ import {LayerTypes, PlotDimensions, SizedConfig} from '../types'
 
 import {get} from '../utils/get'
 import {resizePlotWithStaticLegend} from '../utils/legend/resizePlot'
+import {normalizeConfig} from '../utils/normalizeConfig'
 import {usePlotEnv} from '../utils/usePlotEnv'
 
 import {SizedPlot} from './SizedPlot'
@@ -28,16 +29,16 @@ export const PlotResizer: FC<PlotResizerProps> = props => {
     config.staticLegend
   )
 
-  const sizedConfig: SizedConfig = useMemo(
+  const normalizedConfig: SizedConfig = useMemo(
     () => ({
-      ...config,
+      ...normalizeConfig(config),
       height: resized.height,
       width: resized.width,
     }),
-    [config, height, width]
+    [config, height, width] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
-  const env = usePlotEnv(sizedConfig)
+  const env = usePlotEnv(normalizedConfig)
   const spec = env.getSpec(0)
   const graphType = get(config, 'layers.0.type')
 
@@ -51,14 +52,14 @@ export const PlotResizer: FC<PlotResizerProps> = props => {
     graphType === LayerTypes.Gauge ||
     graphType === LayerTypes.SimpleTable
   ) {
-    return <SizedTable config={sizedConfig}>{children}</SizedTable>
+    return <SizedTable config={normalizedConfig}>{children}</SizedTable>
   }
 
   return (
     <>
       <SizedPlot
         axesCanvasRef={axesCanvasRef}
-        config={sizedConfig}
+        config={normalizedConfig}
         layerCanvasRef={layerCanvasRef}
         env={env}
       >
@@ -67,7 +68,7 @@ export const PlotResizer: FC<PlotResizerProps> = props => {
       {config.staticLegend && !config.staticLegend.hide ? (
         <StaticLegendBox
           columnFormatter={env.getFormatterForColumn}
-          config={config}
+          config={normalizedConfig}
           height={height - resized.height}
           spec={spec}
           top={resized.height}

--- a/giraffe/src/transforms/band.ts
+++ b/giraffe/src/transforms/band.ts
@@ -410,19 +410,14 @@ export const bandTransform = (
     fillColKeys
   )
 
-  const validLowerColumnName =
-    lowerColumnName && lowerColumnName !== rowColumnName ? lowerColumnName : ''
-  const validUpperColumnName =
-    upperColumnName && upperColumnName !== rowColumnName ? upperColumnName : ''
-
   const table = inputTable.addColumn(FILL, 'system', 'number', fillColumn)
   const xCol = table.getColumn(xColumnKey, 'number')
   const yCol = table.getColumn(yColumnKey, 'number')
   const bandLineMap = getBandLineMap(
     fillColumnMap,
-    validLowerColumnName,
+    lowerColumnName,
     rowColumnName,
-    validUpperColumnName
+    upperColumnName
   )
   const fillScale = range =>
     getBandColorScale(bandLineMap, colors)(range * BAND_COLOR_SCALE_CONSTANT)
@@ -475,8 +470,8 @@ export const bandTransform = (
     type: 'band',
     bandLineMap,
     bandName: rowColumnName,
-    upperColumnName: validUpperColumnName,
-    lowerColumnName: validLowerColumnName,
+    upperColumnName,
+    lowerColumnName,
     inputTable,
     table,
     lineData,

--- a/giraffe/src/transforms/band.ts
+++ b/giraffe/src/transforms/band.ts
@@ -410,14 +410,19 @@ export const bandTransform = (
     fillColKeys
   )
 
+  const validLowerColumnName =
+    lowerColumnName && lowerColumnName !== rowColumnName ? lowerColumnName : ''
+  const validUpperColumnName =
+    upperColumnName && upperColumnName !== rowColumnName ? upperColumnName : ''
+
   const table = inputTable.addColumn(FILL, 'system', 'number', fillColumn)
   const xCol = table.getColumn(xColumnKey, 'number')
   const yCol = table.getColumn(yColumnKey, 'number')
   const bandLineMap = getBandLineMap(
     fillColumnMap,
-    lowerColumnName || '',
+    validLowerColumnName,
     rowColumnName,
-    upperColumnName || ''
+    validUpperColumnName
   )
   const fillScale = range =>
     getBandColorScale(bandLineMap, colors)(range * BAND_COLOR_SCALE_CONSTANT)
@@ -470,8 +475,8 @@ export const bandTransform = (
     type: 'band',
     bandLineMap,
     bandName: rowColumnName,
-    upperColumnName,
-    lowerColumnName,
+    upperColumnName: validUpperColumnName,
+    lowerColumnName: validLowerColumnName,
     inputTable,
     table,
     lineData,

--- a/giraffe/src/utils/normalizeConfig.test.ts
+++ b/giraffe/src/utils/normalizeConfig.test.ts
@@ -1,0 +1,106 @@
+import {Config} from '../types'
+import {normalizeConfig} from './normalizeConfig'
+
+describe('normalizeConfig', () => {
+  describe('config for Band Layer', () => {
+    it('returns the config when it has a proper band layer', () => {
+      const config = {
+        layers: [
+          {
+            type: 'band',
+            x: '_time',
+            y: '_value',
+            fill: ['result', '_field', '_measurement', 'cpu', 'host'],
+            mainColumnName: '_result',
+          },
+        ],
+      } as Config
+      expect(normalizeConfig(config)).toEqual({
+        ...config,
+        layers: [
+          {
+            ...config.layers[0],
+            lowerColumnName: '',
+            upperColumnName: '',
+          },
+        ],
+      })
+    })
+
+    it('overrides the "lowerColumnName" and "upperColumnName" when they match "mainColumnName"', () => {
+      const mainColumnName = 'mean'
+      const config = {
+        layers: [
+          {
+            type: 'band',
+            x: '_time',
+            y: '_value',
+            fill: ['result', '_field', '_measurement', 'cpu', 'host'],
+            upperColumnName: mainColumnName,
+            mainColumnName,
+            lowerColumnName: mainColumnName,
+          },
+        ],
+      } as Config
+      expect(normalizeConfig(config)).toEqual({
+        ...config,
+        layers: [
+          {
+            ...config.layers[0],
+            upperColumnName: '',
+            mainColumnName,
+            lowerColumnName: '',
+          },
+        ],
+      })
+    })
+
+    it('uses the "lowerColumnName" and "upperColumnName" when they do not match "mainColumnName"', () => {
+      const upperColumnName = 'max'
+      const mainColumnName = 'mean'
+      const lowerColumnName = 'min'
+      const config = {
+        layers: [
+          {
+            type: 'band',
+            x: '_time',
+            y: '_value',
+            fill: ['result', '_field', '_measurement', 'cpu', 'host'],
+            upperColumnName,
+            mainColumnName,
+            lowerColumnName,
+          },
+        ],
+      } as Config
+      expect(normalizeConfig(config)).toEqual({
+        ...config,
+        layers: [
+          {
+            ...config.layers[0],
+            upperColumnName,
+            mainColumnName,
+            lowerColumnName,
+          },
+        ],
+      })
+    })
+  })
+
+  /*
+    TODO: see https://github.com/influxdata/giraffe/issues/447
+      when ready add the tests for
+      - AnnotationLayerConfig
+      - CustomLayerConfig
+      - GaugeLayerConfig
+      - GeoLayerConfig
+      - HeatmapLayerConfig
+      - HistogramLayerConfig
+      - LineLayerConfig
+      - MosaicLayerConfig
+      - RawFluxDataTableLayerConfig
+      - ScatterLayerConfig
+      - SimpleTableLayerConfig
+      - SingleStatLayerConfig
+      - TableGraphLayerConfig
+  */
+})

--- a/giraffe/src/utils/normalizeConfig.test.ts
+++ b/giraffe/src/utils/normalizeConfig.test.ts
@@ -1,7 +1,15 @@
 import {Config} from '../types'
-import {normalizeConfig} from './normalizeConfig'
+import {normalizeConfig, normalizeLayers} from './normalizeConfig'
 
 describe('normalizeConfig', () => {
+  it('handles unexpected arguments', () => {
+    const emptyConfig = {layers: []}
+
+    expect(normalizeConfig(undefined)).toEqual(emptyConfig)
+    expect(normalizeConfig(null)).toEqual(emptyConfig)
+    expect(normalizeConfig(emptyConfig)).toEqual(emptyConfig)
+  })
+
   describe('config for Band Layer', () => {
     it('returns the config when it has a proper band layer', () => {
       const config = {
@@ -103,4 +111,11 @@ describe('normalizeConfig', () => {
       - SingleStatLayerConfig
       - TableGraphLayerConfig
   */
+})
+
+describe('normalizeLayers', () => {
+  it('handles incorrect usage', () => {
+    expect(normalizeLayers(undefined)).toEqual([])
+    expect(normalizeLayers(null)).toEqual([])
+  })
 })

--- a/giraffe/src/utils/normalizeConfig.ts
+++ b/giraffe/src/utils/normalizeConfig.ts
@@ -1,0 +1,22 @@
+import {Config, LayerConfig} from '../types'
+
+// TODO: move all layer defaults here, see: https://github.com/influxdata/giraffe/issues/447
+export const normalizeLayers = (layers: LayerConfig[]): LayerConfig[] =>
+  layers?.map(layerConfig => {
+    if (layerConfig.type === 'band') {
+      let {upperColumnName, lowerColumnName} = layerConfig
+      if (!upperColumnName || upperColumnName === layerConfig.mainColumnName) {
+        upperColumnName = ''
+      }
+      if (!lowerColumnName || lowerColumnName === layerConfig.upperColumnName) {
+        lowerColumnName = ''
+      }
+      return {...layerConfig, upperColumnName, lowerColumnName}
+    }
+    return layerConfig
+  }) || []
+
+export const normalizeConfig = (config: Config): Config => ({
+  ...config,
+  layers: normalizeLayers(config?.layers),
+})

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.24.1",
+  "version": "2.24.2",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/3404

- Creates a normalizer to set the `config` including the `layers` to acceptable defaults and expectations. This is also the starting point for a separate bigger issue (see https://github.com/influxdata/giraffe/issues/447)

BEFORE, without normalization:

https://user-images.githubusercontent.com/10736577/153316844-83c3fd57-a520-4248-b77b-1eb6a42ca0de.mp4


AFTER, with normalization:

https://user-images.githubusercontent.com/10736577/153316876-29b6e61d-7cd0-4b2d-89d8-dc24a5ddc02d.mp4

