### PR TITLE
feat: consolidate fastFromFlux parser changes to fromFlux

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",
@@ -46,7 +46,6 @@
     "@testing-library/react": "^11.2.2",
     "@types/d3-array": "^2.0.0",
     "@types/d3-color": "^1.2.2",
-    "@types/d3-dsv": "^1.0.36",
     "@types/d3-format": "^1.3.1",
     "@types/d3-interpolate": "^1.3.1",
     "@types/d3-scale": "^2.1.1",
@@ -65,7 +64,6 @@
     "css-modules-typescript-loader": "^4.0.0",
     "d3-array": "^2.0.3",
     "d3-color": "^1.2.3",
-    "d3-dsv": "^1.1.1",
     "d3-format": "^1.3.2",
     "d3-interpolate": "^1.3.2",
     "d3-scale": "^3.0.0",

--- a/giraffe/src/utils/assert.ts
+++ b/giraffe/src/utils/assert.ts
@@ -1,5 +1,0 @@
-export const assert = (condition: boolean, errorMessage: string) => {
-  if (!condition) {
-    throw new Error(errorMessage)
-  }
-}

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2474,11 +2474,6 @@
   resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-1.4.2.tgz#944f281d04a0f06e134ea96adbb68303515b2784"
   integrity sha512-fYtiVLBYy7VQX+Kx7wU/uOIkGQn8aAEY8oWMoyja3N4dLd8Yf6XgSIR/4yWvMuveNOH5VShnqCgRqqh/UNanBA==
 
-"@types/d3-dsv@^1.0.36":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@types/d3-dsv/-/d3-dsv-1.2.1.tgz#1524fee9f19d689c2f76aa0e24e230762bf96994"
-  integrity sha512-LLmJmjiqp/fTNEdij5bIwUJ6P6TVNk5hKM9/uk5RPO2YNgEu9XvKO0dJ7Iqd3psEdmZN1m7gB1bOsjr4HmO2BA==
-
 "@types/d3-format@^1.3.1":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-1.4.2.tgz#ea17bf559b71d9afd569ae9bfe4c544dab863baa"
@@ -4643,7 +4638,7 @@ command-line-args@^5.1.1:
     lodash.camelcase "^4.3.0"
     typical "^4.0.0"
 
-commander@2, commander@^2.19.0, commander@^2.20.0:
+commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -5070,15 +5065,6 @@ d3-color@1, d3-color@^1.2.3:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
   integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
-
-d3-dsv@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.2.0.tgz#9d5f75c3a5f8abd611f74d3f5847b0d4338b885c"
-  integrity sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==
-  dependencies:
-    commander "2"
-    iconv-lite "0.4"
-    rw "1"
 
 "d3-format@1 - 2":
   version "2.0.0"
@@ -7275,7 +7261,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -11430,11 +11416,6 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
-
-rw@1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
-  integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
 rxjs@^6.6.0:
   version "6.6.7"


### PR DESCRIPTION
This PR updates the `fromFlux` parser to consolidate the parser with the changes made to the `fastFromFlux`. In doing so, this PR addresses a variety of outstanding parser issues that exist within the `fromFlux` parser that have been resolved in the `fastFromFlux` parser. As a result, this PR also removes the `d3-dsv` dependency since it is no longer being used.

The `fastFromFlux` changes were last merged in and tested in production 10 days ago without any reported issues while also addressing all remaining issues with the parser