### PR TITLE
fix: fix typo to check against mainColumnName correctly

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/utils/normalizeConfig.test.ts
+++ b/giraffe/src/utils/normalizeConfig.test.ts
@@ -35,7 +35,61 @@ describe('normalizeConfig', () => {
       })
     })
 
-    it('overrides the "lowerColumnName" and "upperColumnName" when they match "mainColumnName"', () => {
+    it('overrides the "lowerColumnName" when it matches "mainColumnName"', () => {
+      const mainColumnName = 'mean'
+      const config = {
+        layers: [
+          {
+            type: 'band',
+            x: '_time',
+            y: '_value',
+            fill: ['result', '_field', '_measurement', 'cpu', 'host'],
+            mainColumnName,
+            lowerColumnName: mainColumnName,
+          },
+        ],
+      } as Config
+      expect(normalizeConfig(config)).toEqual({
+        ...config,
+        layers: [
+          {
+            ...config.layers[0],
+            upperColumnName: '',
+            mainColumnName,
+            lowerColumnName: '',
+          },
+        ],
+      })
+    })
+
+    it('overrides the "upperColumnName" when it matches "mainColumnName"', () => {
+      const mainColumnName = 'mean'
+      const config = {
+        layers: [
+          {
+            type: 'band',
+            x: '_time',
+            y: '_value',
+            fill: ['result', '_field', '_measurement', 'cpu', 'host'],
+            upperColumnName: mainColumnName,
+            mainColumnName,
+          },
+        ],
+      } as Config
+      expect(normalizeConfig(config)).toEqual({
+        ...config,
+        layers: [
+          {
+            ...config.layers[0],
+            upperColumnName: '',
+            mainColumnName,
+            lowerColumnName: '',
+          },
+        ],
+      })
+    })
+
+    it('overrides the "lowerColumnName" and "upperColumnName" when they both match "mainColumnName"', () => {
       const mainColumnName = 'mean'
       const config = {
         layers: [
@@ -67,6 +121,36 @@ describe('normalizeConfig', () => {
       const upperColumnName = 'max'
       const mainColumnName = 'mean'
       const lowerColumnName = 'min'
+      const config = {
+        layers: [
+          {
+            type: 'band',
+            x: '_time',
+            y: '_value',
+            fill: ['result', '_field', '_measurement', 'cpu', 'host'],
+            upperColumnName,
+            mainColumnName,
+            lowerColumnName,
+          },
+        ],
+      } as Config
+      expect(normalizeConfig(config)).toEqual({
+        ...config,
+        layers: [
+          {
+            ...config.layers[0],
+            upperColumnName,
+            mainColumnName,
+            lowerColumnName,
+          },
+        ],
+      })
+    })
+
+    it('allows lowerColumnName and upperColumnName to match if they do not match mainColumnName', () => {
+      const upperColumnName = 'upperandlower'
+      const mainColumnName = 'mean'
+      const lowerColumnName = upperColumnName
       const config = {
         layers: [
           {

--- a/giraffe/src/utils/normalizeConfig.ts
+++ b/giraffe/src/utils/normalizeConfig.ts
@@ -8,7 +8,7 @@ export const normalizeLayers = (layers: LayerConfig[]): LayerConfig[] =>
       if (!upperColumnName || upperColumnName === layerConfig.mainColumnName) {
         upperColumnName = ''
       }
-      if (!lowerColumnName || lowerColumnName === layerConfig.upperColumnName) {
+      if (!lowerColumnName || lowerColumnName === layerConfig.mainColumnName) {
         lowerColumnName = ''
       }
       return {...layerConfig, upperColumnName, lowerColumnName}

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/3404  

Sorry, i typed too quickly and the autocomplete picked the wrong variable which i mistakenly accepted. This corrects the typo and adds additional unit tests.