### PR TITLE
fix: accept partial schemas in fromRows

### DIFF
--- a/giraffe/src/utils/fromRows.ts
+++ b/giraffe/src/utils/fromRows.ts
@@ -24,6 +24,9 @@ export const fromRows = <T extends object>(
 
       if (schema) {
         columnType = schema[key]
+        if (!columnType) {
+          columnType = inferColumnType(row[key])
+        }
         value = parseValue(row[key], columnType)
       } else {
         columnType = inferColumnType(row[key])


### PR DESCRIPTION
While dealing with timestamps in milliseconds, inferColumnType() detects timestamp column type as a number. My first approach to fix that was to set a partial schema to only fix the column that was wrongly detected. But I found out that wasn't possible. This fixes that use case.