### PR TITLE
fix: split out visualizations that do not use PlotEnv

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.35.0",
+  "version": "2.36.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/components/Plot.tsx
+++ b/giraffe/src/components/Plot.tsx
@@ -1,9 +1,16 @@
+// Libraries
 import React, {FunctionComponent, RefObject, useRef} from 'react'
 import AutoSizer from 'react-virtualized-auto-sizer'
 
+// Components
+import {PlotResizer, TableResizer} from './PlotResizer'
+
+// Types
 import {Config, SizedConfig} from '../types'
 
-import {PlotResizer} from './PlotResizer'
+// Utils
+import {hasPlotEnv} from '../utils/hasPlotEnv'
+
 interface PlotProps {
   config: Config
   axesCanvasRef?: RefObject<HTMLCanvasElement>
@@ -25,7 +32,7 @@ export const Plot: FunctionComponent<PlotProps> = props => {
   }
 
   if (config.width && config.height) {
-    return (
+    return hasPlotEnv(config) ? (
       <div className="giraffe-fixedsizer" style={{position: 'relative'}}>
         <PlotResizer
           axesCanvasRef={axesCanvasRef}
@@ -37,10 +44,18 @@ export const Plot: FunctionComponent<PlotProps> = props => {
           {children}
         </PlotResizer>
       </div>
+    ) : (
+      <TableResizer
+        config={config as SizedConfig}
+        height={config.height}
+        width={config.width}
+      >
+        {children}
+      </TableResizer>
     )
   }
 
-  return (
+  return hasPlotEnv(config) ? (
     <AutoSizer className="giraffe-autosizer">
       {({width, height}) => (
         <PlotResizer
@@ -52,6 +67,18 @@ export const Plot: FunctionComponent<PlotProps> = props => {
         >
           {children}
         </PlotResizer>
+      )}
+    </AutoSizer>
+  ) : (
+    <AutoSizer className="giraffe-autosizer">
+      {({width, height}) => (
+        <TableResizer
+          config={config as SizedConfig}
+          height={height}
+          width={width}
+        >
+          {children}
+        </TableResizer>
       )}
     </AutoSizer>
   )

--- a/giraffe/src/components/PlotResizer.tsx
+++ b/giraffe/src/components/PlotResizer.tsx
@@ -1,8 +1,7 @@
 import React, {FC, RefObject, useMemo} from 'react'
 
-import {LayerTypes, PlotDimensions, SizedConfig} from '../types'
+import {PlotDimensions, SizedConfig} from '../types'
 
-import {get} from '../utils/get'
 import {resizePlotWithStaticLegend} from '../utils/legend/resizePlot'
 import {normalizeConfig} from '../utils/normalizeConfig'
 import {usePlotEnv} from '../utils/usePlotEnv'
@@ -40,19 +39,9 @@ export const PlotResizer: FC<PlotResizerProps> = props => {
 
   const env = usePlotEnv(normalizedConfig)
   const spec = env.getSpec(0)
-  const graphType = get(config, 'layers.0.type')
 
   if (width === 0 || height === 0) {
     return null
-  }
-
-  if (
-    graphType === LayerTypes.Table ||
-    graphType === LayerTypes.RawFluxDataTable ||
-    graphType === LayerTypes.Gauge ||
-    graphType === LayerTypes.SimpleTable
-  ) {
-    return <SizedTable config={normalizedConfig}>{children}</SizedTable>
   }
 
   return (
@@ -77,4 +66,29 @@ export const PlotResizer: FC<PlotResizerProps> = props => {
       ) : null}
     </>
   )
+}
+
+interface TableResizerProps {
+  config: SizedConfig
+  height: number
+  width: number
+}
+
+export const TableResizer: FC<TableResizerProps> = props => {
+  const {children, config, height, width} = props
+
+  const normalizedConfig: SizedConfig = useMemo(
+    () => ({
+      ...normalizeConfig(config),
+      height,
+      width,
+    }),
+    [config, height, width]
+  )
+
+  if (width === 0 || height === 0) {
+    return null
+  }
+
+  return <SizedTable config={normalizedConfig}>{children}</SizedTable>
 }

--- a/giraffe/src/components/SizedTable.tsx
+++ b/giraffe/src/components/SizedTable.tsx
@@ -16,19 +16,11 @@ import {FluxTablesTransform} from './FluxTablesTransform'
 import {TableGraphLayer} from './Table'
 import {SimpleTableLayer} from './SimpleTable'
 
-import {usePlotEnv} from '../utils/usePlotEnv'
-
 interface Props {
   config: SizedConfig
 }
 
-export const SizedTable: FunctionComponent<Props> = ({
-  config: userConfig,
-  children,
-}) => {
-  const env = usePlotEnv(userConfig)
-
-  const {config} = env
+export const SizedTable: FunctionComponent<Props> = ({config, children}) => {
   const {width, height} = config
 
   config.showAxes = false
@@ -53,7 +45,7 @@ export const SizedTable: FunctionComponent<Props> = ({
       <div
         className="giraffe-inner-plot"
         style={{
-          cursor: `${userConfig.cursor || 'auto'}`,
+          cursor: `${config.cursor || 'auto'}`,
         }}
       >
         <div className="giraffe-layers" style={fullsizeStyle}>
@@ -112,22 +104,6 @@ export const SizedTable: FunctionComponent<Props> = ({
                     )}
                   </FluxTablesTransform>
                 )
-
-              case LayerTypes.Custom:
-                const renderProps = {
-                  key: layerIndex,
-                  width,
-                  height,
-                  innerWidth: env.innerWidth,
-                  innerHeight: env.innerHeight,
-                  xScale: env.xScale,
-                  yScale: env.yScale,
-                  xDomain: env.xDomain,
-                  yDomain: env.yDomain,
-                  columnFormatter: env.getFormatterForColumn,
-                  yColumnType: env.yColumnType,
-                }
-                return layerConfig.render(renderProps)
 
               default:
                 return null

--- a/giraffe/src/utils/hasPlotEnv.ts
+++ b/giraffe/src/utils/hasPlotEnv.ts
@@ -1,0 +1,15 @@
+import {Config, LayerTypes} from '../types'
+import {get} from './get'
+
+export const hasPlotEnv = (config: Config): boolean => {
+  const graphType = get(config, 'layers.0.type')
+  if (
+    graphType === LayerTypes.Table ||
+    graphType === LayerTypes.RawFluxDataTable ||
+    graphType === LayerTypes.Gauge ||
+    graphType === LayerTypes.SimpleTable
+  ) {
+    return false
+  }
+  return true
+}

--- a/giraffe/src/utils/hasPlotEnv.ts
+++ b/giraffe/src/utils/hasPlotEnv.ts
@@ -4,10 +4,10 @@ import {get} from './get'
 export const hasPlotEnv = (config: Config): boolean => {
   const graphType = get(config, 'layers.0.type')
   if (
-    graphType === LayerTypes.Table ||
-    graphType === LayerTypes.RawFluxDataTable ||
     graphType === LayerTypes.Gauge ||
-    graphType === LayerTypes.SimpleTable
+    graphType === LayerTypes.RawFluxDataTable ||
+    graphType === LayerTypes.SimpleTable ||
+    graphType === LayerTypes.Table
   ) {
     return false
   }

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.35.0",
+  "version": "2.36.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Part of #805  

Certain visualizations do not need the usePlotEnv hook, and the PlotEnv component which is very expensive. PlotEnv was also incorrectly being used twice (!) for `SizedTable`. Remove all usages completely.


Here is a video showing all of the non-PlotEnv visualizations working with the new split

https://user-images.githubusercontent.com/10736577/192071610-93362d29-a864-4bc4-976d-3554ae778c6b.mp4

