### PR TITLE
chore: update CODEOWNERS to AUX

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Changes to any file in this repo require approval from a member of the InfluxData Dumplings team
-*   @influxdata/dumplings
+*   @influxdata/aux


### PR DESCRIPTION
Part of influxdata/quartz#7264.

Update CODEOWNERS to AUX due to team name change.