### PR TITLE
fix: allow Simple Table to render 1 row as minimum regardless of available height

### DIFF
--- a/giraffe/package.json
+++ b/giraffe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe",
-  "version": "2.38.0",
+  "version": "2.38.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/giraffe/src/components/SimpleTable/PagedTable.tsx
+++ b/giraffe/src/components/SimpleTable/PagedTable.tsx
@@ -98,7 +98,7 @@ const getNumberOfRowsOnCurrentPage = (
     rowIdx++
   }
 
-  return Math.max(0, rowIdx - paginationOffset)
+  return Math.max(1, rowIdx - paginationOffset)
 }
 
 const subsetResult = (

--- a/stories/package.json
+++ b/stories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/giraffe-stories",
-  "version": "2.38.0",
+  "version": "2.38.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #823 


BEFORE: data is hidden if available height is too small. MISLEADING!

https://user-images.githubusercontent.com/10736577/198398167-c7322066-679f-4730-94ca-631c593c9e99.mp4



AFTER: "hey user, there is something there! check it out"

https://user-images.githubusercontent.com/10736577/198398256-bc9cee48-583e-49fd-9c83-dd70c828a0ad.mp4

