### PR TITLE
chore: update version for publishing fromRows partial schema

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.32.0",
+  "version": "2.32.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.32.0",
+  "version": "2.32.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updates the version to publish the third party contribution in https://github.com/influxdata/giraffe/pull/779