### PR TITLE
feat: better parsing definitions

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.26.1",
+  "version": "2.26.2",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/utils/fluxParsing.ts
+++ b/giraffe/src/utils/fluxParsing.ts
@@ -33,7 +33,7 @@ export const parseResponse = (response: string): FluxTable[] => {
 export const parseTables = (responseChunk: string): FluxTable[] => {
   const lines = responseChunk
     .split('\n,')
-    .map((s, i) => (i === 0 ? s : `,${s}`)) // Add back the `#` characters that were removed by splitting
+    .map((line, index) => (index === 0 ? line : `,${line}`)) // Add back the `#` characters that were removed by splitting
   const annotationLines: string = lines
     .filter(line => line.startsWith('#'))
     .join('\n')

--- a/giraffe/src/utils/fluxParsing.ts
+++ b/giraffe/src/utils/fluxParsing.ts
@@ -33,7 +33,7 @@ export const parseResponse = (response: string): FluxTable[] => {
 export const parseTables = (responseChunk: string): FluxTable[] => {
   const lines = responseChunk
     .split('\n,')
-    .map((line, index) => (index === 0 ? line : `,${line}`)) // Add back the `#` characters that were removed by splitting
+    .map((line, index) => (index === 0 ? line : `,${line}`)) // Add back the `,` commas that were removed by splitting
   const annotationLines: string = lines
     .filter(line => line.startsWith('#'))
     .join('\n')

--- a/giraffe/src/utils/fluxParsing.ts
+++ b/giraffe/src/utils/fluxParsing.ts
@@ -4,7 +4,7 @@ import uuid from 'uuid'
 import {FluxTable} from '../types'
 import {get} from './get'
 import {groupBy} from './groupBy'
-import { parseChunks } from "./fromFlux";
+import {parseChunks} from './fromFlux'
 
 export const parseResponseError = (response: string): FluxTable[] => {
   const data = Papa.parse(response.trim()).data as string[][]

--- a/giraffe/src/utils/fluxParsing.ts
+++ b/giraffe/src/utils/fluxParsing.ts
@@ -23,6 +23,7 @@ export const parseResponseError = (response: string): FluxTable[] => {
 
 export const parseResponse = (response: string): FluxTable[] => {
   const chunks = parseChunks(response)
+  console.log(chunks)
   const tables = chunks.reduce((acc, chunk) => {
     return [...acc, ...parseTables(chunk)]
   }, [])

--- a/giraffe/src/utils/fluxParsing.ts
+++ b/giraffe/src/utils/fluxParsing.ts
@@ -23,7 +23,6 @@ export const parseResponseError = (response: string): FluxTable[] => {
 
 export const parseResponse = (response: string): FluxTable[] => {
   const chunks = parseChunks(response)
-  console.log(chunks)
   const tables = chunks.reduce((acc, chunk) => {
     return [...acc, ...parseTables(chunk)]
   }, [])

--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -1316,4 +1316,38 @@ there",5
 
     expect(table.getColumn('time')).toEqual([1610972402582])
   })
+
+  it('parses query with newlines and hashtags', () => {
+    const CSV = `#group,false,false,true,false
+#datatype,string,long,long,string
+#default,_result,,,
+,result,table,_time_reverse,_value
+,,0,-1652887800000000000,"Row 1
+
+#newline #somehashTags https://a_link.com/giraffe"
+,,0,-1652887811000000000,Row 2
+,,0,-1652888700000000000,"Row 3: 👇👇👇 // emojis
+Mew line!"
+,,0,-1652889550000000000,"Row 4:
+New line 1!
+New line 2!
+multiple new lines!`
+    const {table} = fastFromFlux(CSV)
+
+    const expectedColumns = [
+      `Row 1
+
+#newline #somehashTags https://a_link.com/giraffe`,
+      'Row 2',
+      `Row 3: 👇👇👇 // emojis
+Mew line!`,
+      `Row 4:
+New line 1!
+New line 2!
+multiple new lines!`,
+    ]
+
+    expect(table.getColumn('_value')).toStrictEqual(expectedColumns)
+  })
+
 })

--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -1349,5 +1349,4 @@ multiple new lines!`,
 
     expect(table.getColumn('_value')).toStrictEqual(expectedColumns)
   })
-
 })

--- a/giraffe/src/utils/fromFlux.test.ts
+++ b/giraffe/src/utils/fromFlux.test.ts
@@ -641,6 +641,39 @@ there",5
 
     expect(table.getColumn('time')).toEqual([1610972402582])
   })
+
+  it('parses query with newlines and hashtags', () => {
+    const CSV = `#group,false,false,true,false
+#datatype,string,long,long,string
+#default,_result,,,
+,result,table,_time_reverse,_value
+,,0,-1652887800000000000,"Row 1
+
+#newline #somehashTags https://a_link.com/giraffe"
+,,0,-1652887811000000000,Row 2
+,,0,-1652888700000000000,"Row 3: 👇👇👇 // emojis
+Mew line!"
+,,0,-1652889550000000000,"Row 4:
+New line 1!
+New line 2!
+multiple new lines!`
+    const {table} = fromFlux(CSV)
+
+    const expectedColumns = [
+      `Row 1
+
+#newline #somehashTags https://a_link.com/giraffe`,
+      'Row 2',
+      `Row 3: 👇👇👇 // emojis
+Mew line!`,
+      `Row 4:
+New line 1!
+New line 2!
+multiple new lines!`,
+    ]
+
+    expect(table.getColumn('_value')).toStrictEqual(expectedColumns)
+  })
 })
 describe('fastFromFlux', () => {
   it('should always pass for stability checks', () => {

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -90,7 +90,7 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
     for (const chunk of chunks) {
       const splittedChunk = chunk
         .split('\n,')
-        .map((s, i) => (i === 0 ? s : `,${s}`)) // Add back the `#` characters that were removed by splitting
+        .map((s, i) => (i === 0 ? s : `,${s}`)) // Add back the `,` (comma) characters that were removed during splitting
 
       const tableTexts = []
       const annotationTexts = []

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -77,7 +77,7 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
   let tableLength = 0
 
   try {
-    const chunks = splitChunks(fluxCSV)
+    const chunks = parseChunks(fluxCSV)
 
     // declaring all nested variables here to reduce memory drain
     let tableText = ''
@@ -88,7 +88,9 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
     let columnDefault: any = ''
 
     for (const chunk of chunks) {
-      const splittedChunk = chunk.split('\n')
+      const splittedChunk = chunk
+        .split('\n,')
+        .map((s, i) => (i === 0 ? s : `,${s}`)) // Add back the `#` characters that were removed by splitting
 
       const tableTexts = []
       const annotationTexts = []
@@ -378,7 +380,7 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
   This function splits up a CSV response into these individual CSV files.
   See https://github.com/influxdata/flux/blob/master/docs/SPEC.md#multiple-tables.
 */
-const splitChunks = (fluxCSV: string): string[] => {
+export const parseChunks = (fluxCSV: string): string[] => {
   const trimmedResponse = fluxCSV.trim()
 
   if (trimmedResponse === '') {
@@ -397,8 +399,8 @@ const splitChunks = (fluxCSV: string): string[] => {
   //
   // [0]: https://github.com/influxdata/influxdb/issues/15017
   const chunks = trimmedResponse
-    .split(/\n\s*\n#/)
-    .map((s, i) => (i === 0 ? s : `#${s}`)) // Add back the `#` characters that were removed by splitting
+    .split(/\n\s*\n#group/)
+    .map((s, i) => (i === 0 ? s : `#group${s}`)) // Add back the `#` characters that were removed by splitting
 
   return chunks
 }

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -90,7 +90,7 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
     for (const chunk of chunks) {
       const splittedChunk = chunk
         .split('\n,')
-        .map((s, i) => (i === 0 ? s : `,${s}`)) // Add back the `,` (comma) characters that were removed during splitting
+        .map((string, index) => (index === 0 ? string : `,${string}`)) // Add back the `,` (comma) characters that were removed during splitting
 
       const tableTexts = []
       const annotationTexts = []
@@ -402,7 +402,7 @@ export const parseChunks = (fluxCSV: string): string[] => {
   // use positive lookahead
   const chunks = trimmedResponse
     .split(/\n\s*\n#(?=datatype|group|default)/)
-    .map((s, i) => (i === 0 ? s : `#${s}`)) // Add back the `#` characters that were removed by splitting
+    .map((chunk, chunkNumber) => (chunkNumber === 0 ? chunk : `#${chunk}`)) // Add back the `#` characters that were removed by splitting
 
   return chunks
 }

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -248,9 +248,10 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
     let columnDefault: any = ''
 
     for (const [start, end] of chunks) {
-      const splittedChunk = fluxCSV.substring(start, end).split('\n,')
+      const splittedChunk = fluxCSV
+        .substring(start, end)
+        .split('\n,')
         .map((line, index) => (index === 0 ? line : `,${line}`)) // Add back the `,` (comma) characters that were removed during splitting
-
 
       const tableTexts = []
       const annotationTexts = []

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -213,7 +213,7 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
     // 1. A newline
     // 2. Followed by any amount of whitespace
     // 3. Followed by a newline
-    // 4. Followed by a `#` character
+    // 4. Followed by a `#` character that has datatype|group|default, following it ex. (#group or #datatype)
     //
     // The last condition is [necessary][0] for handling CSV responses with
     // values containing newlines.
@@ -228,7 +228,7 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
       const oldVal = curr
       const nextIndex = fluxCSV
         .substring(curr, fluxCSV.length)
-        .search(/\n\s*\n#(?=datatype|group|default)/)
+        .search(/\n\s*\n#(?=datatype|group|default)/) // regex uses a lookahead operator to look ahead for the keywords
       if (nextIndex === -1) {
         chunks.push([oldVal, fluxCSV.length])
         curr = -1

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -398,9 +398,11 @@ export const parseChunks = (fluxCSV: string): string[] => {
   // values containing newlines.
   //
   // [0]: https://github.com/influxdata/influxdb/issues/15017
+
+  // use positive lookahead
   const chunks = trimmedResponse
-    .split(/\n\s*\n#group/)
-    .map((s, i) => (i === 0 ? s : `#group${s}`)) // Add back the `#` characters that were removed by splitting
+    .split(/\n\s*\n#(?=datatype|group|default)/)
+    .map((s, i) => (i === 0 ? s : `#${s}`)) // Add back the `#` characters that were removed by splitting
 
   return chunks
 }

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -392,7 +392,7 @@ export const parseChunks = (fluxCSV: string): string[] => {
   // 1. A newline
   // 2. Followed by any amount of whitespace
   // 3. Followed by a newline
-  // 4. Followed by a `#` character
+  // 4. Followed by a `#` character that has datatype|group|default, following it ex. (#group or #datatype)
   //
   // The last condition is [necessary][0] for handling CSV responses with
   // values containing newlines.

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -228,7 +228,7 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
       const oldVal = curr
       const nextIndex = fluxCSV
         .substring(curr, fluxCSV.length)
-        .search(/\n\s*\n#/)
+        .search(/\n\s*\n#(?=datatype|group|default)/)
       if (nextIndex === -1) {
         chunks.push([oldVal, fluxCSV.length])
         curr = -1
@@ -248,7 +248,9 @@ export const fastFromFlux = (fluxCSV: string): FromFluxResult => {
     let columnDefault: any = ''
 
     for (const [start, end] of chunks) {
-      const splittedChunk = fluxCSV.substring(start, end).split('\n')
+      const splittedChunk = fluxCSV.substring(start, end).split('\n,')
+        .map((line, index) => (index === 0 ? line : `,${line}`)) // Add back the `,` (comma) characters that were removed during splitting
+
 
       const tableTexts = []
       const annotationTexts = []

--- a/giraffe/src/utils/fromFlux.ts
+++ b/giraffe/src/utils/fromFlux.ts
@@ -90,7 +90,7 @@ export const fromFlux = (fluxCSV: string): FromFluxResult => {
     for (const chunk of chunks) {
       const splittedChunk = chunk
         .split('\n,')
-        .map((string, index) => (index === 0 ? string : `,${string}`)) // Add back the `,` (comma) characters that were removed during splitting
+        .map((line, index) => (index === 0 ? line : `,${line}`)) // Add back the `,` (comma) characters that were removed during splitting
 
       const tableTexts = []
       const annotationTexts = []

--- a/giraffe/src/utils/rawFluxDataTable.ts
+++ b/giraffe/src/utils/rawFluxDataTable.ts
@@ -2,7 +2,7 @@ import Papa from 'papaparse'
 import HtmlEntities from 'he'
 import unraw from 'unraw'
 
-import {parseChunks} from './fluxParsing'
+import {parseChunks} from './fromFlux'
 import {
   CSV_OBJECT_BASE_NAME,
   CSV_OBJECT_START_STRING,

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.26.1",
+  "version": "2.26.2",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Connects [#4609](https://github.com/influxdata/ui/issues/4609)

### Problem

Previously, we assumed that the flux query can be of this form:

(note that the different tables are separated by `#` and a `new line`.

```#group,false,false,true,true,false,false,true,true,true,true
#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
#default,_result,,,,,,,,,
,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
,,0,2020-07-01T21:45:43.0968Z,2020-07-01T21:50:43.0968Z,2020-07-01T21:45:50Z,+Inf,usage_system,cpu,cpu1,MBP15-TLUONG.local
,,0,2020-07-01T21:45:43.0968Z,2020-07-01T21:50:43.0968Z,2020-07-01T21:46:00Z,Infinity,usage_system,cpu,cpu1,MBP15-TLUONG.local
,,0,2020-07-01T21:45:43.0968Z,2020-07-01T21:50:43.0968Z,2020-07-01T21:46:10Z,-Inf,usage_system,cpu,cpu1,foo1.local

#group,false,false,true,true,false,false,true,true,true,true
#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
#default,_result,,,,,,,,,
,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
,,0,2020-07-01T21:45:43.0968Z,2020-07-01T21:50:43.0968Z,2020-07-01T21:45:50Z,+Inf,usage_system,cpu,cpu1,MBP15-TLUONG.local
,,0,2020-07-01T21:45:43.0968Z,2020-07-01T21:50:43.0968Z,2020-07-01T21:46:00Z,Infinity,usage_system,cpu,cpu1,MBP15-TLUONG.local
,,0,2020-07-01T21:45:43.0968Z,2020-07-01T21:50:43.0968Z,2020-07-01T21:46:10Z,-Inf,usage_system,cpu,cpu1,foo1.local
```

Recently, we realized that the above query handling works fine until we add a `#hashTag` value, with a new line. 

Example: 


```
#group,false,false,true,false
#datatype,string,long,long,string
#default,_result,,,
,result,table,_time_reverse,_value
,,0,-1652887800000000000,"[2022-05-18 15:30:00 UTC] @Benzinga: NASDAQ: $EZFL EzFill, an on-demand fueling service operating in several sectors, released Q1 earnings last week. Check out this interview with Mike McConnell, EzFill CEO, to get the full rundown. Visit https://t.co/L64iQ98BFy to stay updated.

#ad #earnings #ezfill #fuel #energy https://t.co/3GykcCJ8fY"
,,0,-1652887811000000000,"[2022-05-18 15:30:11 UTC] @NYT Business: Sanctions on Russia in response to its invasion of Ukraine have grounded Moscow’s ambitions to be a power in liquefied natural gas. The country’s prospects across a wide spectrum of energy are now deeply uncertain too, analysts say. https://t.co/VrtewI9zw1"
,,0,-1652888700000000000,"[2022-05-18 15:45:00 UTC] @Benzinga: 👇👇👇
https://t.co/o3wHrXw6Cq"
,,0,-1652889073000000000,[2022-05-18 15:51:13 UTC] @Benzinga: @BillyM2k Yes :')
,,0,-1652889550000000000,"[2022-05-18 15:59:10 UTC] @Benzinga: Active chatroom, college-style classroom, homework/quizzes, Trade ideas, and more!

Sign up for your 7-day trial for $7 today!
https://t.co/7dHO4vKQJn"
```

### Solution

We change our assumptions in the regex we use to parse the queries. Instead of assuming that a new table will start if there is a new line followeed by `#`, we now test using regex lookahead to check whether that `#` also has `group OR datatype OR default` keyword. These are the keywords that define the headers for CSV formats in flux queries.


