### PR TITLE
fix: speeds up height calculations for Simple Table

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.34.1",
+  "version": "2.34.2",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/components/SimpleTable/PagedTable.tsx
+++ b/giraffe/src/components/SimpleTable/PagedTable.tsx
@@ -222,6 +222,9 @@ interface Props {
   result: FluxResult['parsed']
 }
 
+const INITIAL_HEADER_HEIGHT = 0
+const INITIAL_HEIGHT = 0
+const INITIAL_ROW_HEIGHT = 10 // must be greater than 0
 const PagedTable: FC<Props> = ({result, properties}) => {
   const {
     offset,
@@ -231,16 +234,21 @@ const PagedTable: FC<Props> = ({result, properties}) => {
     setPage,
     setTotalPages,
   } = useContext(PaginationContext)
-  const [height, setHeight] = useState<number>(0)
-  const [headerHeight, setHeaderHeight] = useState<number>(0)
-  const [rowHeight, setRowHeight] = useState<number>(0)
+  const [height, setHeight] = useState<number>(INITIAL_HEIGHT)
+  const [headerHeight, setHeaderHeight] = useState<number>(
+    INITIAL_HEADER_HEIGHT
+  )
+  const [rowHeight, setRowHeight] = useState<number>(INITIAL_ROW_HEIGHT)
   const ref = useRef<HTMLDivElement>()
   const pagedTableHeaderRef = useRef<HTMLTableSectionElement>()
   const pagedTableBodyRef = useRef<HTMLTableSectionElement>()
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    if (headerHeight === 0 && pagedTableHeaderRef?.current) {
+    if (
+      headerHeight === INITIAL_HEADER_HEIGHT &&
+      pagedTableHeaderRef?.current
+    ) {
       const calculatedHeaderHeight =
         pagedTableHeaderRef.current.clientHeight ?? 0
 
@@ -252,7 +260,7 @@ const PagedTable: FC<Props> = ({result, properties}) => {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    if (rowHeight === 0 && pagedTableBodyRef?.current) {
+    if (rowHeight === INITIAL_ROW_HEIGHT && pagedTableBodyRef?.current) {
       const calculatedRowHeight =
         pagedTableBodyRef.current.children?.[0]?.clientHeight ?? 0
 

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.34.1",
+  "version": "2.34.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/stories/src/simpleTable.stories.tsx
+++ b/stories/src/simpleTable.stories.tsx
@@ -4,6 +4,7 @@ import {boolean, text, withKnobs} from '@storybook/addon-knobs'
 import {PlotContainer} from './helpers'
 import {Config, Plot, fromFlux} from '../../giraffe/src'
 import {tableCSV, nonNumbersInNumbersColumn} from './data/tableGraph'
+import {largeDataSet} from './data/largeDataSet'
 
 storiesOf('Simple Table', module)
   .addDecorator(withKnobs)
@@ -37,6 +38,29 @@ storiesOf('Simple Table', module)
 
     const config: Config = {
       fluxResponse: nonNumbersInNumbersColumn,
+      layers: [
+        {
+          type: 'simple table',
+          showAll: showAll,
+        },
+      ],
+    }
+
+    return (
+      // Simple Table needs a black background by default,
+      //   override Storybook's dark grey
+      <PlotContainer style={{backgroundColor}}>
+        <Plot config={config} />
+      </PlotContainer>
+    )
+  })
+  .add('Very large data set', () => {
+    const backgroundColor = text('Background contrast color:', 'black')
+
+    const showAll = boolean('showAll', false)
+
+    const config: Config = {
+      fluxResponse: largeDataSet,
       layers: [
         {
           type: 'simple table',


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/5692

By changing the initial row height from 0 to a positive number, we dramatically speed up the height estimation used by Simple Table during rendering of large data sets. The actual row height will auto-correct after the initial guess.


https://user-images.githubusercontent.com/10736577/189460829-093e593e-0ca1-4b7f-94bd-c05a0233c419.mp4

