### PR TITLE
fix: update caret down in Table styling to correct value

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.33.2",
+  "version": "2.33.3",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/components/TableGraphs.scss
+++ b/giraffe/src/components/TableGraphs.scss
@@ -202,7 +202,7 @@ $table-light-graph--text-highlight: #383846;
     padding-right: 17px;
 
     &:before {
-      content: '\e902';
+      content: '\e912';
       font-family: 'icomoon';
       font-size: 13px;
       font-size: 17px;

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.33.2",
+  "version": "2.33.3",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/5276  

The new icon set from Clockface added new icons and changed the ordering of the icon hex values. The correct value for "caret down" should be used in Table styling.

FIXED, ascending:
<img width="1728" alt="Screen Shot 2022-08-03 at 10 10 35 AM" src="https://user-images.githubusercontent.com/10736577/182668845-904dfe62-853c-4183-894f-e821aef65c2c.png">


FIXED, descending:
<img width="1728" alt="Screen Shot 2022-08-03 at 10 11 19 AM" src="https://user-images.githubusercontent.com/10736577/182668941-78fa2b36-6a33-4015-acd0-cad53800a91b.png">

