### PR TITLE
feat(Formatters): shorten numbers greater than septillion

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.31.1",
+  "version": "2.32.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/utils/formatters.test.ts
+++ b/giraffe/src/utils/formatters.test.ts
@@ -217,12 +217,12 @@ describe('siPrefixFormatter', () => {
 
   it('can shorten a positive number larger than septillion', () => {
     const f = siPrefixFormatter()
-    expect(f(1.7e308)).toEqual('1.7e+284Y') 
+    expect(f(1.7e308)).toEqual('1.7e+284Y')
   })
 
   it('can shorten a negative number smaller than septillion', () => {
     const f = siPrefixFormatter()
-    expect(f(-1.7e308)).toEqual('-1.7e+284Y') 
+    expect(f(-1.7e308)).toEqual('-1.7e+284Y')
   })
 })
 

--- a/giraffe/src/utils/formatters.test.ts
+++ b/giraffe/src/utils/formatters.test.ts
@@ -214,6 +214,16 @@ describe('siPrefixFormatter', () => {
     expect(f(37)).toEqual('37.00')
     expect(f(37.1234)).toEqual('37.12')
   })
+
+  it('can shorten a positive number larger than septillion', () => {
+    const f = siPrefixFormatter()
+    expect(f(1.7e308)).toEqual('1.7e+284Y') 
+  })
+
+  it('can shorten a negative number smaller than septillion', () => {
+    const f = siPrefixFormatter()
+    expect(f(-1.7e308)).toEqual('-1.7e+284Y') 
+  })
 })
 
 describe('binaryPrefixFormatter', () => {

--- a/giraffe/src/utils/formatters.ts
+++ b/giraffe/src/utils/formatters.ts
@@ -326,11 +326,11 @@ export const siPrefixFormatter = ({
   } else {
     formatter = (x: number): string => {
       // below code shortens extremely large or small numbers (greater than septillion+) by 
-      // first converting number to SI format, then removes the SI prefix to convert
+      // first converting number to SI format, then removing the SI unit to convert
       // number to scientific notation, and finally 
-      // adds yotta (Y) prefix at the end of number
+      // adding yotta (Y) back
       if (x >= 1e30 || x <= -1e30) {
-        const siFormattedValue = String(formatSIPrefix(Math.abs(x))).slice(0,-1) // removes SI unit yotta
+        const siFormattedValue = String(formatSIPrefix(Math.abs(x))).slice(0,-1)
         return `${prefix}${x < 0 ? '-' : ''}${d3Format(`.${significantDigits}`)(Number(siFormattedValue))}Y${suffix}`
       } else {
         return `${prefix}${formatSIPrefix(x)}${suffix}`

--- a/giraffe/src/utils/formatters.ts
+++ b/giraffe/src/utils/formatters.ts
@@ -325,18 +325,22 @@ export const siPrefixFormatter = ({
     formatter = (x: number): string => `${prefix}${x}${suffix}`
   } else {
     formatter = (x: number): string => {
-      // below code shortens extremely large or small numbers (greater than septillion+) by 
+      // below code shortens extremely large or small numbers (greater than septillion+) by
       // first converting number to SI format, then removing the SI unit to convert
-      // number to scientific notation, and finally 
+      // number to scientific notation, and finally
       // adding yotta (Y) back
       if (x >= 1e30 || x <= -1e30) {
-        const siFormattedValue = String(formatSIPrefix(Math.abs(x))).slice(0,-1)
-        return `${prefix}${x < 0 ? '-' : ''}${d3Format(`.${significantDigits}`)(Number(siFormattedValue))}Y${suffix}`
+        const siFormattedValue = String(formatSIPrefix(Math.abs(x))).slice(
+          0,
+          -1
+        )
+        return `${prefix}${x < 0 ? '-' : ''}${d3Format(`.${significantDigits}`)(
+          Number(siFormattedValue)
+        )}Y${suffix}`
       } else {
         return `${prefix}${formatSIPrefix(x)}${suffix}`
       }
-
-    } 
+    }
   }
 
   formatter._GIRAFFE_FORMATTER_TYPE = FormatterType.SIPrefix as FormatterType.SIPrefix

--- a/giraffe/src/utils/formatters.ts
+++ b/giraffe/src/utils/formatters.ts
@@ -325,7 +325,7 @@ export const siPrefixFormatter = ({
     formatter = (x: number): string => `${prefix}${x}${suffix}`
   } else {
     formatter = (x: number): string => {
-      // below code shortens extremely large or small numbers (greater than septillion+) by
+      // code below shortens extremely large or small numbers (greater than septillion+) by
       // first converting number to SI format, then removing the SI unit to convert
       // number to scientific notation, and finally
       // adding yotta (Y) back

--- a/giraffe/src/utils/formatters.ts
+++ b/giraffe/src/utils/formatters.ts
@@ -337,9 +337,8 @@ export const siPrefixFormatter = ({
         return `${prefix}${x < 0 ? '-' : ''}${d3Format(`.${significantDigits}`)(
           Number(siFormattedValue)
         )}Y${suffix}`
-      } else {
-        return `${prefix}${formatSIPrefix(x)}${suffix}`
       }
+      return `${prefix}${formatSIPrefix(x)}${suffix}`
     }
   }
 

--- a/giraffe/src/utils/formatters.ts
+++ b/giraffe/src/utils/formatters.ts
@@ -324,7 +324,19 @@ export const siPrefixFormatter = ({
   if (format !== true) {
     formatter = (x: number): string => `${prefix}${x}${suffix}`
   } else {
-    formatter = (x: number): string => `${prefix}${formatSIPrefix(x)}${suffix}`
+    formatter = (x: number): string => {
+      // below code shortens extremely large or small numbers (greater than septillion+) by 
+      // first converting number to SI format, then removes the SI prefix to convert
+      // number to scientific notation, and finally 
+      // adds yotta (Y) prefix at the end of number
+      if (x >= 1e30 || x <= -1e30) {
+        const siFormattedValue = String(formatSIPrefix(Math.abs(x))).slice(0,-1) // removes SI unit yotta
+        return `${prefix}${x < 0 ? '-' : ''}${d3Format(`.${significantDigits}`)(Number(siFormattedValue))}Y${suffix}`
+      } else {
+        return `${prefix}${formatSIPrefix(x)}${suffix}`
+      }
+
+    } 
   }
 
   formatter._GIRAFFE_FORMATTER_TYPE = FormatterType.SIPrefix as FormatterType.SIPrefix

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.31.1",
+  "version": "2.32.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes [#4429](https://github.com/influxdata/ui/issues/4429)

PR addresses bug ticket by condescending extremely large numbers (>10^30) by converting its SI value to scientific notation. 
Before fix: 
when data point = 1.7e308 is graphed with its Y-value unit prefix set to `SI`, we see 1 followed by ~50 zeros in the y axis. 

After fix: 
same data point graphs with 1.7e284Y value on the Y axis. 