### PR TITLE
chore: update version numbers

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.24.3",
+  "version": "2.24.4",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.24.3",
+  "version": "2.24.4",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumping version numbers to do a publish.

We will be testing if `npm publish` is any different than `yarn publish` and if the publishing has any issue completing.