### PR TITLE
fix: clarify the definition of isDefined

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.36.0",
+  "version": "2.36.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/utils/isDefined.test.ts
+++ b/giraffe/src/utils/isDefined.test.ts
@@ -1,24 +1,49 @@
-import {isDefined} from './isDefined'
+import {isDefined, isDefinedOrNaN} from './isDefined'
 
-describe('isDefined', () => {
-  it('handles falsy input', () => {
-    expect(isDefined()).toEqual(false)
-    expect(isDefined(null)).toEqual(false)
-    expect(isDefined(undefined)).toEqual(false)
-    expect(isDefined(NaN)).toEqual(false)
+describe('utils/isDefined', () => {
+  describe('isDefined', () => {
+    it('handles falsy input', () => {
+      expect(isDefined()).toEqual(false)
+      expect(isDefined(null)).toEqual(false)
+      expect(isDefined(undefined)).toEqual(false)
+      expect(isDefined(NaN)).toEqual(false)
 
-    expect(isDefined(false)).toEqual(true)
-    expect(isDefined('')).toEqual(true)
-    expect(isDefined(0)).toEqual(true)
+      expect(isDefined(false)).toEqual(true)
+      expect(isDefined('')).toEqual(true)
+      expect(isDefined(0)).toEqual(true)
+    })
+
+    it('handles other input', () => {
+      expect(isDefined(true)).toEqual(true)
+      expect(isDefined('string')).toEqual(true)
+      expect(isDefined(1)).toEqual(true)
+      expect(isDefined({})).toEqual(true)
+      expect(isDefined([])).toEqual(true)
+      expect(isDefined(() => {})).toEqual(true)
+      expect(isDefined(Symbol())).toEqual(true)
+    })
   })
 
-  it('handles other input', () => {
-    expect(isDefined(true)).toEqual(true)
-    expect(isDefined('string')).toEqual(true)
-    expect(isDefined(1)).toEqual(true)
-    expect(isDefined({})).toEqual(true)
-    expect(isDefined([])).toEqual(true)
-    expect(isDefined(() => {})).toEqual(true)
-    expect(isDefined(Symbol())).toEqual(true)
+  describe('isDefinedOrNaN', () => {
+    it('handles falsy input', () => {
+      expect(isDefinedOrNaN()).toEqual(false)
+      expect(isDefinedOrNaN(null)).toEqual(false)
+      expect(isDefinedOrNaN(undefined)).toEqual(false)
+
+      expect(isDefinedOrNaN(NaN)).toEqual(true)
+      expect(isDefinedOrNaN(false)).toEqual(true)
+      expect(isDefinedOrNaN('')).toEqual(true)
+      expect(isDefinedOrNaN(0)).toEqual(true)
+    })
+
+    it('handles other input', () => {
+      expect(isDefinedOrNaN(true)).toEqual(true)
+      expect(isDefinedOrNaN('string')).toEqual(true)
+      expect(isDefinedOrNaN(1)).toEqual(true)
+      expect(isDefinedOrNaN({})).toEqual(true)
+      expect(isDefinedOrNaN([])).toEqual(true)
+      expect(isDefinedOrNaN(() => {})).toEqual(true)
+      expect(isDefinedOrNaN(Symbol())).toEqual(true)
+    })
   })
 })

--- a/giraffe/src/utils/isDefined.test.ts
+++ b/giraffe/src/utils/isDefined.test.ts
@@ -1,0 +1,24 @@
+import {isDefined} from './isDefined'
+
+describe('isDefined', () => {
+  it('handles falsy input', () => {
+    expect(isDefined()).toEqual(false)
+    expect(isDefined(null)).toEqual(false)
+    expect(isDefined(undefined)).toEqual(false)
+    expect(isDefined(NaN)).toEqual(false)
+
+    expect(isDefined(false)).toEqual(true)
+    expect(isDefined('')).toEqual(true)
+    expect(isDefined(0)).toEqual(true)
+  })
+
+  it('handles other input', () => {
+    expect(isDefined(true)).toEqual(true)
+    expect(isDefined('string')).toEqual(true)
+    expect(isDefined(1)).toEqual(true)
+    expect(isDefined({})).toEqual(true)
+    expect(isDefined([])).toEqual(true)
+    expect(isDefined(() => {})).toEqual(true)
+    expect(isDefined(Symbol())).toEqual(true)
+  })
+})

--- a/giraffe/src/utils/isDefined.ts
+++ b/giraffe/src/utils/isDefined.ts
@@ -1,2 +1,4 @@
 export const isDefined = (x?: any) =>
   x !== null && x !== undefined && !Number.isNaN(x)
+
+export const isDefinedOrNaN = (x?: any) => x !== null && x !== undefined

--- a/giraffe/src/utils/isDefined.ts
+++ b/giraffe/src/utils/isDefined.ts
@@ -1,1 +1,2 @@
-export const isDefined = (x: any) => x !== null && x !== undefined && !isNaN(x)
+export const isDefined = (x?: any) =>
+  x !== null && x !== undefined && !Number.isNaN(x)

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.36.0",
+  "version": "2.36.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
While refactoring the Simple Table code for readability, I came across an issue with `isDefined`. Currently, `isDefined` uses `isNaN` as one of its underlying comparisons. However, the built-in `isNaN` is not the appropriate checker for `NaN` which is what our `isDefined` is trying to look for. The appropriate checker is `Number.isNaN`.

The differences can be seen in the console:
<img width="264" alt="Screen Shot 2022-09-27 at 2 18 41 PM" src="https://user-images.githubusercontent.com/10736577/192637469-7abbd3b2-8775-493b-949d-01e6afc7968f.png">

What we want: strings should be treated as separate from `NaN` and consequently `isDefined('string')` should return `true`.

Unit tests have been added to enforce this expectation, as well as other expectations.

**_EDIT_**: additionally, we will add a new function called `isDefinedOrNaN` to make clear that we are semantically calling `NaN` undefined. Having them in the same file makes clear how we treat `NaN` in terms of being "defined".

Although `isDefined` is not currently used in Simple Table, it will be, after the refactor. `isDefined` only affects line graphs and band graphs at the moment. And they are unaffected by this change.

https://user-images.githubusercontent.com/10736577/192638169-fc2ed7c3-8640-4c0a-bfc2-7c3d6f4cbcfe.mp4


