### PR TITLE
fix(TabelCell): update first row to be button

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.33.5",
+  "version": "2.33.6",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/components/TableCell.tsx
+++ b/giraffe/src/components/TableCell.tsx
@@ -324,7 +324,7 @@ export const TableCell: FunctionComponent<Props> = (props: Props) => {
 
   if (rowIndex === 0) {
     return (
-      <div
+      <button
         style={getStyle(props)}
         className={getClassName(props)}
         onClick={handleClick}
@@ -335,7 +335,7 @@ export const TableCell: FunctionComponent<Props> = (props: Props) => {
         title={getContents(props)}
       >
         {getContents(props)}
-      </div>
+      </button>
     )
   }
   return (

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.33.5",
+  "version": "2.33.6",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #789 

Pr updates first row of table cell to be of button element instead of div. This prevents unintentional highlighting of 
header rows when clicked. 

Before:  

https://user-images.githubusercontent.com/66275100/185636775-54aca6a6-bb14-4771-9042-29e2d1613bbe.mp4


After:  

https://user-images.githubusercontent.com/66275100/185636661-741f680f-e5e2-4d19-a72c-e9a24941e130.mov




