### PR TITLE
fix: allow Safari users to select text

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.33.3",
+  "version": "2.33.4",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/components/SimpleTable/SimpleTableGraph.scss
+++ b/giraffe/src/components/SimpleTable/SimpleTableGraph.scss
@@ -7,6 +7,7 @@
   display: flex;
   flex-direction: column;
   font-family: $cf-code-font;
+  -webkit-user-select: text;
   user-select: text;
 
   .cf-dapper-scrollbars {

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.33.3",
+  "version": "2.33.4",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/3650

Missed one. Add this fix to SimpleTable.