### PR TITLE
chore: add .npmrc to gitignore to support publishing without leaking tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 .env
 .vscode
 coverage
+.npmrc


### PR DESCRIPTION
**npm** requires new steps to publish when requiring 2FA (two-factor authentication). One of the steps involves inserting a token into your local **.npmrc** file, which should remain local so that we do not leak tokens.

- add **.npmrc** to **.gitignore**