### PR TITLE
fix: add a second color blind friendly pallet to avoid clashing with background color

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.31.0",
+  "version": "2.31.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/constants/colorSchemes.ts
+++ b/giraffe/src/constants/colorSchemes.ts
@@ -211,8 +211,19 @@ export const RAINBOW_SIXTEEN = [
   '#4dc98e',
   '#007c41',
 ]
-export const COLOR_BLIND_FRIENDLY = [
+export const COLOR_BLIND_FRIENDLY_DARK = [
   '#000000',
+  '#E69F00',
+  '#56B4E9',
+  '#009E73',
+  '#F0E442',
+  '#0072B2',
+  '#D55E00',
+  '#CC79A7',
+]
+
+export const COLOR_BLIND_FRIENDLY_LIGHT = [
+  '#FFFFFF',
   '#E69F00',
   '#56B4E9',
   '#009E73',

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.31.0",
+  "version": "2.31.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/stories/src/helpers.tsx
+++ b/stories/src/helpers.tsx
@@ -54,7 +54,8 @@ export const colorSchemeKnob = (initial?: string[]) =>
     'Color Scheme',
     {
       'Nineteen Eighty Four': giraffe.NINETEEN_EIGHTY_FOUR,
-      'Color Blind Friendly': giraffe.COLOR_BLIND_FRIENDLY,
+      'Color Blind Friendly Light': giraffe.COLOR_BLIND_FRIENDLY_LIGHT,
+      'Color Blind Friendly Dark': giraffe.COLOR_BLIND_FRIENDLY_DARK,
       Atlantis: giraffe.ATLANTIS,
       'Do Androids Dream': giraffe.DO_ANDROIDS_DREAM,
       Delorean: giraffe.DELOREAN,


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/5069

To avoid clashing with the background color, the color blind friendly pallet should be two pallets to allow the user to adjust to the background.

Light pallet:
<img width="1728" alt="Screen Shot 2022-07-15 at 10 17 48 AM" src="https://user-images.githubusercontent.com/10736577/179275669-f83fbe7a-bb6e-44db-ac62-1d82a0912c5d.png">


Dark pallet:
<img width="1728" alt="Screen Shot 2022-07-15 at 10 18 34 AM" src="https://user-images.githubusercontent.com/10736577/179275703-661b53fe-b013-4981-85c3-9501309f6e3b.png">
