### PR TITLE
fix: change font loader from file-loader to url-loader

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.34.4",
+  "version": "2.34.5",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",
@@ -102,6 +102,7 @@
     "ts-jest": "^27.1.3",
     "typescript": "3.8.3",
     "unraw": "2.0.0",
+    "url-loader": "^4.1.1",
     "uuid": "^3.2.1",
     "version-bump-prompt": "^5.0.0",
     "webpack": "^5.2.0",

--- a/giraffe/webpack.common.config.js
+++ b/giraffe/webpack.common.config.js
@@ -59,7 +59,7 @@ module.exports = {
         use: [{loader: 'style-loader'}, 'css-loader'],
       },
       {
-        test: /\.(png|svg|jpg|gif|eot|ttf|woff|woff2|otf)$/,
+        test: /\.(png|svg|jpg|gif)$/,
         use: [
           {
             loader: 'file-loader',
@@ -69,6 +69,17 @@ module.exports = {
           },
         ],
       },
+      {
+        test: /\.(eot|ttf|woff|woff2|otf)$/,
+        use: [
+          {
+            loader: 'url-loader',
+            options: {
+              limit: Infinity
+            },
+          },
+        ],
+      }
     ],
   },
 }

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.34.4",
+  "version": "2.34.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7321,10 +7321,10 @@ ignore@^5.1.1, ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
   integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
 
-immer@8.0.1, immer@^9.0.6:
-  version "9.0.15"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.15.tgz#0b9169e5b1d22137aba7d43f8a81a495dd1b62dc"
-  integrity sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==
+immer@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
+  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
 import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -8507,7 +8507,7 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsprim@^1.2.2, jsprim@^1.4.2:
+jsprim@^1.2.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
   integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
@@ -11739,10 +11739,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.7.2, shell-quote@1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
-  integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
+shell-quote@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
+  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
 shelljs@^0.8.1:
   version "0.8.5"


### PR DESCRIPTION
Helps with: https://github.com/influxdata/ui/issues/1673
Helps with:  https://github.com/influxdata/ui/issues/2629

In cloud environments, there are font loading errors that are thrown in the console on every page. These don't show up in development environments, and so this has been a historically difficult issue to reproduce.

I was finally able to do it by creating a minimal application that used Clockface and Giraffe. I was able to fix it by changing the webpack configuration of Giraffe to use `url-loader` instead of `font-loader` when loading webfonts. [This issue in webpack's repo](https://github.com/webpack/webpack/issues/7353) was extremely helpful.

### Before
![before](https://user-images.githubusercontent.com/146112/191359956-c6957178-b9d3-4b2c-aed6-3ed25c0d691d.png)

### After
![after](https://user-images.githubusercontent.com/146112/191359966-f85f864e-0f90-4aae-9d4e-da1acc59dc6a.png)

Testing in the UI. If you clicked on one of the loaded fonts in the browser network tab, there would be an error when loading it. After, no such error.

### Before
https://user-images.githubusercontent.com/146112/191370921-96601592-e288-49b3-8ef3-bb4683bb0875.mov

### After
https://user-images.githubusercontent.com/146112/191370909-7d8b95ae-3edb-4a4f-8b51-85501e52517b.mov

