### PR TITLE
fix: cap the estimated screen height

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.33.4",
+  "version": "2.33.5",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/components/SimpleTable/PagedTable.tsx
+++ b/giraffe/src/components/SimpleTable/PagedTable.tsx
@@ -277,7 +277,9 @@ const PagedTable: FC<Props> = ({result, properties}) => {
 
       timeout = setTimeout(() => {
         animationFrameID = requestAnimationFrame(() => {
-          setHeight(entries[0].contentRect.height)
+          setHeight(
+            Math.min(entries[0].contentRect.height, window.screen.height)
+          )
         })
       }, 200)
     })
@@ -289,7 +291,7 @@ const PagedTable: FC<Props> = ({result, properties}) => {
     const rect = curr?.getBoundingClientRect()
 
     if (rect && rect.height !== height) {
-      setHeight(rect.height)
+      setHeight(Math.min(rect.height, window.screen.height))
     }
 
     return () => {

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.33.4",
+  "version": "2.33.5",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Part of https://github.com/influxdata/ui/issues/5317  

Matches the changes found here: https://github.com/influxdata/ui/pull/5318