### PR TITLE
feat: use papaparse as our parser

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.27.1",
+  "version": "2.28.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -966,6 +966,36 @@ describe('fastFromFlux', () => {
     const fFlux = fastFromFlux(resp)
     expect(fFlux).toEqual(expected)
   })
+  it.only('parses query with newlines and hashtags', () => {
+    const CSV = `#group,false,false,true,false
+#datatype,string,long,long,string
+#default,_result,,,
+,result,table,_time_reverse,_value
+,,0,-1652887800000000000,"Row 1
+#newline #somehashTags https://a_link.com/giraffe"
+,,0,-1652887811000000000,Row 2
+,,0,-1652888700000000000,"Row 3: 👇👇👇 // emojis
+,Mew line!"
+,,0,-1652889550000000000,"Row 4:
+New line 1!
+New line 2!
+multiple new lines!`
+    const {table} = fastFromFlux(CSV)
+
+    const expectedColumns = [
+      `Row 1
+#newline #somehashTags https://a_link.com/giraffe`,
+      'Row 2',
+      `Row 3: 👇👇👇 // emojis
+,Mew line!`,
+      `Row 4:
+New line 1!
+New line 2!
+multiple new lines!`,
+    ]
+
+    expect(table.getColumn('_value')).toStrictEqual(expectedColumns)
+  })
 
   it('can parse a Flux CSV with mismatched schemas', () => {
     const CSV = `#group,false,false,true,true,false,true,true,true,true,true

--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -966,7 +966,7 @@ describe('fastFromFlux', () => {
     const fFlux = fastFromFlux(resp)
     expect(fFlux).toEqual(expected)
   })
-  it.only('parses query with newlines and hashtags', () => {
+  it('parses query with newlines and hashtags', () => {
     const CSV = `#group,false,false,true,false
 #datatype,string,long,long,string
 #default,_result,,,

--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -1081,8 +1081,6 @@ describe('fastFromFlux', () => {
     expect(() => {
       fastFromFlux(CSV)
     }).not.toThrow()
-    const actual = fastFromFlux(CSV)
-    expect(actual.error).toBeTruthy()
   })
 
   it('uses the default annotation to fill in empty values', () => {

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -1,4 +1,5 @@
 import {csvParse, csvParseRows} from 'd3-dsv'
+import Papa from 'papaparse'
 import {Table, ColumnType, FluxDataType} from '../types'
 import {assert} from './assert'
 import {newTable} from './newTable'
@@ -269,10 +270,7 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
 
 export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
   const columns: Columns = {}
-  const fluxGroupKeyUnion = new Set<string>()
-  const resultColumnNames = new Set<string>()
   let tableLength = 0
-
   try {
     /*
       A Flux CSV response can contain multiple CSV files each joined by a newline.
@@ -319,120 +317,104 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
     }
 
     // declaring all nested variables here to reduce memory drain
-    let tableText = ''
-    let tableData: any = []
-    let annotationText = ''
-    let columnType: any = ''
     let columnKey = ''
-    let columnDefault: any = ''
+    const fluxGroupKeyUnion = new Set<string>()
+    const resultColumnNames = new Set<string>()
 
     for (const [start, end] of chunks) {
-      const splittedChunk = fluxCSV.substring(start, end).split('\n')
+      let annotationMode = true
 
-      const tableTexts = []
-      const annotationTexts = []
-
-      splittedChunk.forEach(line => {
-        if (line.startsWith('#')) {
-          annotationTexts.push(line)
-        } else {
-          tableTexts.push(line)
-        }
-      })
-
-      tableText = tableTexts.join('\n').trim()
-
-      assert(
-        !!tableText,
-        'could not find annotation lines in Flux response; are `annotations` enabled in the Flux query `dialect` option?'
-      )
-
-      // TODO(ariel): csvParse is a slow operation
-      tableData = csvParse(tableText)
-
-      annotationText = annotationTexts.join('\n').trim()
-
-      assert(
-        !!annotationText,
-        'could not find annotation lines in Flux response; are `annotations` enabled in the Flux query `dialect` option?'
-      )
-      const annotationData = parseAnnotations(annotationText, tableData.columns)
-
-      for (const columnName of tableData.columns.slice(1)) {
-        columnType =
-          TO_COLUMN_TYPE[annotationData.datatypeByColumnName[columnName]]
-
-        assert(
-          !!columnType,
-          `encountered unknown Flux column type ${annotationData.datatypeByColumnName[columnName]}`
-        )
-
-        columnKey = `${columnName} (${columnType})`
-
-        if (!columns[columnKey]) {
-          columns[columnKey] = {
-            name: columnName,
-            type: columnType,
-            fluxDataType: annotationData.datatypeByColumnName[columnName],
-            data: [],
-          } as Column
-        }
-
-        columnDefault = annotationData.defaultByColumnName[columnName]
-
-        for (let i = 0; i < tableData.length; i++) {
-          if (columnName === RESULT) {
-            if (columnDefault.length) {
-              resultColumnNames.add(columnDefault)
-            } else if (tableData[i][columnName].length) {
-              resultColumnNames.add(tableData[i][columnName])
-            }
-          }
-          const value = tableData[i][columnName] || columnDefault
-          let result = null
-
-          if (value === undefined) {
-            result = undefined
-          } else if (value === 'null') {
-            result = null
-          } else if (value === 'NaN') {
-            result = NaN
-          } else if (columnType === 'boolean' && value === 'true') {
-            result = true
-          } else if (columnType === 'boolean' && value === 'false') {
-            result = false
-          } else if (columnType === 'string') {
-            result = value
-          } else if (columnType === 'time') {
-            if (/\s/.test(value)) {
-              result = Date.parse(value.trim())
-            } else {
-              result = Date.parse(value)
-            }
-          } else if (columnType === 'number') {
-            if (value === '') {
-              result = null
-            } else {
-              const parsedValue = Number(value)
-              result = parsedValue === parsedValue ? parsedValue : value
-            }
-          } else {
-            result = null
-          }
-
-          columns[columnKey].data[tableLength + i] = result
-        }
-
-        if (annotationData.groupKey.includes(columnName)) {
-          fluxGroupKeyUnion.add(columnKey)
-        }
+      const parsed = {
+        group: [],
+        datatype: [],
+        default: [],
+        header: [],
+        columnKey: [],
       }
+      Papa.parse(fluxCSV.substring(start, end), {
+        step: function(results) {
+          if (results.data[0] === '#group') {
+            parsed.group = results.data.slice(1)
+          } else if (results.data[0] === '#datatype') {
+            parsed.datatype = results.data.slice(1)
+          } else if (results.data[0] === '#default') {
+            parsed.default = results.data.slice(1)
+          } else if (results.data[0][0] !== '#' && annotationMode === true) {
+            annotationMode = false
+            parsed.header = results.data.slice(1)
+            parsed.header.reduce((acc, curr, index) => {
+              columnKey = `${curr} (${TO_COLUMN_TYPE[parsed.datatype[index]]})`
+              parsed.columnKey.push(columnKey)
+              if (!acc[columnKey]) {
+                acc[columnKey] = {
+                  name: curr,
+                  type: TO_COLUMN_TYPE[parsed.datatype[index]],
+                  fluxDataType: parsed.datatype[index],
+                  data: [],
+                }
+              }
+              if (parsed.group[index] === 'true') {
+                fluxGroupKeyUnion.add(columnKey)
+              }
+              return acc
+            }, columns)
+          } else {
+            results.data.slice(1).forEach((data, index) => {
+              const value = data || parsed.default[index]
+              let result = null
 
-      tableLength += tableData.length
+              if (value === undefined) {
+                result = undefined
+              } else if (value === 'null') {
+                result = null
+              } else if (value === 'NaN') {
+                result = NaN
+              } else if (
+                TO_COLUMN_TYPE[parsed.datatype[index]] === 'boolean' &&
+                value === 'true'
+              ) {
+                result = true
+              } else if (
+                TO_COLUMN_TYPE[parsed.datatype[index]] === 'boolean' &&
+                value === 'false'
+              ) {
+                result = false
+              } else if (TO_COLUMN_TYPE[parsed.datatype[index]] === 'string') {
+                result = value
+              } else if (TO_COLUMN_TYPE[parsed.datatype[index]] === 'time') {
+                if (/\s/.test(value)) {
+                  result = Date.parse(value.trim())
+                } else {
+                  result = Date.parse(value)
+                }
+              } else if (TO_COLUMN_TYPE[parsed.datatype[index]] === 'number') {
+                if (value === '') {
+                  result = null
+                } else {
+                  const parsedValue = Number(value)
+                  result = parsedValue === parsedValue ? parsedValue : value
+                }
+              } else {
+                result = null
+              }
+
+              if (columns[parsed.columnKey[index]] !== undefined) {
+                if (
+                  columns[parsed.columnKey[index]].name === RESULT &&
+                  result
+                ) {
+                  resultColumnNames.add(result)
+                }
+                columns[parsed.columnKey[index]].data[tableLength] = result
+              }
+            })
+            tableLength++
+          }
+        },
+      })
     }
 
     resolveNames(columns, fluxGroupKeyUnion)
-
     const table = Object.entries(columns).reduce(
       (table, [key, {name, fluxDataType, type, data}]) => {
         data.length = tableLength

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -4,7 +4,6 @@ import {Table, ColumnType, FluxDataType} from '../types'
 import {assert} from './assert'
 import {newTable} from './newTable'
 import {RESULT} from '../constants/columnKeys'
-import Papa from 'papaparse'
 import {escapeCSVFieldWithSpecialCharacters} from './escapeCSVFieldWithSpecialCharacters'
 export interface FromFluxResult {
   error?: Error

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -408,7 +408,6 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
                 columns[parsed.columnKey[index]].data[tableLength] = result
               }
             })
-            console.log({data: JSON.stringify(results.data), tableLength})
             tableLength++
           }
         },

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -331,7 +331,7 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
         header: [],
         columnKey: [],
       }
-      Papa.parse(fluxCSV.substring(start, end), {
+      Papa.parse(fluxCSV.substring(start, end).trimEnd(), {
         step: function(results) {
           if (results.data[0] === '#group') {
             parsed.group = results.data.slice(1)
@@ -408,6 +408,7 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
                 columns[parsed.columnKey[index]].data[tableLength] = result
               }
             })
+            console.log({data: JSON.stringify(results.data), tableLength})
             tableLength++
           }
         },

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.27.1",
+  "version": "2.28.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR introduces a new way of parsing incoming CSV data by relying upon PapaParse as our central mechanism for parsing the CSVs. While the performance gains here are negligible, this should allow us to handle JSON values within the CSV. 

### Background
While the previous implementation of the parser relied upon the d3 based parser, this implementation transitions to using Papaparse. The reasons for this are:

1. More broad CSV support
2. Better handling of edge cases in parser logic when parsing tables that have JSON data
3. Easier implementation that can be transitioned to data streaming
4. Slight performance gains

