### PR TITLE
feat: add color blind friendly color scheme

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.30.1",
+  "version": "2.31.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/constants/colorSchemes.ts
+++ b/giraffe/src/constants/colorSchemes.ts
@@ -211,6 +211,16 @@ export const RAINBOW_SIXTEEN = [
   '#4dc98e',
   '#007c41',
 ]
+export const COLOR_BLIND_FRIENDLY = [
+  '#000000',
+  '#E69F00',
+  '#56B4E9',
+  '#009E73',
+  '#F0E442',
+  '#0072B2',
+  '#D55E00',
+  '#CC79A7',
+]
 
 // Solid Colors
 export const SOLID_RED = ['#DC4E58', '#DC4E58', '#DC4E58']

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.30.1",
+  "version": "2.31.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/stories/src/helpers.tsx
+++ b/stories/src/helpers.tsx
@@ -54,6 +54,7 @@ export const colorSchemeKnob = (initial?: string[]) =>
     'Color Scheme',
     {
       'Nineteen Eighty Four': giraffe.NINETEEN_EIGHTY_FOUR,
+      'Color Blind Friendly': giraffe.COLOR_BLIND_FRIENDLY,
       Atlantis: giraffe.ATLANTIS,
       'Do Androids Dream': giraffe.DO_ANDROIDS_DREAM,
       Delorean: giraffe.DELOREAN,


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/4549

Adds a color blind friendly color scheme

<img width="1728" alt="Screen Shot 2022-07-14 at 2 40 44 PM" src="https://user-images.githubusercontent.com/10736577/179098046-becbdd50-3bf0-42e7-b512-bb90c8e3272b.png">
