### PR TITLE
chore: update version number for demo

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.24.4",
+  "version": "2.24.5",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/publish
+++ b/giraffe/publish
@@ -45,8 +45,7 @@ if ! git status | grep -q "Your branch is up to date with 'origin/master'."; the
 fi
 
 if ! git status | grep -q 'working tree clean'; then
-  echo "Error! Cannot publish with dirty working tree"
-  exit 1
+  echo "*** Warning: publishing with dirty working tree"
 fi
 
 echo "Installing dependencies"

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.24.4",
+  "version": "2.24.5",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Allows the `publish` script to proceed even with a dirty working tree. 