### PR TITLE
chore: use resolutions to use d3-color 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "resolutions": {
     "immer": "^9.0.6",
     "jsprim": "^1.4.2",
-    "shell-quote": "1.7.3"
+    "shell-quote": "1.7.3",
+    "d3-color": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "resolutions": {
     "immer": "^9.0.6",
     "jsprim": "^1.4.2",
-    "shell-quote": "1.7.3",
+    "shell-quote": "^1.7.3",
     "d3-color": "^3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5056,17 +5056,7 @@ d3-array@2, d3-array@^2.0.3, d3-array@^2.3.0, d3-array@^2.4.0:
   dependencies:
     internmap "^1.0.0"
 
-d3-color@1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
-  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
-
-"d3-color@1 - 2":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
-  integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
-
-d3-color@^3.1.0:
+d3-color@1, "d3-color@1 - 2", d3-color@3.1.0, d3-color@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==


### PR DESCRIPTION
* chore: use resolutions to use d3-color 3.1.0
    
    d3-scale and d3-interpolate both specify "d3-color@1 - 3" and are
    already at 3.0.1 in the upstream yarn.lock, so it should be safe to use
    3.1.0 in a resolution since according to semver, 3.1 should not break
    3.0.
* package.json: use ^1.7.3 for shell-quote rather than exact version

    This resolves a yarn warning introduced in 4b61d6bf.

Note: I've not personally tested this. I've you'd like testing beyond the automatic tests from the PR submission, please advise.