### PR TITLE
chore: reduce mallocs in favor and speed parser up

### DIFF
--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -333,7 +333,8 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
           fluxCSV[index - 1] === '\n' || fluxCSV[index - 1] === undefined
         // check to see if the one before that is whitespace or a new line
         const isWhitespaceOrNewLine =
-          fluxCSV[index - 2] === undefined || fluxCSV[index - 2]?.trim() === ''
+          fluxCSV[index - 2] === undefined ||
+          fluxCSV[index - 2]?.search(/\S/) === -1
         if (startsWithHash && isPrevNewLine && isWhitespaceOrNewLine) {
           const nextIndex =
             fluxCSV.substring(index, end).lastIndexOf('\n#') + index

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -355,11 +355,10 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
         }
       }
 
-      if (!!tableText) {
-        throw new Error(
-          'could not find table text lines in Flux response; are `annotations` enabled in the Flux query `dialect` option?'
-        )
-      }
+      assert(
+        !!tableText,
+        'could not find table text lines in Flux response; are `annotations` enabled in the Flux query `dialect` option?'
+      )
 
       /**
        * csvParse is a slow operation, so we may want to see whether we can
@@ -367,23 +366,20 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
        */
       tableData = csvParse(tableText)
 
-      if (!!annotationText) {
-        throw new Error(
-          'could not find annotation lines lines in Flux response; are `annotations` enabled in the Flux query `dialect` option?'
-        )
-      }
-
+      assert(
+        !!annotationText,
+        'could not find annotation lines in Flux response; are `annotations` enabled in the Flux query `dialect` option?'
+      )
       const annotationData = parseAnnotations(annotationText, tableData.columns)
 
       for (const columnName of tableData.columns.slice(1)) {
         columnType =
           TO_COLUMN_TYPE[annotationData.datatypeByColumnName[columnName]]
 
-        if (!!columnType) {
-          throw new Error(
-            `encountered unknown Flux column type ${annotationData.datatypeByColumnName[columnName]}`
-          )
-        }
+        assert(
+          !!columnType,
+          `encountered unknown Flux column type ${annotationData.datatypeByColumnName[columnName]}`
+        )
 
         columnKey = `${columnName} (${columnType})`
 


### PR DESCRIPTION
This implementation is currently a WIP to try and reduce the memory allocation operations that the parser is currently using to operate. This **does not** fully operate off of pointers, nor does it address the original chunking behavior (of searching for chunks based on searching for a regex match. 

Ideally we can use this as a blueprint for performing annotation and table text building as we define the boundaries of the chunk in the previous step and consolidate some of the logic so that we can eventually stream data.  