### PR TITLE
fix: update Band to avoid using the Douglas Peucker algorithm

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.34.0",
+  "version": "2.34.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/components/Band/BandLayer.tsx
+++ b/giraffe/src/components/Band/BandLayer.tsx
@@ -2,7 +2,7 @@ import React, {FunctionComponent, RefObject, useMemo} from 'react'
 
 import {LayerProps, BandLayerSpec, BandLayerConfig} from '../../types'
 import {BandHoverLayer} from './BandHoverLayer'
-import {simplifyLineData} from '../../utils/lineData'
+import {simplifyBandData} from '../../utils/lineData'
 import {useCanvas} from '../../utils/useCanvas'
 import {drawBands} from '../../utils/drawBands'
 import {useHoverPointIndices} from '../../utils/useHoverPointIndices'
@@ -45,7 +45,7 @@ export const BandLayer: FunctionComponent<Props> = props => {
 
   const simplifiedLineData = useMemo(
     () =>
-      simplifyLineData(
+      simplifyBandData(
         alignMinMaxWithBand(spec.lineData, spec.bandLineMap),
         xScale,
         yScale

--- a/giraffe/src/utils/lineData.test.ts
+++ b/giraffe/src/utils/lineData.test.ts
@@ -1,13 +1,17 @@
 import {DomainLabel} from '../types'
-import {getDomainDataFromLines, simplifyBandData} from './lineData'
+import {
+  getDomainDataFromLines,
+  simplifyBandData,
+  simplifyLineData,
+} from './lineData'
 import {getLinearScale} from './getLinearScale'
 
 describe('lineData', () => {
   describe('get domain data from line data', () => {
     const lineData = {
       0: {
-        xs: [],
-        ys: [],
+        xs: [] as any,
+        ys: [] as any,
         fill: 'some color',
       },
     }
@@ -48,11 +52,11 @@ describe('lineData', () => {
   })
 
   describe('simplifyBandData', () => {
-    const xScale = getLinearScale(0, 100, 0, 1200)
-
     const NOW = new Date().getTime()
     const TWENTY_FOUR_HOURS_FROM_NOW = NOW + 1000 * 60 * 60 * 24
-    const yScale = getLinearScale(NOW, TWENTY_FOUR_HOURS_FROM_NOW, 800, 0)
+    const xScale = getLinearScale(NOW, TWENTY_FOUR_HOURS_FROM_NOW, 0, 1200)
+
+    const yScale = getLinearScale(0, 100, 800, 0)
 
     it('returns the same number of points that it receives for each line', () => {
       const lineData = {
@@ -64,8 +68,11 @@ describe('lineData', () => {
             NOW + 1000 * 60 * 60 * 3,
             NOW + 1000 * 60 * 60 * 4,
             NOW + 1000 * 60 * 60 * 5,
+            NOW + 1000 * 60 * 60 * 6,
+            NOW + 1000 * 60 * 60 * 7,
+            NOW + 1000 * 60 * 60 * 8,
           ],
-          ys: [77, 60, 33, 63, 71],
+          ys: [77, 77, 77, 90, 90, 77, 77, 77],
         },
         1: {
           fill: '#31C0F6',
@@ -75,8 +82,11 @@ describe('lineData', () => {
             NOW + 1000 * 60 * 60 * 3,
             NOW + 1000 * 60 * 60 * 4,
             NOW + 1000 * 60 * 60 * 5,
+            NOW + 1000 * 60 * 60 * 6,
+            NOW + 1000 * 60 * 60 * 7,
+            NOW + 1000 * 60 * 60 * 8,
           ],
-          ys: [25, 40, 32, 22, 58],
+          ys: [25, 40, 32, 22, 58, 33, 52, 66],
         },
         2: {
           fill: '#31C0F6',
@@ -86,10 +96,23 @@ describe('lineData', () => {
             NOW + 1000 * 60 * 60 * 3,
             NOW + 1000 * 60 * 60 * 4,
             NOW + 1000 * 60 * 60 * 5,
+            NOW + 1000 * 60 * 60 * 6,
+            NOW + 1000 * 60 * 60 * 7,
+            NOW + 1000 * 60 * 60 * 8,
           ],
-          ys: [22, 31, 9, 13, 44],
+          ys: [1, 1, 1, 2, 1, 1, 1, 1],
         },
       }
+
+      const truncatedResult = simplifyLineData(lineData, xScale, yScale)
+      expect(truncatedResult[0].xs.length).not.toEqual(lineData[0].xs.length)
+      expect(truncatedResult[2].xs.length).not.toEqual(lineData[2].xs.length)
+      expect(truncatedResult[0].xs.length).not.toEqual(
+        truncatedResult[1].xs.length
+      )
+      expect(truncatedResult[1].xs.length).not.toEqual(
+        truncatedResult[2].xs.length
+      )
 
       const result = simplifyBandData(lineData, xScale, yScale)
       expect(result[0].xs.length).toEqual(lineData[0].xs.length)

--- a/giraffe/src/utils/lineData.test.ts
+++ b/giraffe/src/utils/lineData.test.ts
@@ -1,5 +1,6 @@
 import {DomainLabel} from '../types'
-import {getDomainDataFromLines} from './lineData'
+import {getDomainDataFromLines, simplifyBandData} from './lineData'
+import {getLinearScale} from './getLinearScale'
 
 describe('lineData', () => {
   describe('get domain data from line data', () => {
@@ -43,6 +44,62 @@ describe('lineData', () => {
           DomainLabel.Y
         )
       ).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+    })
+  })
+
+  describe('simplifyBandData', () => {
+    const xScale = getLinearScale(0, 100, 0, 1200)
+
+    const NOW = new Date().getTime()
+    const TWENTY_FOUR_HOURS_FROM_NOW = NOW + 1000 * 60 * 60 * 24
+    const yScale = getLinearScale(NOW, TWENTY_FOUR_HOURS_FROM_NOW, 800, 0)
+
+    it('returns the same number of points that it receives for each line', () => {
+      const lineData = {
+        0: {
+          fill: '#31C0F6',
+          xs: [
+            NOW + 1000 * 60 * 60 * 1,
+            NOW + 1000 * 60 * 60 * 2,
+            NOW + 1000 * 60 * 60 * 3,
+            NOW + 1000 * 60 * 60 * 4,
+            NOW + 1000 * 60 * 60 * 5,
+          ],
+          ys: [77, 60, 33, 63, 71],
+        },
+        1: {
+          fill: '#31C0F6',
+          xs: [
+            NOW + 1000 * 60 * 60 * 1,
+            NOW + 1000 * 60 * 60 * 2,
+            NOW + 1000 * 60 * 60 * 3,
+            NOW + 1000 * 60 * 60 * 4,
+            NOW + 1000 * 60 * 60 * 5,
+          ],
+          ys: [25, 40, 32, 22, 58],
+        },
+        2: {
+          fill: '#31C0F6',
+          xs: [
+            NOW + 1000 * 60 * 60 * 1,
+            NOW + 1000 * 60 * 60 * 2,
+            NOW + 1000 * 60 * 60 * 3,
+            NOW + 1000 * 60 * 60 * 4,
+            NOW + 1000 * 60 * 60 * 5,
+          ],
+          ys: [22, 31, 9, 13, 44],
+        },
+      }
+
+      const result = simplifyBandData(lineData, xScale, yScale)
+      expect(result[0].xs.length).toEqual(lineData[0].xs.length)
+      expect(result[0].ys.length).toEqual(lineData[0].ys.length)
+
+      expect(result[1].xs.length).toEqual(lineData[1].xs.length)
+      expect(result[1].ys.length).toEqual(lineData[1].ys.length)
+
+      expect(result[2].xs.length).toEqual(lineData[2].xs.length)
+      expect(result[2].ys.length).toEqual(lineData[2].ys.length)
     })
   })
 })

--- a/giraffe/src/utils/lineData.ts
+++ b/giraffe/src/utils/lineData.ts
@@ -52,6 +52,23 @@ export const simplifyLineData = (
   return result
 }
 
+export const simplifyBandData = (
+  lineData: LineData,
+  xScale,
+  yScale
+): LineData => {
+  const result = {}
+
+  for (const [k, {xs, ys, fill}] of Object.entries(lineData)) {
+    const simplifedXs = xs.map(x => xScale(x || 0))
+    const simplifiedYs = ys.map(y => yScale(y || 0))
+
+    result[k] = {xs: simplifedXs, ys: simplifiedYs, fill}
+  }
+
+  return result
+}
+
 export const getDomainDataFromLines = (
   lineData: LineData,
   fillCol: Array<number | string>,

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.34.0",
+  "version": "2.34.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #799 

In Band, avoid the Douglas Peucker algorithm, which sometimes returns fewer points of line data than it receives. Band must always have the same number of points for all lines.

BEFORE:
<img width="1728" alt="Screen Shot 2022-08-31 at 3 14 32 PM" src="https://user-images.githubusercontent.com/10736577/187803386-455e04e3-a1ee-4775-9cbf-6f781170a3f7.png">


AFTER:
<img width="1728" alt="Screen Shot 2022-08-31 at 4 37 42 PM" src="https://user-images.githubusercontent.com/10736577/187803400-5a315268-0677-44a1-804c-3bc439bf0be2.png">
