### PR TITLE
fix: limit row generation at the outset of the table

### DIFF
--- a/giraffe/src/components/SimpleTable/PagedTable.tsx
+++ b/giraffe/src/components/SimpleTable/PagedTable.tsx
@@ -44,6 +44,12 @@ const getNumberOfRowsOnCurrentPage = (
     return 0
   }
 
+  // this means that no rows have been mounted or measured, so we need to
+  // mount one row to measure the row height
+  if (rowHeight === 0) {
+    return 1
+  }
+
   const minimumLength = result?.table?.length ?? 1
   const estimatedRowHeight = Math.min(
     Math.ceil(totalAvailableHeight / minimumLength),


### PR DESCRIPTION
This PR adds a condition to initially render one row for a table that has no rows yet available. As is, the UI currently renders rows until the DOM becomes responsive to those changes and sets the data accordingly. In some cases, that means that we're rendering 600+ rows, then rerendering the table with the initial 13 rows. Since the initial row number is 0, we want to set the returned row number to 1 so that only 1 is rendered at the outset, and we can then calculate the row height properly based on that and return the correct number of rows to render.