### PR TITLE
chore: clean up drift between parsers after proven success

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.27.1",
+  "version": "2.27.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.26.2",
+  "version": "2.27.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -77,7 +77,51 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
   let tableLength = 0
 
   try {
-    const chunks = splitChunks(fluxCSV)
+    /*
+      A Flux CSV response can contain multiple CSV files each joined by a newline.
+      This function splits up a CSV response into these individual CSV files.
+      See https://github.com/influxdata/flux/blob/master/docs/SPEC.md#multiple-tables.
+    */
+    fluxCSV = fluxCSV.trimEnd()
+
+    if (fluxCSV === '') {
+      return {
+        table: newTable(0),
+        fluxGroupKeyUnion: [],
+        resultColumnNames: [],
+      }
+    }
+
+    // Split the response into separate chunks whenever we encounter:
+    //
+    // 1. A newline
+    // 2. Followed by any amount of whitespace
+    // 3. Followed by a newline
+    // 4. Followed by a `#` character
+    //
+    // The last condition is [necessary][0] for handling CSV responses with
+    // values containing newlines.
+    //
+    // [0]: https://github.com/influxdata/influxdb/issues/15017
+
+    // finds the first non-whitespace character
+    let curr = fluxCSV.search(/\S/)
+
+    const chunks = []
+    while (curr !== -1) {
+      const oldVal = curr
+      const nextIndex = fluxCSV
+        .substring(curr, fluxCSV.length)
+        .search(/\n\s*\n#/)
+      if (nextIndex === -1) {
+        chunks.push([oldVal, fluxCSV.length])
+        curr = -1
+        break
+      } else {
+        chunks.push([oldVal, oldVal + nextIndex])
+        curr = oldVal + nextIndex + 2
+      }
+    }
 
     // declaring all nested variables here to reduce memory drain
     let tableText = ''
@@ -86,8 +130,10 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
     let columnType: any = ''
     let columnKey = ''
     let columnDefault: any = ''
+    let chunk = ''
 
-    for (const chunk of chunks) {
+    for (const [start, end] of chunks) {
+      chunk = fluxCSV.substring(start, end)
       const splittedChunk = chunk.split('\n')
 
       const tableTexts = []
@@ -148,10 +194,35 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
               resultColumnNames.add(tableData[i][columnName])
             }
           }
-          columns[columnKey].data[tableLength + i] = parseValue(
-            tableData[i][columnName] || columnDefault,
-            columnType
-          )
+          const value = tableData[i][columnName] || columnDefault
+          let result = null
+
+          if (value === undefined) {
+            result = undefined
+          } else if (value === 'null') {
+            result = null
+          } else if (value === 'NaN') {
+            result = NaN
+          } else if (columnType === 'boolean' && value === 'true') {
+            result = true
+          } else if (columnType === 'boolean' && value === 'false') {
+            result = false
+          } else if (columnType === 'string') {
+            result = value
+          } else if (columnType === 'time') {
+            result = Date.parse(value.trim())
+          } else if (columnType === 'number') {
+            if (value === '') {
+              result = null
+            } else {
+              const parsedValue = Number(value)
+              result = parsedValue === parsedValue ? parsedValue : value
+            }
+          } else {
+            result = null
+          }
+
+          columns[columnKey].data[tableLength + i] = result
         }
 
         if (annotationData.groupKey.includes(columnName)) {
@@ -196,6 +267,11 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
   let tableLength = 0
 
   try {
+    /*
+      A Flux CSV response can contain multiple CSV files each joined by a newline.
+      This function splits up a CSV response into these individual CSV files.
+      See https://github.com/influxdata/flux/blob/master/docs/SPEC.md#multiple-tables.
+    */
     fluxCSV = fluxCSV.trimEnd()
 
     if (fluxCSV === '') {
@@ -373,36 +449,6 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
   }
 }
 
-/*
-  A Flux CSV response can contain multiple CSV files each joined by a newline.
-  This function splits up a CSV response into these individual CSV files.
-  See https://github.com/influxdata/flux/blob/master/docs/SPEC.md#multiple-tables.
-*/
-const splitChunks = (fluxCSV: string): string[] => {
-  const trimmedResponse = fluxCSV.trim()
-
-  if (trimmedResponse === '') {
-    return []
-  }
-
-  // Split the response into separate chunks whenever we encounter:
-  //
-  // 1. A newline
-  // 2. Followed by any amount of whitespace
-  // 3. Followed by a newline
-  // 4. Followed by a `#` character
-  //
-  // The last condition is [necessary][0] for handling CSV responses with
-  // values containing newlines.
-  //
-  // [0]: https://github.com/influxdata/influxdb/issues/15017
-  const chunks = trimmedResponse
-    .split(/\n\s*\n#/)
-    .map((s, i) => (i === 0 ? s : `#${s}`)) // Add back the `#` characters that were removed by splitting
-
-  return chunks
-}
-
 const parseAnnotations = (
   annotationData: string,
   headerRow: string[]
@@ -444,46 +490,6 @@ const TO_COLUMN_TYPE: {[fluxDatatype: string]: ColumnType} = {
   double: 'number',
   string: 'string',
   'dateTime:RFC3339': 'time',
-}
-
-const parseValue = (value: string | undefined, columnType: ColumnType): any => {
-  if (value === undefined) {
-    return undefined
-  }
-
-  if (value === 'null') {
-    return null
-  }
-
-  if (value === 'NaN') {
-    return NaN
-  }
-
-  if (columnType === 'boolean' && value === 'true') {
-    return true
-  }
-
-  if (columnType === 'boolean' && value === 'false') {
-    return false
-  }
-
-  if (columnType === 'string') {
-    return value
-  }
-
-  if (columnType === 'time') {
-    return Date.parse(value.trim())
-  }
-
-  if (columnType === 'number') {
-    if (value === '') {
-      return null
-    }
-    const parsedValue = Number(value)
-    return parsedValue === parsedValue ? parsedValue : value
-  }
-
-  return null
 }
 
 /*

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -82,9 +82,10 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
       This function splits up a CSV response into these individual CSV files.
       See https://github.com/influxdata/flux/blob/master/docs/SPEC.md#multiple-tables.
     */
-    fluxCSV = fluxCSV.trimEnd()
+    // finds the first non-whitespace character
+    let currentIndex = fluxCSV.search(/\S/)
 
-    if (fluxCSV === '') {
+    if (currentIndex === -1) {
       return {
         table: newTable(0),
         fluxGroupKeyUnion: [],
@@ -103,9 +104,6 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
     // values containing newlines.
     //
     // [0]: https://github.com/influxdata/influxdb/issues/15017
-
-    // finds the first non-whitespace character
-    let currentIndex = fluxCSV.search(/\S/)
 
     const chunks = []
     while (currentIndex !== -1) {
@@ -210,7 +208,11 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
           } else if (columnType === 'string') {
             result = value
           } else if (columnType === 'time') {
-            result = Date.parse(value.trim())
+            if (/\s/.test(value)) {
+              result = Date.parse(value.trim())
+            } else {
+              result = Date.parse(value)
+            }
           } else if (columnType === 'number') {
             if (value === '') {
               result = null
@@ -272,9 +274,10 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
       This function splits up a CSV response into these individual CSV files.
       See https://github.com/influxdata/flux/blob/master/docs/SPEC.md#multiple-tables.
     */
-    fluxCSV = fluxCSV.trimEnd()
+    // finds the first non-whitespace character
+    let curr = fluxCSV.search(/\S/)
 
-    if (fluxCSV === '') {
+    if (curr === -1) {
       return {
         table: newTable(0),
         fluxGroupKeyUnion: [],
@@ -293,9 +296,6 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
     // values containing newlines.
     //
     // [0]: https://github.com/influxdata/influxdb/issues/15017
-
-    // finds the first non-whitespace character
-    let curr = fluxCSV.search(/\S/)
 
     const chunks = []
     while (curr !== -1) {
@@ -399,7 +399,11 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
           } else if (columnType === 'string') {
             result = value
           } else if (columnType === 'time') {
-            result = Date.parse(value.trim())
+            if (/\s/.test(value)) {
+              result = Date.parse(value.trim())
+            } else {
+              result = Date.parse(value)
+            }
           } else if (columnType === 'number') {
             if (value === '') {
               result = null

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -105,21 +105,21 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
     // [0]: https://github.com/influxdata/influxdb/issues/15017
 
     // finds the first non-whitespace character
-    let curr = fluxCSV.search(/\S/)
+    let currentIndex = fluxCSV.search(/\S/)
 
     const chunks = []
-    while (curr !== -1) {
-      const oldVal = curr
+    while (currentIndex !== -1) {
+      const prevIndex = currentIndex
       const nextIndex = fluxCSV
-        .substring(curr, fluxCSV.length)
+        .substring(currentIndex, fluxCSV.length)
         .search(/\n\s*\n#/)
       if (nextIndex === -1) {
-        chunks.push([oldVal, fluxCSV.length])
-        curr = -1
+        chunks.push([prevIndex, fluxCSV.length])
+        currentIndex = -1
         break
       } else {
-        chunks.push([oldVal, oldVal + nextIndex])
-        curr = oldVal + nextIndex + 2
+        chunks.push([prevIndex, prevIndex + nextIndex])
+        currentIndex = prevIndex + nextIndex + 2
       }
     }
 

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.27.1",
+  "version": "2.27.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.26.2",
+  "version": "2.27.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR consolidates the changes that were made here:

https://github.com/influxdata/giraffe/pull/752

### Background

The linked PR was made to help address some performance issues with the fromFlux parser. After merging the changes in, publishing a new version of giraffe in the UI, and feature flagging the usages of fromFlux in the UI to use the `fastFromFlux` the parser changes appear to have improved the UI's usage of the parser without any known issues. Having said that, this implementation still relies upon allocating memory for chunks of data that are then parsed, chunked and joined again. While this imperfect implementation is a lot better than the previous one, we want to be able to iterate on the `fastFromFlux` parser without compromising gains made to the parser.

### Reviewer Notes

This PR basically just updates the changes that were applied to the `fastFromFlux` parser to the `fromFlux` parser after it's been a proven success. The plan here is to publish a new version of giraffe, turn the `fastFromFlux` feature flag off in the UI with the newly published version of giraffe, and iterate on updating the `fastFromFlux` parser so that we can improve performance without compromising gains 